### PR TITLE
bump to v0.1.33

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.33-dev"
+const Version = "0.1.33"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.33"
+const Version = "0.1.34-dev"


### PR DESCRIPTION
close https://github.com/containers/skopeo/issues/574

will tag https://github.com/containers/skopeo/commit/6eb5131b8554650f4529e6c4475a7e970ec5be36 as `v0.1.33`