### PR TITLE
Add add-signature and verify-signature

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -76,6 +76,8 @@ func createApp() *cli.App {
 		manifestDigestCmd,
 		standaloneSignCmd,
 		standaloneVerifyCmd,
+		addSignatureCmd,
+		verifySignatureCmd,
 	}
 	return app
 }

--- a/cmd/skopeo/signing.go
+++ b/cmd/skopeo/signing.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 
 	"github.com/containers/image/signature"
+	"github.com/containers/image/transports"
 	"github.com/urfave/cli"
 )
 
@@ -87,4 +88,180 @@ var standaloneVerifyCmd = cli.Command{
 	Usage:     "Verify a signature using local files",
 	ArgsUsage: "MANIFEST DOCKER-REFERENCE KEY-FINGERPRINT SIGNATURE",
 	Action:    standaloneVerify,
+}
+
+func addSignature(context *cli.Context) error {
+	if len(context.Args()) != 2 {
+		return errors.New("Usage: skopeo add-signature reference key-fingerprint")
+	}
+	ref := context.Args()[0]
+	fingerprint := context.Args()[1]
+
+	imageRef, err := transports.ParseImageName(ref)
+	if err != nil {
+		return fmt.Errorf("Error parsing %s: %v", ref, err)
+	}
+	name := transports.ImageName(imageRef)
+
+	reference := context.String("reference")
+	if reference == "" {
+		signReference := imageRef.DockerReference()
+		if signReference == nil {
+			return fmt.Errorf("No reference associated with image %s: %v", ref, err)
+		}
+		reference = signReference.String()
+	} else {
+		signRef, err := imageRef.Transport().ParseReference(reference)
+		if err != nil {
+			return fmt.Errorf("Error parsing %s: %v", reference, err)
+		}
+		signReference := signRef.DockerReference()
+		if signReference != nil {
+			reference = signReference.String()
+		}
+	}
+
+	systemContext := contextFromGlobalOptions(context)
+	src, err := imageRef.NewImageSource(systemContext, nil)
+	if err != nil {
+		return fmt.Errorf("Error reading %s: %v", name, err)
+	}
+	defer src.Close()
+
+	manifest, _, err := src.GetManifest()
+	if err != nil {
+		return fmt.Errorf("Error reading manifest for %s: %v", name, err)
+	}
+
+	mech, err := signature.NewGPGSigningMechanism()
+	if err != nil {
+		return fmt.Errorf("Error initializing GPG: %v", err)
+	}
+
+	signature, err := signature.SignDockerManifest(manifest, reference, mech, fingerprint)
+	if err != nil {
+		return fmt.Errorf("Error creating signature: %v", err)
+	}
+
+	dest, err := imageRef.NewImageDestination(systemContext)
+	if err != nil {
+		return fmt.Errorf("Error writing to %s: %v", name, err)
+	}
+	defer dest.Close()
+
+	signatures, err := src.GetSignatures()
+	if err != nil {
+		return fmt.Errorf("Error reading signatures from %s: %v", name, err)
+	}
+
+	signatures = append(signatures, signature)
+
+	err = dest.PutSignatures(signatures)
+	if err != nil {
+		return fmt.Errorf("Error saving signatures for %s: %v", name, err)
+	}
+
+	err = dest.Commit()
+	if err != nil {
+		return fmt.Errorf("Error saving updates to %s: %v", name, err)
+	}
+
+	return nil
+}
+
+var addSignatureCmd = cli.Command{
+	Name:      "add-signature",
+	Usage:     "Add a signature to an image",
+	ArgsUsage: "IMAGE-REFERENCE KEY-FINGERPRINT",
+	Action:    addSignature,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "reference, r",
+			Usage: "sign a specified reference instead the image's default",
+		},
+	},
+}
+
+func verifySignature(context *cli.Context) error {
+	var sig *signature.Signature
+
+	if len(context.Args()) != 2 {
+		return errors.New("Usage: skopeo verify-signature reference key-fingerprint")
+	}
+	ref := context.Args()[0]
+	expectedFingerprint := context.Args()[1]
+
+	imageRef, err := transports.ParseImageName(ref)
+	if err != nil {
+		return fmt.Errorf("Error parsing %s: %v", ref, err)
+	}
+	name := transports.ImageName(imageRef)
+
+	reference := context.String("reference")
+	if reference == "" {
+		verifyReference := imageRef.DockerReference()
+		if verifyReference == nil {
+			return fmt.Errorf("No reference associated with image %s: %v", ref, err)
+		}
+		reference = verifyReference.String()
+	} else {
+		verifyRef, err := imageRef.Transport().ParseReference(reference)
+		if err != nil {
+			return fmt.Errorf("Error parsing %s: %v", reference, err)
+		}
+		verifyReference := verifyRef.DockerReference()
+		if verifyReference != nil {
+			reference = verifyReference.String()
+		}
+	}
+
+	systemContext := contextFromGlobalOptions(context)
+	src, err := imageRef.NewImageSource(systemContext, nil)
+	if err != nil {
+		return fmt.Errorf("Error reading %s: %v", name, err)
+	}
+	defer src.Close()
+
+	unverifiedManifest, _, err := src.GetManifest()
+	if err != nil {
+		return fmt.Errorf("Error reading manifest for %s: %v", name, err)
+	}
+
+	mech, err := signature.NewGPGSigningMechanism()
+	if err != nil {
+		return fmt.Errorf("Error initializing GPG: %v", err)
+	}
+
+	signatures, err := src.GetSignatures()
+	if err != nil {
+		return fmt.Errorf("Error reading signatures from %s: %v", name, err)
+	}
+
+	if len(signatures) == 0 {
+		return fmt.Errorf("No signatures found: %v", err)
+	}
+
+	// TODO: is there a better way to zero in on which signature we want to check, instead of checking them all for a match with our criteria?
+	for _, unverifiedSignature := range signatures {
+		sig, err = signature.VerifyDockerManifestSignature(unverifiedSignature, unverifiedManifest, reference, mech, expectedFingerprint)
+		if err == nil {
+			fmt.Fprintf(context.App.Writer, "Signature verified, digest %s\n", sig.DockerManifestDigest)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Error verifying signature: %v", err)
+}
+
+var verifySignatureCmd = cli.Command{
+	Name:      "verify-signature",
+	Usage:     "Verify a signature on an image",
+	ArgsUsage: "IMAGE-REFERENCE KEY-FINGERPRINT",
+	Action:    verifySignature,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "reference, r",
+			Usage: "verify a specified reference instead of one associated with the image name",
+		},
+	},
 }

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -133,6 +133,33 @@ Verify a signature using local files, digest will be printed on success.
 
 **Note:** If you do use this, make sure that the image can not be changed at the source location between the times of its verification and use.
 
+## skopeo add-signature
+**skopeo add-signature** [**--reference=**_signing-reference_] _image-reference key-fingerprint_
+
+Add an additional signature to an image in its current location.  If only one
+signature is needed, using `skopeo copy --sign-by` instead to publish and sign
+an image in a single step is recommended over using `skopeo copy` followed by
+`skopeo add-signature`.
+
+  _reference_ A reference to the image
+
+  _key-fingerprint_ Key identity to use for signing
+
+  **--reference** Add a signature for the specified reference, instead of the image's default.
+
+## skopeo verify-signature
+**skopeo verify-signature** [**--reference=**_verify-reference_] _image-reference key-fingerprint_
+
+Verify a signature on an image now.  Its digest will be printed on success.
+
+  _reference_ A reference expected to identify the image
+
+  _key-fingerprint_ Expected identity of the signing key
+
+  **--reference** Verify a signature for the specified reference, instead of the image's default.
+
+**Note:** If you do use this, make sure that the image can not be changed at the specified location between the times of its verification and use.
+
 ## skopeo help
 show help for `skopeo`
 


### PR DESCRIPTION
Add add-signature and verify-signature commands, for adding a signature to an image in its current location, and for verifying an image in place.