### PR TITLE
Add --no-creds flag to skopeo inspect

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -141,6 +141,16 @@ var copyCmd = cli.Command{
 			Value: "",
 			Usage: "Use `USERNAME[:PASSWORD]` for accessing the destination registry",
 		},
+		cli.BoolFlag{
+			Name:  "src-no-creds",
+			Value: "",
+			Usage: "access the source registry anonymously",
+		},
+		cli.BoolFlag{
+			Name:  "dest-no-creds",
+			Value: "",
+			Usage: "access the destination registry anonymously",
+		},
 		cli.StringFlag{
 			Name:  "src-cert-dir",
 			Value: "",

--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -51,6 +51,10 @@ var deleteCmd = cli.Command{
 			Value: "",
 			Usage: "Use `USERNAME[:PASSWORD]` for accessing the registry",
 		},
+		cli.BoolFlag{
+			Name:  "no-creds",
+			Usage: "access the registry anonymously",
+		},
 		cli.StringFlag{
 			Name:  "cert-dir",
 			Value: "",

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -65,6 +65,10 @@ var inspectCmd = cli.Command{
 			Value: "",
 			Usage: "Use `USERNAME[:PASSWORD]` for accessing the registry",
 		},
+		cli.BoolFlag{
+			Name:  "no-creds",
+			Usage: "access the registry anonymously",
+		},
 	},
 	Action: func(c *cli.Context) (retErr error) {
 		ctx := context.Background()

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -27,6 +27,9 @@ func contextFromGlobalOptions(c *cli.Context, flagPrefix string) (*types.SystemC
 		DockerDaemonCertPath:              c.String(flagPrefix + "cert-dir"),
 		DockerDaemonInsecureSkipTLSVerify: !c.BoolT(flagPrefix + "tls-verify"),
 	}
+	if c.IsSet(flagPrefix+"creds") && c.IsSet(flagPrefix+"no-creds") {
+		return nil, errors.New("creds and no-creds cannot be specified at the same time")
+	}
 	if c.IsSet(flagPrefix + "tls-verify") {
 		ctx.DockerInsecureSkipTLSVerify = !c.BoolT(flagPrefix + "tls-verify")
 	}
@@ -36,6 +39,9 @@ func contextFromGlobalOptions(c *cli.Context, flagPrefix string) (*types.SystemC
 		if err != nil {
 			return nil, err
 		}
+	}
+	if c.Bool(flagPrefix + "no-creds") {
+		ctx.DockerAuthConfig = &types.DockerAuthConfig{}
 	}
 	return ctx, nil
 }


### PR DESCRIPTION
Implements https://github.com/projectatomic/skopeo/issues/421

Currently skopeo inspect allows to:
* Use the default credentials in $HOME/.docker.config
* Explicitly define credentials via de --creds flag

This implements a --no-creds flag which will query docker registries anonymously. 