### PR TITLE
Add tls-verify to copy to toggle both src and dest

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -191,5 +191,9 @@ var copyCmd = cli.Command{
 			Value: "",
 			Usage: "use docker daemon host at `HOST` (docker-daemon destinations only)",
 		},
+		cli.BoolTFlag{
+			Name:  "tls-verify",
+			Usage: "require HTTPS and verify certificates when talking to the container registry or daemon at the source and the destination (defaults to true)",
+		},
 	},
 }

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -27,6 +27,9 @@ func contextFromGlobalOptions(c *cli.Context, flagPrefix string) (*types.SystemC
 		DockerDaemonCertPath:              c.String(flagPrefix + "cert-dir"),
 		DockerDaemonInsecureSkipTLSVerify: !c.BoolT(flagPrefix + "tls-verify"),
 	}
+	if c.IsSet("tls-verify") {
+		ctx.DockerInsecureSkipTLSVerify = !c.BoolT("tls-verify")
+	}
 	if c.IsSet(flagPrefix + "tls-verify") {
 		ctx.DockerInsecureSkipTLSVerify = !c.BoolT(flagPrefix + "tls-verify")
 	}

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -107,6 +107,8 @@ Uses the system's trust policy to validate images, rejects images not trusted by
 
   **--dest-daemon-host** _host_ Copy to docker daemon at _host_. If _host_ starts with `tcp://`, HTTPS is enabled by default. To use plain HTTP, use the form `http://` (default is `unix:///var/run/docker.sock`).
 
+  **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries for both the destination and the source (defaults to true).
+
 Existing signatures, if any, are preserved as well.
 
 ## skopeo delete


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add tls-verify to the copy command so the end user doesn't have to specify both a destination and source tls if they both have the same setting.