### PR TITLE
Re-vendor image-spec from upstream again

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/golang/protobuf 8d92cf5fc15a4382f8964b08e1f42a75c0591aa3
 github.com/docker/libtrust master
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/opencontainers/runc master
-github.com/opencontainers/image-spec unique-ids https://github.com/mtrmac/image-spec
+github.com/opencontainers/image-spec 7b1e489870acb042978a3935d2fb76f8a79aff81
 # -- start OCI image validation requirements.
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/image-tools 6d941547fa1df31900990b3fb47ec2468c9c6469


### PR DESCRIPTION
... after https://github.com/opencontainers/image-spec/pull/750 was merged.