### PR TITLE
WIP: Add support for (make check CHECK_BASE_IMAGES='fedora centos')

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ jobs:
       services:
       - docker
       script: 
-      - make vendor && ./hack/tree_status.sh && make local-cross && make check
+      - make vendor && ./hack/tree_status.sh && make local-cross && make check CHECK_BASE_IMAGES='fedora centos'
 
     # Run 3 image-build-push tasks in parallel for linux/amd64, linux/s390x and linux/ppc64le platforms (for upstream and stable)
     - stage: image-build-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM fedora
 
-RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-md2man \
+RUN if (. /etc/os-release ; [ "$ID" != centos ]); then dnf=dnf; md2man=golang-github-cpuguy83-md2man; else dnf=yum; md2man=golang-github-cpuguy83-go-md2man; $dnf install -y epel-release; fi \
+	&& $dnf -y update && $dnf install -y make git golang $md2man \
 	# storage deps
 	btrfs-progs-devel \
 	device-mapper-devel \
@@ -14,7 +15,7 @@ RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-md2ma
         bats jq podman runc \
 	golint \
 	openssl \
-	&& dnf clean all
+	&& $dnf clean all
 
 # Install two versions of the registry. The first is an older version that
 # only supports schema1 manifests. The second is a newer version that supports

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,16 @@ ifeq ($(GOOS), linux)
 endif
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-IMAGE := skopeo-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
+# Default base container image on which to run tests
+DEFAULT_BASE := fedora
+# Base image for most commands, overridable by command-line arguments
+BASE_IMAGE := fedora
+# Base images (one or more) used for (make check), overridable by command-line arguments
+CHECK_BASE_IMAGES := $(BASE_IMAGE)
+# Name for our containers: skopeo-dev[-base-image][:branch]
+define image_name
+skopeo-dev$(if $(filter-out $(DEFAULT_BASE),$1),-$1)$(if $(GIT_BRANCH),:$(GIT_BRANCH))
+endef
 # set env like gobuildtag?
 CONTAINER_CMD := ${CONTAINER_RUNTIME} run --rm -i -e TESTFLAGS="$(TESTFLAGS)" #$(CONTAINER_ENVS)
 # if this session isn't interactive, then we don't want to allocate a
@@ -63,7 +72,6 @@ INTERACTIVE := $(shell [ -t 0 ] && echo 1 || echo 0)
 ifeq ($(INTERACTIVE), 1)
 	CONTAINER_CMD += -t
 endif
-CONTAINER_RUN := $(CONTAINER_CMD) "$(IMAGE)"
 
 GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || true)
 
@@ -132,8 +140,12 @@ bin/skopeo.%:
 	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) $(GO) build $(MOD_VENDOR) ${SKOPEO_LDFLAGS} -tags "containers_image_openpgp $(BUILDTAGS)" -o $@ ./cmd/skopeo
 local-cross: bin/skopeo.darwin.amd64 bin/skopeo.linux.arm bin/skopeo.linux.arm64 bin/skopeo.windows.386.exe bin/skopeo.windows.amd64.exe
 
-build-container:
-	${CONTAINER_RUNTIME} build ${BUILD_ARGS} -t "$(IMAGE)" .
+build-container: build-container-$(BASE_IMAGE)
+build-container-%:
+	base=$*; if [ "$$base" = centos ]; then base=centos:7; fi; \
+		dockerfile=$$(mktemp -p .); sed "s/^FROM fedora/FROM $$base/" Dockerfile > "$$dockerfile"; \
+	${CONTAINER_RUNTIME} build ${BUILD_ARGS} -f $$dockerfile -t "$(call image_name,$*)" . ; exit=$$?; \
+	rm "$$dockerfile"; exit $$exit
 
 $(MANPAGES): %: %.md
 	sed -e 's/\((skopeo.*\.md)\)//' -e 's/\[\(skopeo.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $@
@@ -167,32 +179,37 @@ install-completions:
 	install -m 755 -d ${BASHINSTALLDIR}
 	install -m 644 completions/bash/skopeo ${BASHINSTALLDIR}/skopeo
 
-shell: build-container
-	$(CONTAINER_RUN) bash
+shell: shell-$(BASE_IMAGE)
+shell-%: build-container-%
+	$(CONTAINER_CMD) "$(call image_name,$*)" bash
 
-check: validate test-unit test-integration test-system
+check: $(foreach image,$(CHECK_BASE_IMAGES),validate-$(image) test-unit-$(image) test-integration-$(image) test-system-$(image))
 
+test-integration: test-integration-$(BASE_IMAGE)
 # The tests can run out of entropy and block in containers, so replace /dev/random.
-test-integration: build-container
-	$(CONTAINER_RUN) bash -c 'rm -f /dev/random; ln -sf /dev/urandom /dev/random; SKOPEO_CONTAINER_TESTS=1 BUILDTAGS="$(BUILDTAGS)" hack/make.sh test-integration'
+test-integration-%: build-container-%
+	$(CONTAINER_CMD) "$(call image_name,$*)" bash -c 'rm -f /dev/random; ln -sf /dev/urandom /dev/random; SKOPEO_CONTAINER_TESTS=1 BUILDTAGS="$(BUILDTAGS)" hack/make.sh test-integration'
 
+test-system: test-system-$(BASE_IMAGE)
 # complicated set of options needed to run podman-in-podman
-test-system: build-container
+test-system-%: build-container-%
 	DTEMP=$(shell mktemp -d --tmpdir=/var/tmp podman-tmp.XXXXXX); \
 	$(CONTAINER_CMD) --privileged \
 	    -v $$DTEMP:/var/lib/containers:Z -v /run/systemd/journal/socket:/run/systemd/journal/socket \
-            "$(IMAGE)" \
+            "$(call image_name,$*)" \
             bash -c 'BUILDTAGS="$(BUILDTAGS)" hack/make.sh test-system'; \
 	rc=$$?; \
 	$(RM) -rf $$DTEMP; \
 	exit $$rc
 
-test-unit: build-container
-	# Just call (make test unit-local) here instead of worrying about environment differences
-	$(CONTAINER_RUN) make test-unit-local BUILDTAGS='$(BUILDTAGS)'
+test-unit: test-unit-$(BASE_IMAGE)
+# Just call (make test unit-local) here instead of worrying about environment differences
+test-unit-%: build-container-%
+	$(CONTAINER_CMD) "$(call image_name,$*)" make test-unit-local BUILDTAGS='$(BUILDTAGS)'
 
-validate: build-container
-	$(CONTAINER_RUN) hack/make.sh validate-git-marks validate-gofmt validate-lint validate-vet
+validate: validate-$(BASE_IMAGE)
+validate-%: build-container-%
+	$(CONTAINER_CMD) "$(call image_name,$*)" hack/make.sh validate-git-marks validate-gofmt validate-lint validate-vet
 
 # This target is only intended for development, e.g. executing it from an IDE. Use (make test) for CI or pre-release testing.
 test-all-local: validate-local test-unit-local

--- a/systemtest/010-inspect.bats
+++ b/systemtest/010-inspect.bats
@@ -44,7 +44,7 @@ load helpers
     #
     # The reason for a hardcoded list, instead of 'jq keys', is that RepoTags
     # is always empty locally, but a list remotely.
-    while read key expect; do
+    while IFS=$' \t\n' read key expect; do
         local=$(echo "$inspect_local" | jq -r ".$key")
         remote=$(echo "$inspect_remote" | jq -r ".$key")
 

--- a/systemtest/050-signing.bats
+++ b/systemtest/050-signing.bats
@@ -97,7 +97,7 @@ END_POLICY_JSON
 
     # Push a bunch of images. Do so *without* --policy flag; this lets us
     # sign or not, creating images that will or won't conform to policy.
-    while read path sig comments; do
+    while IFS=$' \t\n' read path sig comments; do
         local sign_opt=
         if [[ $sig != '-' ]]; then
             sign_opt="--sign-by=${sig}@test.redhat.com"
@@ -118,7 +118,7 @@ END_PUSH
     # Done pushing. Now try to fetch. From here on we use the --policy option.
     # The table below lists the paths to fetch, and the expected errors (or
     # none, if we expect them to pass).
-    while read path expected_error; do
+    while IFS=$' \t\n' read path expected_error; do
         expected_rc=
         if [[ -n $expected_error ]]; then
             expected_rc=1


### PR DESCRIPTION
This is intended for use in Travis, modifying the `make check` command to the above (but running this locally would of course also be possible).  The default behavior remains the same, uses the `fedora` image.

At the moment, this does not work because in `centos`, the `python-pip` package is not available (perhaps in EPEL?).

(Also note that the `(yum install)` does not fail when one of the packages is missing.)

Anyone, feel free to take this over (adding conditionals to `Dockerfile`s? Maintaining a `Dockerfile.fedora` and `Dockerfile.centos` separately?) if you have the time.
