### PR TITLE
add timeout support for image copy

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -88,7 +87,10 @@ func copyHandler(c *cli.Context) error {
 		}
 	}
 
-	_, err = copy.Image(context.Background(), policyContext, destRef, srcRef, &copy.Options{
+	ctx, cancel := commandTimeoutContextFromGlobalOptions(c)
+	defer cancel()
+
+	_, err = copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{
 		RemoveSignatures:      removeSignatures,
 		SignBy:                signBy,
 		ReportWriter:          os.Stdout,

--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,7 +24,10 @@ func deleteHandler(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return ref.DeleteImage(context.Background(), sys)
+
+	ctx, cancel := commandTimeoutContextFromGlobalOptions(c)
+	defer cancel()
+	return ref.DeleteImage(ctx, sys)
 }
 
 var deleteCmd = cli.Command{

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -67,7 +66,8 @@ var inspectCmd = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) (retErr error) {
-		ctx := context.Background()
+		ctx, cancel := commandTimeoutContextFromGlobalOptions(c)
+		defer cancel()
 
 		img, err := parseImage(ctx, c)
 		if err != nil {

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,7 +25,8 @@ var layersCmd = cli.Command{
 			return errors.New("Usage: layers imageReference [layer...]")
 		}
 
-		ctx := context.Background()
+		ctx, cancel := commandTimeoutContextFromGlobalOptions(c)
+		defer cancel()
 
 		sys, err := contextFromGlobalOptions(c, "")
 		if err != nil {

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -60,6 +60,10 @@ func createApp() *cli.App {
 			Value: "",
 			Usage: "use `OS` instead of the running OS for choosing images",
 		},
+		cli.DurationFlag{
+			Name:  "command-timeout",
+			Usage: "timeout for the command execution",
+		},
 	}
 	app.Before = func(c *cli.Context) error {
 		if c.GlobalBool("debug") {

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -40,6 +40,15 @@ func contextFromGlobalOptions(c *cli.Context, flagPrefix string) (*types.SystemC
 	return ctx, nil
 }
 
+func commandTimeoutContextFromGlobalOptions(c *cli.Context) (context.Context, context.CancelFunc) {
+	ctx := context.Background()
+	var cancel context.CancelFunc = func() {}
+	if c.GlobalDuration("command-timeout") > 0 {
+		ctx, cancel = context.WithTimeout(ctx, c.GlobalDuration("command-timeout"))
+	}
+	return ctx, cancel
+}
+
 func parseCreds(creds string) (string, string, error) {
 	if creds == "" {
 		return "", "", errors.New("credentials can't be empty")

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -110,6 +110,7 @@ _skopeo_skopeo() {
 	   --registries.d
        --override-arch
        --override-os
+       --command-timeout
      "
      local boolean_options="
 	   --insecure-policy

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -59,6 +59,8 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
   **--override-os** _OS_ Use _OS_ instead of the running OS for choosing images.
 
+  **--command-timeout** _duration_ Timeout for the command execution.
+
   **--help**|**-h** Show help
 
   **--version**|**-v** print the version number


### PR DESCRIPTION
the copy sub command may stuck if there are some network issue(e.g. slow network cause of network flapping in infrastructure), skopeo stuck there and application cannot do anything. It results in all the workers hang and cannot continue(retry, or report failure). 

Add the command-timeout option to make it possible to terminate the command to avoid this case.

Test result:
```
./skopeo copy --command-timeout=2s  --src-tls-verify=true --src-creds ****:***** docker://ubuntu:14.04 dir:/tmp/*****/raw
Getting image source signatures
Copying blob sha256:*******
 4.53 MB / 48.98 MB [=====>-------------------------------------------------] 1s
FATA[0002] Error writing blob: context deadline exceeded
```