### PR TITLE
docs: consolidate CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,35 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
 
+### Dependencies management
+
+Make sure [`vndr`](https://github.com/LK4D4/vndr) is installed.
+
+In order to add a new dependency to this project:
+
+- add a new line to `vendor.conf` according to `vndr` rules (e.g. `github.com/pkg/errors master`)
+- run `make vendor`
+
+In order to update an existing dependency:
+
+- update the relevant dependency line in `vendor.conf`
+- run `make vendor`
+
+When new PRs for [containers/image](https://github.com/containers/image) break `skopeo` (i.e. `containers/image` tests fail in `make test-skopeo`):
+
+- create out a new branch in your `skopeo` checkout and switch to it
+- update `vendor.conf`. Find out the `containers/image` dependency; update it to vendor from your own branch and your own repository fork (e.g. `github.com/containers/image my-branch https://github.com/runcom/image`)
+- run `make vendor`
+- make any other necessary changes in the skopeo repo (e.g. add other dependencies now requied by `containers/image`, or update skopeo for changed `containers/image` API)
+- optionally add new integration tests to the skopeo repo
+- submit the resulting branch as a skopeo PR, marked “DO NOT MERGE”
+- iterate until tests pass and the PR is reviewed
+- then the original `containers/image` PR can be merged, disregarding its `make test-skopeo` failure
+- as soon as possible after that, in the skopeo PR, restore the `containers/image` line in `vendor.conf` to use `containers/image:master`
+- run `make vendor`
+- update the skopeo PR with the result, drop the “DO NOT MERGE” marking
+- after tests complete succcesfully again, merge the skopeo PR
+
 ## Communications
 
 For general questions, or discussions, please use the 

--- a/README.md
+++ b/README.md
@@ -229,34 +229,7 @@ NOT TODO
 CONTRIBUTING
 -
 
-### Dependencies management
-
-Make sure [`vndr`](https://github.com/LK4D4/vndr) is installed.
-
-In order to add a new dependency to this project:
-
-- add a new line to `vendor.conf` according to `vndr` rules (e.g. `github.com/pkg/errors master`)
-- run `make vendor`
-
-In order to update an existing dependency:
-
-- update the relevant dependency line in `vendor.conf`
-- run `make vendor`
-
-When new PRs for [containers/image](https://github.com/containers/image) break `skopeo` (i.e. `containers/image` tests fail in `make test-skopeo`):
-
-- create out a new branch in your `skopeo` checkout and switch to it
-- update `vendor.conf`. Find out the `containers/image` dependency; update it to vendor from your own branch and your own repository fork (e.g. `github.com/containers/image my-branch https://github.com/runcom/image`)
-- run `make vendor`
-- make any other necessary changes in the skopeo repo (e.g. add other dependencies now requied by `containers/image`, or update skopeo for changed `containers/image` API)
-- optionally add new integration tests to the skopeo repo
-- submit the resulting branch as a skopeo PR, marked “DO NOT MERGE”
-- iterate until tests pass and the PR is reviewed
-- then the original `containers/image` PR can be merged, disregarding its `make test-skopeo` failure
-- as soon as possible after that, in the skopeo PR, restore the `containers/image` line in `vendor.conf` to use `containers/image:master`
-- run `make vendor`
-- update the skopeo PR with the result, drop the “DO NOT MERGE” marking
-- after tests complete succcesfully again, merge the skopeo PR
+Please read the [contribution guide](CONTRIBUTING.md) if you want to collaborate in the project.
 
 License
 -


### PR DESCRIPTION
Move documentation about dependencies management from README.md to
CONTRIBUTING.md.

Closes #583

Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>