### PR TITLE
Allow specifying fine grained install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary build-container docs build-local clean install install-binary install-completions shell test-integration vendor
+.PHONY: all binary build-container docs build-local clean install install-defaults install-binary install-docs install-completions shell test-integration vendor
 
 export GO15VENDOREXPERIMENT=1
 
@@ -101,7 +101,9 @@ docs: $(MANPAGES_MD:%.md=%)
 clean:
 	rm -f skopeo docs/*.1
 
-install: install-binary install-docs install-completions
+install: install-binary install-docs install-completions install-defaults
+
+install-defaults:
 	install -d -m 755 ${SIGSTOREDIR}
 	install -d -m 755 ${CONTAINERSSYSCONFIGDIR}
 	install -m 644 default-policy.json ${CONTAINERSSYSCONFIGDIR}/policy.json


### PR DESCRIPTION
One may wish to omit the bash completions, docs, or even the binary. For example if these are installed at a different point in the build process, not using the Makefile.

I specifically want this because I am seeing the following error while building a package for Void Linux.

    make: *** No rule to make target 'skopeo', needed by 'install-binary'.  Stop.

The binary is built in a different location (GOPATH) and installed before `make install` is invoked.