### PR TITLE
Complete transition from the `projectactomic` project to the `containers` one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ that we follow.
 ## Reporting Issues
 
 Before reporting an issue, check our backlog of 
-[open issues](https://github.com/projectatomic/skopeo/issues)
+[open issues](https://github.com/containers/skopeo/issues)
 to see if someone else has already reported it. If so, feel free to add
 your scenario, or additional information, to the discussion. Or simply 
 "subscribe" to it to be notified when it is updated.
@@ -122,9 +122,9 @@ IRC group on `irc.freenode.net` called `container-projects`
 that has been setup.
 
 For discussions around issues/bugs and features, you can use the github
-[issues](https://github.com/projectatomic/skopeo/issues)
+[issues](https://github.com/containers/skopeo/issues)
 and
-[PRs](https://github.com/projectatomic/skopeo/pulls)
+[PRs](https://github.com/containers/skopeo/pulls)
 tracking system.
 
 <!--

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN set -x \
 ENV GOPATH /usr/share/gocode:/go
 ENV PATH $GOPATH/bin:/usr/share/gocode/bin:$PATH
 RUN go get github.com/golang/lint/golint
-WORKDIR /go/src/github.com/projectatomic/skopeo
-COPY . /go/src/github.com/projectatomic/skopeo
+WORKDIR /go/src/github.com/containers/skopeo
+COPY . /go/src/github.com/containers/skopeo
 
 #ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -11,4 +11,4 @@ RUN apt-get update && apt-get install -y \
     libostree-dev
 
 ENV GOPATH=/
-WORKDIR /src/github.com/projectatomic/skopeo
+WORKDIR /src/github.com/containers/skopeo

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,14 @@ binary: cmd/skopeo
 ifneq ($(DISABLE_CGO), 1)
 	docker build ${DOCKER_BUILD_ARGS} -f Dockerfile.build -t $(DOCKER_BUILD_IMAGE) .
 endif
-	docker run --rm --security-opt label:disable -v $$(pwd):/src/github.com/projectatomic/skopeo \
+	docker run --rm --security-opt label:disable -v $$(pwd):/src/github.com/containers/skopeo \
 		$(DOCKER_BUILD_IMAGE) make binary-local $(if $(DEBUG),DEBUG=$(DEBUG)) BUILDTAGS='$(BUILDTAGS)'
 
 binary-static: cmd/skopeo
 ifneq ($(DISABLE_CGO), 1)
 	docker build ${DOCKER_BUILD_ARGS} -f Dockerfile.build -t $(DOCKER_BUILD_IMAGE) .
 endif
-	docker run --rm --security-opt label:disable -v $$(pwd):/src/github.com/projectatomic/skopeo \
+	docker run --rm --security-opt label:disable -v $$(pwd):/src/github.com/containers/skopeo \
 		$(DOCKER_BUILD_IMAGE) make binary-local-static $(if $(DEBUG),DEBUG=$(DEBUG)) BUILDTAGS='$(BUILDTAGS)'
 
 # Build w/o using Docker containers
@@ -144,7 +144,7 @@ validate-local:
 	hack/make.sh validate-git-marks validate-gofmt validate-lint validate-vet
 
 test-unit-local:
-	$(GPGME_ENV) $(GO) test -tags "$(BUILDTAGS)" $$($(GO) list -tags "$(BUILDTAGS)" -e ./... | grep -v '^github\.com/projectatomic/skopeo/\(integration\|vendor/.*\)$$')
+	$(GPGME_ENV) $(GO) test -tags "$(BUILDTAGS)" $$($(GO) list -tags "$(BUILDTAGS)" -e ./... | grep -v '^github\.com/containers/skopeo/\(integration\|vendor/.*\)$$')
 
 vendor: vendor.conf
 	vndr -whitelist '^github.com/containers/image/docs/.*'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-skopeo [![Build Status](https://travis-ci.org/projectatomic/skopeo.svg?branch=master)](https://travis-ci.org/projectatomic/skopeo)
+skopeo [![Build Status](https://travis-ci.org/containers/skopeo.svg?branch=master)](https://travis-ci.org/containers/skopeo)
 =
 
-<img src="https://cdn.rawgit.com/projectatomic/skopeo/master/docs/skopeo.svg" width="250">
+<img src="https://cdn.rawgit.com/containers/skopeo/master/docs/skopeo.svg" width="250">
 
 ----
 
@@ -178,8 +178,8 @@ macOS$ brew install gpgme
 Make sure to clone this repository in your `GOPATH` - otherwise compilation fails.
 
 ```sh
-$ git clone https://github.com/projectatomic/skopeo $GOPATH/src/github.com/projectatomic/skopeo
-$ cd $GOPATH/src/github.com/projectatomic/skopeo && make binary-local
+$ git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo
+$ cd $GOPATH/src/github.com/containers/skopeo && make binary-local
 ```
 
 ### Building in a container

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/containers/image/signature"
+	"github.com/containers/skopeo/version"
 	"github.com/containers/storage/pkg/reexec"
-	"github.com/projectatomic/skopeo/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -6,7 +6,7 @@ set -e
 #
 # Requirements:
 # - The current directory should be a checkout of the skopeo source code
-#   (https://github.com/projectatomic/skopeo). Whatever version is checked out
+#   (https://github.com/containers/skopeo). Whatever version is checked out
 #   will be built.
 # - The script is intended to be run inside the docker container specified
 #   in the Dockerfile at the root of the source. In other words:
@@ -19,7 +19,7 @@ set -e
 
 set -o pipefail
 
-export SKOPEO_PKG='github.com/projectatomic/skopeo'
+export SKOPEO_PKG='github.com/containers/skopeo'
 export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export MAKEDIR="$SCRIPTDIR/make"
 

--- a/hack/travis_osx.sh
+++ b/hack/travis_osx.sh
@@ -4,13 +4,13 @@ set -e
 export GOPATH=$(pwd)/_gopath
 export PATH=$GOPATH/bin:$PATH
 
-_projectatomic="${GOPATH}/src/github.com/projectatomic"
-mkdir -vp ${_projectatomic}
-ln -vsf $(pwd) ${_projectatomic}/skopeo
+_containers="${GOPATH}/src/github.com/containers"
+mkdir -vp ${_containers}
+ln -vsf $(pwd) ${_containers}/skopeo
 
 go get -u github.com/cpuguy83/go-md2man github.com/golang/lint/golint
 
-cd ${_projectatomic}/skopeo
+cd ${_containers}/skopeo
 make validate-local test-unit-local binary-local
 sudo make install
 skopeo -v

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -5,8 +5,8 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/containers/skopeo/version"
 	"github.com/go-check/check"
-	"github.com/projectatomic/skopeo/version"
 )
 
 const (


### PR DESCRIPTION
Replace the occurrences of `github.com/projectatomic` with `github.com/containers` to ensure clean clones of the project are building, travis badges on the README work as expected and other minor
things.

All the tests are still green after this change.