### PR TITLE
vendor latest c/image

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/urfave/cli v1.20.0
 github.com/kr/pretty v0.1.0
 github.com/kr/text v0.1.0
-github.com/containers/image f0cbc16b444d729362c78244c715b45bf4019b71
+github.com/containers/image 693ff528622c5dd8835012f4e257a5793be577e0
 golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 gopkg.in/cheggaaa/pb.v1 v1.0.27

--- a/vendor/github.com/containers/image/copy/copy.go
+++ b/vendor/github.com/containers/image/copy/copy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -22,6 +23,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sync/semaphore"
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
@@ -84,6 +86,7 @@ type copier struct {
 	dest             types.ImageDestination
 	rawSource        types.ImageSource
 	reportWriter     io.Writer
+	progressOutput   io.Writer
 	progressInterval time.Duration
 	progress         chan types.ProgressProperties
 	blobInfoCache    types.BlobInfoCache
@@ -152,11 +155,19 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		}
 	}()
 
+	// If reportWriter is not a TTY (e.g., when piping to a file), do not
+	// print the progress bars to avoid long and hard to parse output.
+	// createProgressBar() will print a single line instead.
+	progressOutput := reportWriter
+	if !isTTY(reportWriter) {
+		progressOutput = ioutil.Discard
+	}
 	copyInParallel := dest.HasThreadSafePutBlob() && rawSource.HasThreadSafeGetBlob()
 	c := &copier{
 		dest:             dest,
 		rawSource:        rawSource,
 		reportWriter:     reportWriter,
+		progressOutput:   progressOutput,
 		progressInterval: options.ProgressInterval,
 		progress:         options.Progress,
 		copyInParallel:   copyInParallel,
@@ -394,15 +405,28 @@ func shortDigest(d digest.Digest) string {
 	return d.Encoded()[:12]
 }
 
-// createProgressBar creates a pb.ProgressBar.
-func createProgressBar(srcInfo types.BlobInfo, kind string, writer io.Writer) *pb.ProgressBar {
+// createProgressBar creates a pb.ProgressBar.  Note that if the copier's
+// reportWriter is ioutil.Discard, the progress bar's output will be discarded
+// and a single line will be printed instead.
+func (c *copier) createProgressBar(srcInfo types.BlobInfo, kind string) *pb.ProgressBar {
 	bar := pb.New(int(srcInfo.Size)).SetUnits(pb.U_BYTES)
 	bar.SetMaxWidth(80)
 	bar.ShowTimeLeft = false
 	bar.ShowPercent = false
 	bar.Prefix(fmt.Sprintf("Copying %s %s:", kind, shortDigest(srcInfo.Digest)))
-	bar.Output = writer
+	bar.Output = c.progressOutput
+	if bar.Output == ioutil.Discard {
+		c.Printf("Copying %s %s\n", kind, srcInfo.Digest)
+	}
 	return bar
+}
+
+// isTTY returns true if the io.Writer is a file and a tty.
+func isTTY(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		return terminal.IsTerminal(int(f.Fd()))
+	}
+	return false
 }
 
 // copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.canModifyManifest.
@@ -469,12 +493,13 @@ func (ic *imageCopier) copyLayers(ctx context.Context) error {
 
 	progressBars := make([]*pb.ProgressBar, numLayers)
 	for i, srcInfo := range srcInfos {
-		bar := createProgressBar(srcInfo, "blob", nil)
+		bar := ic.c.createProgressBar(srcInfo, "blob")
 		progressBars[i] = bar
 	}
 
 	progressPool := pb.NewPool(progressBars...)
-	progressPool.Output = ic.c.reportWriter
+	progressPool.Output = ic.c.progressOutput
+
 	if err := progressPool.Start(); err != nil {
 		return errors.Wrapf(err, "error creating progress-bar pool")
 	}
@@ -568,7 +593,7 @@ func (c *copier) copyConfig(ctx context.Context, src types.Image) error {
 		if err != nil {
 			return errors.Wrapf(err, "Error reading config blob %s", srcInfo.Digest)
 		}
-		bar := createProgressBar(srcInfo, "config", c.reportWriter)
+		bar := c.createProgressBar(srcInfo, "config")
 		defer bar.Finish()
 		bar.Start()
 		destInfo, err := c.copyBlobFromStream(ctx, bytes.NewReader(configBlob), srcInfo, nil, false, true, bar)

--- a/vendor/golang.org/x/crypto/otr/libotr_test_helper.c
+++ b/vendor/golang.org/x/crypto/otr/libotr_test_helper.c
@@ -1,0 +1,197 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This code can be compiled and used to test the otr package against libotr.
+// See otr_test.go.
+
+// +build ignore
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <proto.h>
+#include <message.h>
+#include <privkey.h>
+
+static int g_session_established = 0;
+
+OtrlPolicy policy(void *opdata, ConnContext *context) {
+  return OTRL_POLICY_ALWAYS;
+}
+
+int is_logged_in(void *opdata, const char *accountname, const char *protocol,
+                 const char *recipient) {
+  return 1;
+}
+
+void inject_message(void *opdata, const char *accountname, const char *protocol,
+                    const char *recipient, const char *message) {
+  printf("%s\n", message);
+  fflush(stdout);
+  fprintf(stderr, "libotr helper sent: %s\n", message);
+}
+
+void update_context_list(void *opdata) {}
+
+void new_fingerprint(void *opdata, OtrlUserState us, const char *accountname,
+                     const char *protocol, const char *username,
+                     unsigned char fingerprint[20]) {
+  fprintf(stderr, "NEW FINGERPRINT\n");
+  g_session_established = 1;
+}
+
+void write_fingerprints(void *opdata) {}
+
+void gone_secure(void *opdata, ConnContext *context) {}
+
+void gone_insecure(void *opdata, ConnContext *context) {}
+
+void still_secure(void *opdata, ConnContext *context, int is_reply) {}
+
+int max_message_size(void *opdata, ConnContext *context) { return 99999; }
+
+const char *account_name(void *opdata, const char *account,
+                         const char *protocol) {
+  return "ACCOUNT";
+}
+
+void account_name_free(void *opdata, const char *account_name) {}
+
+const char *error_message(void *opdata, ConnContext *context,
+                          OtrlErrorCode err_code) {
+  return "ERR";
+}
+
+void error_message_free(void *opdata, const char *msg) {}
+
+void resent_msg_prefix_free(void *opdata, const char *prefix) {}
+
+void handle_smp_event(void *opdata, OtrlSMPEvent smp_event,
+                      ConnContext *context, unsigned short progress_event,
+                      char *question) {}
+
+void handle_msg_event(void *opdata, OtrlMessageEvent msg_event,
+                      ConnContext *context, const char *message,
+                      gcry_error_t err) {
+  fprintf(stderr, "msg event: %d %s\n", msg_event, message);
+}
+
+OtrlMessageAppOps uiops = {
+    policy,
+    NULL,
+    is_logged_in,
+    inject_message,
+    update_context_list,
+    new_fingerprint,
+    write_fingerprints,
+    gone_secure,
+    gone_insecure,
+    still_secure,
+    max_message_size,
+    account_name,
+    account_name_free,
+    NULL, /* received_symkey */
+    error_message,
+    error_message_free,
+    NULL, /* resent_msg_prefix */
+    resent_msg_prefix_free,
+    handle_smp_event,
+    handle_msg_event,
+    NULL /* create_instag */,
+    NULL /* convert_msg */,
+    NULL /* convert_free */,
+    NULL /* timer_control */,
+};
+
+static const char kPrivateKeyData[] =
+    "(privkeys (account (name \"account\") (protocol proto) (private-key (dsa "
+    "(p "
+    "#00FC07ABCF0DC916AFF6E9AE47BEF60C7AB9B4D6B2469E436630E36F8A489BE812486A09F"
+    "30B71224508654940A835301ACC525A4FF133FC152CC53DCC59D65C30A54F1993FE13FE63E"
+    "5823D4C746DB21B90F9B9C00B49EC7404AB1D929BA7FBA12F2E45C6E0A651689750E8528AB"
+    "8C031D3561FECEE72EBB4A090D450A9B7A857#) (q "
+    "#00997BD266EF7B1F60A5C23F3A741F2AEFD07A2081#) (g "
+    "#535E360E8A95EBA46A4F7DE50AD6E9B2A6DB785A66B64EB9F20338D2A3E8FB0E94725848F"
+    "1AA6CC567CB83A1CC517EC806F2E92EAE71457E80B2210A189B91250779434B41FC8A8873F"
+    "6DB94BEA7D177F5D59E7E114EE10A49CFD9CEF88AE43387023B672927BA74B04EB6BBB5E57"
+    "597766A2F9CE3857D7ACE3E1E3BC1FC6F26#) (y "
+    "#0AC8670AD767D7A8D9D14CC1AC6744CD7D76F993B77FFD9E39DF01E5A6536EF65E775FCEF"
+    "2A983E2A19BD6415500F6979715D9FD1257E1FE2B6F5E1E74B333079E7C880D39868462A93"
+    "454B41877BE62E5EF0A041C2EE9C9E76BD1E12AE25D9628DECB097025DD625EF49C3258A1A"
+    "3C0FF501E3DC673B76D7BABF349009B6ECF#) (x "
+    "#14D0345A3562C480A039E3C72764F72D79043216#)))))\n";
+
+int main() {
+  OTRL_INIT;
+
+  // We have to write the private key information to a file because the libotr
+  // API demands a filename to read from.
+  const char *tmpdir = "/tmp";
+  if (getenv("TMP")) {
+    tmpdir = getenv("TMP");
+  }
+
+  char private_key_file[256];
+  snprintf(private_key_file, sizeof(private_key_file),
+           "%s/libotr_test_helper_privatekeys-XXXXXX", tmpdir);
+  int fd = mkstemp(private_key_file);
+  if (fd == -1) {
+    perror("creating temp file");
+  }
+  write(fd, kPrivateKeyData, sizeof(kPrivateKeyData) - 1);
+  close(fd);
+
+  OtrlUserState userstate = otrl_userstate_create();
+  otrl_privkey_read(userstate, private_key_file);
+  unlink(private_key_file);
+
+  fprintf(stderr, "libotr helper started\n");
+
+  char buf[4096];
+
+  for (;;) {
+    char *message = fgets(buf, sizeof(buf), stdin);
+    if (strlen(message) == 0) {
+      break;
+    }
+    message[strlen(message) - 1] = 0;
+    fprintf(stderr, "libotr helper got: %s\n", message);
+
+    char *newmessage = NULL;
+    OtrlTLV *tlvs;
+    int ignore_message = otrl_message_receiving(
+        userstate, &uiops, NULL, "account", "proto", "peer", message,
+        &newmessage, &tlvs, NULL, NULL, NULL);
+    if (tlvs) {
+      otrl_tlv_free(tlvs);
+    }
+
+    if (newmessage != NULL) {
+      fprintf(stderr, "libotr got: %s\n", newmessage);
+      otrl_message_free(newmessage);
+
+      gcry_error_t err;
+      char *newmessage = NULL;
+
+      err = otrl_message_sending(userstate, &uiops, NULL, "account", "proto",
+                                 "peer", 0, "test message", NULL, &newmessage,
+                                 OTRL_FRAGMENT_SEND_SKIP, NULL, NULL, NULL);
+      if (newmessage == NULL) {
+        fprintf(stderr, "libotr didn't encrypt message\n");
+        return 1;
+      }
+      write(1, newmessage, strlen(newmessage));
+      write(1, "\n", 1);
+      fprintf(stderr, "libotr sent: %s\n", newmessage);
+      otrl_message_free(newmessage);
+
+      g_session_established = 0;
+      write(1, "?OTRv2?\n", 8);
+      fprintf(stderr, "libotr sent: ?OTRv2\n");
+    }
+  }
+
+  return 0;
+}

--- a/vendor/golang.org/x/crypto/otr/otr.go
+++ b/vendor/golang.org/x/crypto/otr/otr.go
@@ -1,0 +1,1415 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package otr implements the Off The Record protocol as specified in
+// http://www.cypherpunks.ca/otr/Protocol-v2-3.1.0.html
+package otr // import "golang.org/x/crypto/otr"
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/dsa"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"hash"
+	"io"
+	"math/big"
+	"strconv"
+)
+
+// SecurityChange describes a change in the security state of a Conversation.
+type SecurityChange int
+
+const (
+	NoChange SecurityChange = iota
+	// NewKeys indicates that a key exchange has completed. This occurs
+	// when a conversation first becomes encrypted, and when the keys are
+	// renegotiated within an encrypted conversation.
+	NewKeys
+	// SMPSecretNeeded indicates that the peer has started an
+	// authentication and that we need to supply a secret. Call SMPQuestion
+	// to get the optional, human readable challenge and then Authenticate
+	// to supply the matching secret.
+	SMPSecretNeeded
+	// SMPComplete indicates that an authentication completed. The identity
+	// of the peer has now been confirmed.
+	SMPComplete
+	// SMPFailed indicates that an authentication failed.
+	SMPFailed
+	// ConversationEnded indicates that the peer ended the secure
+	// conversation.
+	ConversationEnded
+)
+
+// QueryMessage can be sent to a peer to start an OTR conversation.
+var QueryMessage = "?OTRv2?"
+
+// ErrorPrefix can be used to make an OTR error by appending an error message
+// to it.
+var ErrorPrefix = "?OTR Error:"
+
+var (
+	fragmentPartSeparator = []byte(",")
+	fragmentPrefix        = []byte("?OTR,")
+	msgPrefix             = []byte("?OTR:")
+	queryMarker           = []byte("?OTR")
+)
+
+// isQuery attempts to parse an OTR query from msg and returns the greatest
+// common version, or 0 if msg is not an OTR query.
+func isQuery(msg []byte) (greatestCommonVersion int) {
+	pos := bytes.Index(msg, queryMarker)
+	if pos == -1 {
+		return 0
+	}
+	for i, c := range msg[pos+len(queryMarker):] {
+		if i == 0 {
+			if c == '?' {
+				// Indicates support for version 1, but we don't
+				// implement that.
+				continue
+			}
+
+			if c != 'v' {
+				// Invalid message
+				return 0
+			}
+
+			continue
+		}
+
+		if c == '?' {
+			// End of message
+			return
+		}
+
+		if c == ' ' || c == '\t' {
+			// Probably an invalid message
+			return 0
+		}
+
+		if c == '2' {
+			greatestCommonVersion = 2
+		}
+	}
+
+	return 0
+}
+
+const (
+	statePlaintext = iota
+	stateEncrypted
+	stateFinished
+)
+
+const (
+	authStateNone = iota
+	authStateAwaitingDHKey
+	authStateAwaitingRevealSig
+	authStateAwaitingSig
+)
+
+const (
+	msgTypeDHCommit  = 2
+	msgTypeData      = 3
+	msgTypeDHKey     = 10
+	msgTypeRevealSig = 17
+	msgTypeSig       = 18
+)
+
+const (
+	// If the requested fragment size is less than this, it will be ignored.
+	minFragmentSize = 18
+	// Messages are padded to a multiple of this number of bytes.
+	paddingGranularity = 256
+	// The number of bytes in a Diffie-Hellman private value (320-bits).
+	dhPrivateBytes = 40
+	// The number of bytes needed to represent an element of the DSA
+	// subgroup (160-bits).
+	dsaSubgroupBytes = 20
+	// The number of bytes of the MAC that are sent on the wire (160-bits).
+	macPrefixBytes = 20
+)
+
+// These are the global, common group parameters for OTR.
+var (
+	p       *big.Int // group prime
+	g       *big.Int // group generator
+	q       *big.Int // group order
+	pMinus2 *big.Int
+)
+
+func init() {
+	p, _ = new(big.Int).SetString("FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3DC2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F83655D23DCA3AD961C62F356208552BB9ED529077096966D670C354E4ABC9804F1746C08CA237327FFFFFFFFFFFFFFFF", 16)
+	q, _ = new(big.Int).SetString("7FFFFFFFFFFFFFFFE487ED5110B4611A62633145C06E0E68948127044533E63A0105DF531D89CD9128A5043CC71A026EF7CA8CD9E69D218D98158536F92F8A1BA7F09AB6B6A8E122F242DABB312F3F637A262174D31BF6B585FFAE5B7A035BF6F71C35FDAD44CFD2D74F9208BE258FF324943328F6722D9EE1003E5C50B1DF82CC6D241B0E2AE9CD348B1FD47E9267AFC1B2AE91EE51D6CB0E3179AB1042A95DCF6A9483B84B4B36B3861AA7255E4C0278BA36046511B993FFFFFFFFFFFFFFFF", 16)
+	g = new(big.Int).SetInt64(2)
+	pMinus2 = new(big.Int).Sub(p, g)
+}
+
+// Conversation represents a relation with a peer. The zero value is a valid
+// Conversation, although PrivateKey must be set.
+//
+// When communicating with a peer, all inbound messages should be passed to
+// Conversation.Receive and all outbound messages to Conversation.Send. The
+// Conversation will take care of maintaining the encryption state and
+// negotiating encryption as needed.
+type Conversation struct {
+	// PrivateKey contains the private key to use to sign key exchanges.
+	PrivateKey *PrivateKey
+
+	// Rand can be set to override the entropy source. Otherwise,
+	// crypto/rand will be used.
+	Rand io.Reader
+	// If FragmentSize is set, all messages produced by Receive and Send
+	// will be fragmented into messages of, at most, this number of bytes.
+	FragmentSize int
+
+	// Once Receive has returned NewKeys once, the following fields are
+	// valid.
+	SSID           [8]byte
+	TheirPublicKey PublicKey
+
+	state, authState int
+
+	r       [16]byte
+	x, y    *big.Int
+	gx, gy  *big.Int
+	gxBytes []byte
+	digest  [sha256.Size]byte
+
+	revealKeys, sigKeys akeKeys
+
+	myKeyId         uint32
+	myCurrentDHPub  *big.Int
+	myCurrentDHPriv *big.Int
+	myLastDHPub     *big.Int
+	myLastDHPriv    *big.Int
+
+	theirKeyId        uint32
+	theirCurrentDHPub *big.Int
+	theirLastDHPub    *big.Int
+
+	keySlots [4]keySlot
+
+	myCounter    [8]byte
+	theirLastCtr [8]byte
+	oldMACs      []byte
+
+	k, n int // fragment state
+	frag []byte
+
+	smp smpState
+}
+
+// A keySlot contains key material for a specific (their keyid, my keyid) pair.
+type keySlot struct {
+	// used is true if this slot is valid. If false, it's free for reuse.
+	used                   bool
+	theirKeyId             uint32
+	myKeyId                uint32
+	sendAESKey, recvAESKey []byte
+	sendMACKey, recvMACKey []byte
+	theirLastCtr           [8]byte
+}
+
+// akeKeys are generated during key exchange. There's one set for the reveal
+// signature message and another for the signature message. In the protocol
+// spec the latter are indicated with a prime mark.
+type akeKeys struct {
+	c      [16]byte
+	m1, m2 [32]byte
+}
+
+func (c *Conversation) rand() io.Reader {
+	if c.Rand != nil {
+		return c.Rand
+	}
+	return rand.Reader
+}
+
+func (c *Conversation) randMPI(buf []byte) *big.Int {
+	_, err := io.ReadFull(c.rand(), buf)
+	if err != nil {
+		panic("otr: short read from random source")
+	}
+
+	return new(big.Int).SetBytes(buf)
+}
+
+// tlv represents the type-length value from the protocol.
+type tlv struct {
+	typ, length uint16
+	data        []byte
+}
+
+const (
+	tlvTypePadding          = 0
+	tlvTypeDisconnected     = 1
+	tlvTypeSMP1             = 2
+	tlvTypeSMP2             = 3
+	tlvTypeSMP3             = 4
+	tlvTypeSMP4             = 5
+	tlvTypeSMPAbort         = 6
+	tlvTypeSMP1WithQuestion = 7
+)
+
+// Receive handles a message from a peer. It returns a human readable message,
+// an indicator of whether that message was encrypted, a hint about the
+// encryption state and zero or more messages to send back to the peer.
+// These messages do not need to be passed to Send before transmission.
+func (c *Conversation) Receive(in []byte) (out []byte, encrypted bool, change SecurityChange, toSend [][]byte, err error) {
+	if bytes.HasPrefix(in, fragmentPrefix) {
+		in, err = c.processFragment(in)
+		if in == nil || err != nil {
+			return
+		}
+	}
+
+	if bytes.HasPrefix(in, msgPrefix) && in[len(in)-1] == '.' {
+		in = in[len(msgPrefix) : len(in)-1]
+	} else if version := isQuery(in); version > 0 {
+		c.authState = authStateAwaitingDHKey
+		c.reset()
+		toSend = c.encode(c.generateDHCommit())
+		return
+	} else {
+		// plaintext message
+		out = in
+		return
+	}
+
+	msg := make([]byte, base64.StdEncoding.DecodedLen(len(in)))
+	msgLen, err := base64.StdEncoding.Decode(msg, in)
+	if err != nil {
+		err = errors.New("otr: invalid base64 encoding in message")
+		return
+	}
+	msg = msg[:msgLen]
+
+	// The first two bytes are the protocol version (2)
+	if len(msg) < 3 || msg[0] != 0 || msg[1] != 2 {
+		err = errors.New("otr: invalid OTR message")
+		return
+	}
+
+	msgType := int(msg[2])
+	msg = msg[3:]
+
+	switch msgType {
+	case msgTypeDHCommit:
+		switch c.authState {
+		case authStateNone:
+			c.authState = authStateAwaitingRevealSig
+			if err = c.processDHCommit(msg); err != nil {
+				return
+			}
+			c.reset()
+			toSend = c.encode(c.generateDHKey())
+			return
+		case authStateAwaitingDHKey:
+			// This is a 'SYN-crossing'. The greater digest wins.
+			var cmp int
+			if cmp, err = c.compareToDHCommit(msg); err != nil {
+				return
+			}
+			if cmp > 0 {
+				// We win. Retransmit DH commit.
+				toSend = c.encode(c.serializeDHCommit())
+				return
+			} else {
+				// They win. We forget about our DH commit.
+				c.authState = authStateAwaitingRevealSig
+				if err = c.processDHCommit(msg); err != nil {
+					return
+				}
+				c.reset()
+				toSend = c.encode(c.generateDHKey())
+				return
+			}
+		case authStateAwaitingRevealSig:
+			if err = c.processDHCommit(msg); err != nil {
+				return
+			}
+			toSend = c.encode(c.serializeDHKey())
+		case authStateAwaitingSig:
+			if err = c.processDHCommit(msg); err != nil {
+				return
+			}
+			c.reset()
+			toSend = c.encode(c.generateDHKey())
+			c.authState = authStateAwaitingRevealSig
+		default:
+			panic("bad state")
+		}
+	case msgTypeDHKey:
+		switch c.authState {
+		case authStateAwaitingDHKey:
+			var isSame bool
+			if isSame, err = c.processDHKey(msg); err != nil {
+				return
+			}
+			if isSame {
+				err = errors.New("otr: unexpected duplicate DH key")
+				return
+			}
+			toSend = c.encode(c.generateRevealSig())
+			c.authState = authStateAwaitingSig
+		case authStateAwaitingSig:
+			var isSame bool
+			if isSame, err = c.processDHKey(msg); err != nil {
+				return
+			}
+			if isSame {
+				toSend = c.encode(c.serializeDHKey())
+			}
+		}
+	case msgTypeRevealSig:
+		if c.authState != authStateAwaitingRevealSig {
+			return
+		}
+		if err = c.processRevealSig(msg); err != nil {
+			return
+		}
+		toSend = c.encode(c.generateSig())
+		c.authState = authStateNone
+		c.state = stateEncrypted
+		change = NewKeys
+	case msgTypeSig:
+		if c.authState != authStateAwaitingSig {
+			return
+		}
+		if err = c.processSig(msg); err != nil {
+			return
+		}
+		c.authState = authStateNone
+		c.state = stateEncrypted
+		change = NewKeys
+	case msgTypeData:
+		if c.state != stateEncrypted {
+			err = errors.New("otr: encrypted message received without encrypted session established")
+			return
+		}
+		var tlvs []tlv
+		out, tlvs, err = c.processData(msg)
+		encrypted = true
+
+	EachTLV:
+		for _, inTLV := range tlvs {
+			switch inTLV.typ {
+			case tlvTypeDisconnected:
+				change = ConversationEnded
+				c.state = stateFinished
+				break EachTLV
+			case tlvTypeSMP1, tlvTypeSMP2, tlvTypeSMP3, tlvTypeSMP4, tlvTypeSMPAbort, tlvTypeSMP1WithQuestion:
+				var reply tlv
+				var complete bool
+				reply, complete, err = c.processSMP(inTLV)
+				if err == smpSecretMissingError {
+					err = nil
+					change = SMPSecretNeeded
+					c.smp.saved = &inTLV
+					return
+				}
+				if err == smpFailureError {
+					err = nil
+					change = SMPFailed
+				} else if complete {
+					change = SMPComplete
+				}
+				if reply.typ != 0 {
+					toSend = c.encode(c.generateData(nil, &reply))
+				}
+				break EachTLV
+			default:
+				// skip unknown TLVs
+			}
+		}
+	default:
+		err = errors.New("otr: unknown message type " + strconv.Itoa(msgType))
+	}
+
+	return
+}
+
+// Send takes a human readable message from the local user, possibly encrypts
+// it and returns zero one or more messages to send to the peer.
+func (c *Conversation) Send(msg []byte) ([][]byte, error) {
+	switch c.state {
+	case statePlaintext:
+		return [][]byte{msg}, nil
+	case stateEncrypted:
+		return c.encode(c.generateData(msg, nil)), nil
+	case stateFinished:
+		return nil, errors.New("otr: cannot send message because secure conversation has finished")
+	}
+
+	return nil, errors.New("otr: cannot send message in current state")
+}
+
+// SMPQuestion returns the human readable challenge question from the peer.
+// It's only valid after Receive has returned SMPSecretNeeded.
+func (c *Conversation) SMPQuestion() string {
+	return c.smp.question
+}
+
+// Authenticate begins an authentication with the peer. Authentication involves
+// an optional challenge message and a shared secret. The authentication
+// proceeds until either Receive returns SMPComplete, SMPSecretNeeded (which
+// indicates that a new authentication is happening and thus this one was
+// aborted) or SMPFailed.
+func (c *Conversation) Authenticate(question string, mutualSecret []byte) (toSend [][]byte, err error) {
+	if c.state != stateEncrypted {
+		err = errors.New("otr: can't authenticate a peer without a secure conversation established")
+		return
+	}
+
+	if c.smp.saved != nil {
+		c.calcSMPSecret(mutualSecret, false /* they started it */)
+
+		var out tlv
+		var complete bool
+		out, complete, err = c.processSMP(*c.smp.saved)
+		if complete {
+			panic("SMP completed on the first message")
+		}
+		c.smp.saved = nil
+		if out.typ != 0 {
+			toSend = c.encode(c.generateData(nil, &out))
+		}
+		return
+	}
+
+	c.calcSMPSecret(mutualSecret, true /* we started it */)
+	outs := c.startSMP(question)
+	for _, out := range outs {
+		toSend = append(toSend, c.encode(c.generateData(nil, &out))...)
+	}
+	return
+}
+
+// End ends a secure conversation by generating a termination message for
+// the peer and switches to unencrypted communication.
+func (c *Conversation) End() (toSend [][]byte) {
+	switch c.state {
+	case statePlaintext:
+		return nil
+	case stateEncrypted:
+		c.state = statePlaintext
+		return c.encode(c.generateData(nil, &tlv{typ: tlvTypeDisconnected}))
+	case stateFinished:
+		c.state = statePlaintext
+		return nil
+	}
+	panic("unreachable")
+}
+
+// IsEncrypted returns true if a message passed to Send would be encrypted
+// before transmission. This result remains valid until the next call to
+// Receive or End, which may change the state of the Conversation.
+func (c *Conversation) IsEncrypted() bool {
+	return c.state == stateEncrypted
+}
+
+var fragmentError = errors.New("otr: invalid OTR fragment")
+
+// processFragment processes a fragmented OTR message and possibly returns a
+// complete message. Fragmented messages look like "?OTR,k,n,msg," where k is
+// the fragment number (starting from 1), n is the number of fragments in this
+// message and msg is a substring of the base64 encoded message.
+func (c *Conversation) processFragment(in []byte) (out []byte, err error) {
+	in = in[len(fragmentPrefix):] // remove "?OTR,"
+	parts := bytes.Split(in, fragmentPartSeparator)
+	if len(parts) != 4 || len(parts[3]) != 0 {
+		return nil, fragmentError
+	}
+
+	k, err := strconv.Atoi(string(parts[0]))
+	if err != nil {
+		return nil, fragmentError
+	}
+
+	n, err := strconv.Atoi(string(parts[1]))
+	if err != nil {
+		return nil, fragmentError
+	}
+
+	if k < 1 || n < 1 || k > n {
+		return nil, fragmentError
+	}
+
+	if k == 1 {
+		c.frag = append(c.frag[:0], parts[2]...)
+		c.k, c.n = k, n
+	} else if n == c.n && k == c.k+1 {
+		c.frag = append(c.frag, parts[2]...)
+		c.k++
+	} else {
+		c.frag = c.frag[:0]
+		c.n, c.k = 0, 0
+	}
+
+	if c.n > 0 && c.k == c.n {
+		c.n, c.k = 0, 0
+		return c.frag, nil
+	}
+
+	return nil, nil
+}
+
+func (c *Conversation) generateDHCommit() []byte {
+	_, err := io.ReadFull(c.rand(), c.r[:])
+	if err != nil {
+		panic("otr: short read from random source")
+	}
+
+	var xBytes [dhPrivateBytes]byte
+	c.x = c.randMPI(xBytes[:])
+	c.gx = new(big.Int).Exp(g, c.x, p)
+	c.gy = nil
+	c.gxBytes = appendMPI(nil, c.gx)
+
+	h := sha256.New()
+	h.Write(c.gxBytes)
+	h.Sum(c.digest[:0])
+
+	aesCipher, err := aes.NewCipher(c.r[:])
+	if err != nil {
+		panic(err.Error())
+	}
+
+	var iv [aes.BlockSize]byte
+	ctr := cipher.NewCTR(aesCipher, iv[:])
+	ctr.XORKeyStream(c.gxBytes, c.gxBytes)
+
+	return c.serializeDHCommit()
+}
+
+func (c *Conversation) serializeDHCommit() []byte {
+	var ret []byte
+	ret = appendU16(ret, 2) // protocol version
+	ret = append(ret, msgTypeDHCommit)
+	ret = appendData(ret, c.gxBytes)
+	ret = appendData(ret, c.digest[:])
+	return ret
+}
+
+func (c *Conversation) processDHCommit(in []byte) error {
+	var ok1, ok2 bool
+	c.gxBytes, in, ok1 = getData(in)
+	digest, in, ok2 := getData(in)
+	if !ok1 || !ok2 || len(in) > 0 {
+		return errors.New("otr: corrupt DH commit message")
+	}
+	copy(c.digest[:], digest)
+	return nil
+}
+
+func (c *Conversation) compareToDHCommit(in []byte) (int, error) {
+	_, in, ok1 := getData(in)
+	digest, in, ok2 := getData(in)
+	if !ok1 || !ok2 || len(in) > 0 {
+		return 0, errors.New("otr: corrupt DH commit message")
+	}
+	return bytes.Compare(c.digest[:], digest), nil
+}
+
+func (c *Conversation) generateDHKey() []byte {
+	var yBytes [dhPrivateBytes]byte
+	c.y = c.randMPI(yBytes[:])
+	c.gy = new(big.Int).Exp(g, c.y, p)
+	return c.serializeDHKey()
+}
+
+func (c *Conversation) serializeDHKey() []byte {
+	var ret []byte
+	ret = appendU16(ret, 2) // protocol version
+	ret = append(ret, msgTypeDHKey)
+	ret = appendMPI(ret, c.gy)
+	return ret
+}
+
+func (c *Conversation) processDHKey(in []byte) (isSame bool, err error) {
+	gy, in, ok := getMPI(in)
+	if !ok {
+		err = errors.New("otr: corrupt DH key message")
+		return
+	}
+	if gy.Cmp(g) < 0 || gy.Cmp(pMinus2) > 0 {
+		err = errors.New("otr: DH value out of range")
+		return
+	}
+	if c.gy != nil {
+		isSame = c.gy.Cmp(gy) == 0
+		return
+	}
+	c.gy = gy
+	return
+}
+
+func (c *Conversation) generateEncryptedSignature(keys *akeKeys, xFirst bool) ([]byte, []byte) {
+	var xb []byte
+	xb = c.PrivateKey.PublicKey.Serialize(xb)
+
+	var verifyData []byte
+	if xFirst {
+		verifyData = appendMPI(verifyData, c.gx)
+		verifyData = appendMPI(verifyData, c.gy)
+	} else {
+		verifyData = appendMPI(verifyData, c.gy)
+		verifyData = appendMPI(verifyData, c.gx)
+	}
+	verifyData = append(verifyData, xb...)
+	verifyData = appendU32(verifyData, c.myKeyId)
+
+	mac := hmac.New(sha256.New, keys.m1[:])
+	mac.Write(verifyData)
+	mb := mac.Sum(nil)
+
+	xb = appendU32(xb, c.myKeyId)
+	xb = append(xb, c.PrivateKey.Sign(c.rand(), mb)...)
+
+	aesCipher, err := aes.NewCipher(keys.c[:])
+	if err != nil {
+		panic(err.Error())
+	}
+	var iv [aes.BlockSize]byte
+	ctr := cipher.NewCTR(aesCipher, iv[:])
+	ctr.XORKeyStream(xb, xb)
+
+	mac = hmac.New(sha256.New, keys.m2[:])
+	encryptedSig := appendData(nil, xb)
+	mac.Write(encryptedSig)
+
+	return encryptedSig, mac.Sum(nil)
+}
+
+func (c *Conversation) generateRevealSig() []byte {
+	s := new(big.Int).Exp(c.gy, c.x, p)
+	c.calcAKEKeys(s)
+	c.myKeyId++
+
+	encryptedSig, mac := c.generateEncryptedSignature(&c.revealKeys, true /* gx comes first */)
+
+	c.myCurrentDHPub = c.gx
+	c.myCurrentDHPriv = c.x
+	c.rotateDHKeys()
+	incCounter(&c.myCounter)
+
+	var ret []byte
+	ret = appendU16(ret, 2)
+	ret = append(ret, msgTypeRevealSig)
+	ret = appendData(ret, c.r[:])
+	ret = append(ret, encryptedSig...)
+	ret = append(ret, mac[:20]...)
+	return ret
+}
+
+func (c *Conversation) processEncryptedSig(encryptedSig, theirMAC []byte, keys *akeKeys, xFirst bool) error {
+	mac := hmac.New(sha256.New, keys.m2[:])
+	mac.Write(appendData(nil, encryptedSig))
+	myMAC := mac.Sum(nil)[:20]
+
+	if len(myMAC) != len(theirMAC) || subtle.ConstantTimeCompare(myMAC, theirMAC) == 0 {
+		return errors.New("bad signature MAC in encrypted signature")
+	}
+
+	aesCipher, err := aes.NewCipher(keys.c[:])
+	if err != nil {
+		panic(err.Error())
+	}
+	var iv [aes.BlockSize]byte
+	ctr := cipher.NewCTR(aesCipher, iv[:])
+	ctr.XORKeyStream(encryptedSig, encryptedSig)
+
+	sig := encryptedSig
+	sig, ok1 := c.TheirPublicKey.Parse(sig)
+	keyId, sig, ok2 := getU32(sig)
+	if !ok1 || !ok2 {
+		return errors.New("otr: corrupt encrypted signature")
+	}
+
+	var verifyData []byte
+	if xFirst {
+		verifyData = appendMPI(verifyData, c.gx)
+		verifyData = appendMPI(verifyData, c.gy)
+	} else {
+		verifyData = appendMPI(verifyData, c.gy)
+		verifyData = appendMPI(verifyData, c.gx)
+	}
+	verifyData = c.TheirPublicKey.Serialize(verifyData)
+	verifyData = appendU32(verifyData, keyId)
+
+	mac = hmac.New(sha256.New, keys.m1[:])
+	mac.Write(verifyData)
+	mb := mac.Sum(nil)
+
+	sig, ok1 = c.TheirPublicKey.Verify(mb, sig)
+	if !ok1 {
+		return errors.New("bad signature in encrypted signature")
+	}
+	if len(sig) > 0 {
+		return errors.New("corrupt encrypted signature")
+	}
+
+	c.theirKeyId = keyId
+	zero(c.theirLastCtr[:])
+	return nil
+}
+
+func (c *Conversation) processRevealSig(in []byte) error {
+	r, in, ok1 := getData(in)
+	encryptedSig, in, ok2 := getData(in)
+	theirMAC := in
+	if !ok1 || !ok2 || len(theirMAC) != 20 {
+		return errors.New("otr: corrupt reveal signature message")
+	}
+
+	aesCipher, err := aes.NewCipher(r)
+	if err != nil {
+		return errors.New("otr: cannot create AES cipher from reveal signature message: " + err.Error())
+	}
+	var iv [aes.BlockSize]byte
+	ctr := cipher.NewCTR(aesCipher, iv[:])
+	ctr.XORKeyStream(c.gxBytes, c.gxBytes)
+	h := sha256.New()
+	h.Write(c.gxBytes)
+	digest := h.Sum(nil)
+	if len(digest) != len(c.digest) || subtle.ConstantTimeCompare(digest, c.digest[:]) == 0 {
+		return errors.New("otr: bad commit MAC in reveal signature message")
+	}
+	var rest []byte
+	c.gx, rest, ok1 = getMPI(c.gxBytes)
+	if !ok1 || len(rest) > 0 {
+		return errors.New("otr: gx corrupt after decryption")
+	}
+	if c.gx.Cmp(g) < 0 || c.gx.Cmp(pMinus2) > 0 {
+		return errors.New("otr: DH value out of range")
+	}
+	s := new(big.Int).Exp(c.gx, c.y, p)
+	c.calcAKEKeys(s)
+
+	if err := c.processEncryptedSig(encryptedSig, theirMAC, &c.revealKeys, true /* gx comes first */); err != nil {
+		return errors.New("otr: in reveal signature message: " + err.Error())
+	}
+
+	c.theirCurrentDHPub = c.gx
+	c.theirLastDHPub = nil
+
+	return nil
+}
+
+func (c *Conversation) generateSig() []byte {
+	c.myKeyId++
+
+	encryptedSig, mac := c.generateEncryptedSignature(&c.sigKeys, false /* gy comes first */)
+
+	c.myCurrentDHPub = c.gy
+	c.myCurrentDHPriv = c.y
+	c.rotateDHKeys()
+	incCounter(&c.myCounter)
+
+	var ret []byte
+	ret = appendU16(ret, 2)
+	ret = append(ret, msgTypeSig)
+	ret = append(ret, encryptedSig...)
+	ret = append(ret, mac[:macPrefixBytes]...)
+	return ret
+}
+
+func (c *Conversation) processSig(in []byte) error {
+	encryptedSig, in, ok1 := getData(in)
+	theirMAC := in
+	if !ok1 || len(theirMAC) != macPrefixBytes {
+		return errors.New("otr: corrupt signature message")
+	}
+
+	if err := c.processEncryptedSig(encryptedSig, theirMAC, &c.sigKeys, false /* gy comes first */); err != nil {
+		return errors.New("otr: in signature message: " + err.Error())
+	}
+
+	c.theirCurrentDHPub = c.gy
+	c.theirLastDHPub = nil
+
+	return nil
+}
+
+func (c *Conversation) rotateDHKeys() {
+	// evict slots using our retired key id
+	for i := range c.keySlots {
+		slot := &c.keySlots[i]
+		if slot.used && slot.myKeyId == c.myKeyId-1 {
+			slot.used = false
+			c.oldMACs = append(c.oldMACs, slot.recvMACKey...)
+		}
+	}
+
+	c.myLastDHPriv = c.myCurrentDHPriv
+	c.myLastDHPub = c.myCurrentDHPub
+
+	var xBytes [dhPrivateBytes]byte
+	c.myCurrentDHPriv = c.randMPI(xBytes[:])
+	c.myCurrentDHPub = new(big.Int).Exp(g, c.myCurrentDHPriv, p)
+	c.myKeyId++
+}
+
+func (c *Conversation) processData(in []byte) (out []byte, tlvs []tlv, err error) {
+	origIn := in
+	flags, in, ok1 := getU8(in)
+	theirKeyId, in, ok2 := getU32(in)
+	myKeyId, in, ok3 := getU32(in)
+	y, in, ok4 := getMPI(in)
+	counter, in, ok5 := getNBytes(in, 8)
+	encrypted, in, ok6 := getData(in)
+	macedData := origIn[:len(origIn)-len(in)]
+	theirMAC, in, ok7 := getNBytes(in, macPrefixBytes)
+	_, in, ok8 := getData(in)
+	if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 || !ok6 || !ok7 || !ok8 || len(in) > 0 {
+		err = errors.New("otr: corrupt data message")
+		return
+	}
+
+	ignoreErrors := flags&1 != 0
+
+	slot, err := c.calcDataKeys(myKeyId, theirKeyId)
+	if err != nil {
+		if ignoreErrors {
+			err = nil
+		}
+		return
+	}
+
+	mac := hmac.New(sha1.New, slot.recvMACKey)
+	mac.Write([]byte{0, 2, 3})
+	mac.Write(macedData)
+	myMAC := mac.Sum(nil)
+	if len(myMAC) != len(theirMAC) || subtle.ConstantTimeCompare(myMAC, theirMAC) == 0 {
+		if !ignoreErrors {
+			err = errors.New("otr: bad MAC on data message")
+		}
+		return
+	}
+
+	if bytes.Compare(counter, slot.theirLastCtr[:]) <= 0 {
+		err = errors.New("otr: counter regressed")
+		return
+	}
+	copy(slot.theirLastCtr[:], counter)
+
+	var iv [aes.BlockSize]byte
+	copy(iv[:], counter)
+	aesCipher, err := aes.NewCipher(slot.recvAESKey)
+	if err != nil {
+		panic(err.Error())
+	}
+	ctr := cipher.NewCTR(aesCipher, iv[:])
+	ctr.XORKeyStream(encrypted, encrypted)
+	decrypted := encrypted
+
+	if myKeyId == c.myKeyId {
+		c.rotateDHKeys()
+	}
+	if theirKeyId == c.theirKeyId {
+		// evict slots using their retired key id
+		for i := range c.keySlots {
+			slot := &c.keySlots[i]
+			if slot.used && slot.theirKeyId == theirKeyId-1 {
+				slot.used = false
+				c.oldMACs = append(c.oldMACs, slot.recvMACKey...)
+			}
+		}
+
+		c.theirLastDHPub = c.theirCurrentDHPub
+		c.theirKeyId++
+		c.theirCurrentDHPub = y
+	}
+
+	if nulPos := bytes.IndexByte(decrypted, 0); nulPos >= 0 {
+		out = decrypted[:nulPos]
+		tlvData := decrypted[nulPos+1:]
+		for len(tlvData) > 0 {
+			var t tlv
+			var ok1, ok2, ok3 bool
+
+			t.typ, tlvData, ok1 = getU16(tlvData)
+			t.length, tlvData, ok2 = getU16(tlvData)
+			t.data, tlvData, ok3 = getNBytes(tlvData, int(t.length))
+			if !ok1 || !ok2 || !ok3 {
+				err = errors.New("otr: corrupt tlv data")
+				return
+			}
+			tlvs = append(tlvs, t)
+		}
+	} else {
+		out = decrypted
+	}
+
+	return
+}
+
+func (c *Conversation) generateData(msg []byte, extra *tlv) []byte {
+	slot, err := c.calcDataKeys(c.myKeyId-1, c.theirKeyId)
+	if err != nil {
+		panic("otr: failed to generate sending keys: " + err.Error())
+	}
+
+	var plaintext []byte
+	plaintext = append(plaintext, msg...)
+	plaintext = append(plaintext, 0)
+
+	padding := paddingGranularity - ((len(plaintext) + 4) % paddingGranularity)
+	plaintext = appendU16(plaintext, tlvTypePadding)
+	plaintext = appendU16(plaintext, uint16(padding))
+	for i := 0; i < padding; i++ {
+		plaintext = append(plaintext, 0)
+	}
+
+	if extra != nil {
+		plaintext = appendU16(plaintext, extra.typ)
+		plaintext = appendU16(plaintext, uint16(len(extra.data)))
+		plaintext = append(plaintext, extra.data...)
+	}
+
+	encrypted := make([]byte, len(plaintext))
+
+	var iv [aes.BlockSize]byte
+	copy(iv[:], c.myCounter[:])
+	aesCipher, err := aes.NewCipher(slot.sendAESKey)
+	if err != nil {
+		panic(err.Error())
+	}
+	ctr := cipher.NewCTR(aesCipher, iv[:])
+	ctr.XORKeyStream(encrypted, plaintext)
+
+	var ret []byte
+	ret = appendU16(ret, 2)
+	ret = append(ret, msgTypeData)
+	ret = append(ret, 0 /* flags */)
+	ret = appendU32(ret, c.myKeyId-1)
+	ret = appendU32(ret, c.theirKeyId)
+	ret = appendMPI(ret, c.myCurrentDHPub)
+	ret = append(ret, c.myCounter[:]...)
+	ret = appendData(ret, encrypted)
+
+	mac := hmac.New(sha1.New, slot.sendMACKey)
+	mac.Write(ret)
+	ret = append(ret, mac.Sum(nil)[:macPrefixBytes]...)
+	ret = appendData(ret, c.oldMACs)
+	c.oldMACs = nil
+	incCounter(&c.myCounter)
+
+	return ret
+}
+
+func incCounter(counter *[8]byte) {
+	for i := 7; i >= 0; i-- {
+		counter[i]++
+		if counter[i] > 0 {
+			break
+		}
+	}
+}
+
+// calcDataKeys computes the keys used to encrypt a data message given the key
+// IDs.
+func (c *Conversation) calcDataKeys(myKeyId, theirKeyId uint32) (slot *keySlot, err error) {
+	// Check for a cache hit.
+	for i := range c.keySlots {
+		slot = &c.keySlots[i]
+		if slot.used && slot.theirKeyId == theirKeyId && slot.myKeyId == myKeyId {
+			return
+		}
+	}
+
+	// Find an empty slot to write into.
+	slot = nil
+	for i := range c.keySlots {
+		if !c.keySlots[i].used {
+			slot = &c.keySlots[i]
+			break
+		}
+	}
+	if slot == nil {
+		return nil, errors.New("otr: internal error: no more key slots")
+	}
+
+	var myPriv, myPub, theirPub *big.Int
+
+	if myKeyId == c.myKeyId {
+		myPriv = c.myCurrentDHPriv
+		myPub = c.myCurrentDHPub
+	} else if myKeyId == c.myKeyId-1 {
+		myPriv = c.myLastDHPriv
+		myPub = c.myLastDHPub
+	} else {
+		err = errors.New("otr: peer requested keyid " + strconv.FormatUint(uint64(myKeyId), 10) + " when I'm on " + strconv.FormatUint(uint64(c.myKeyId), 10))
+		return
+	}
+
+	if theirKeyId == c.theirKeyId {
+		theirPub = c.theirCurrentDHPub
+	} else if theirKeyId == c.theirKeyId-1 && c.theirLastDHPub != nil {
+		theirPub = c.theirLastDHPub
+	} else {
+		err = errors.New("otr: peer requested keyid " + strconv.FormatUint(uint64(myKeyId), 10) + " when they're on " + strconv.FormatUint(uint64(c.myKeyId), 10))
+		return
+	}
+
+	var sendPrefixByte, recvPrefixByte [1]byte
+
+	if myPub.Cmp(theirPub) > 0 {
+		// we're the high end
+		sendPrefixByte[0], recvPrefixByte[0] = 1, 2
+	} else {
+		// we're the low end
+		sendPrefixByte[0], recvPrefixByte[0] = 2, 1
+	}
+
+	s := new(big.Int).Exp(theirPub, myPriv, p)
+	sBytes := appendMPI(nil, s)
+
+	h := sha1.New()
+	h.Write(sendPrefixByte[:])
+	h.Write(sBytes)
+	slot.sendAESKey = h.Sum(slot.sendAESKey[:0])[:16]
+
+	h.Reset()
+	h.Write(slot.sendAESKey)
+	slot.sendMACKey = h.Sum(slot.sendMACKey[:0])
+
+	h.Reset()
+	h.Write(recvPrefixByte[:])
+	h.Write(sBytes)
+	slot.recvAESKey = h.Sum(slot.recvAESKey[:0])[:16]
+
+	h.Reset()
+	h.Write(slot.recvAESKey)
+	slot.recvMACKey = h.Sum(slot.recvMACKey[:0])
+
+	slot.theirKeyId = theirKeyId
+	slot.myKeyId = myKeyId
+	slot.used = true
+
+	zero(slot.theirLastCtr[:])
+	return
+}
+
+func (c *Conversation) calcAKEKeys(s *big.Int) {
+	mpi := appendMPI(nil, s)
+	h := sha256.New()
+
+	var cBytes [32]byte
+	hashWithPrefix(c.SSID[:], 0, mpi, h)
+
+	hashWithPrefix(cBytes[:], 1, mpi, h)
+	copy(c.revealKeys.c[:], cBytes[:16])
+	copy(c.sigKeys.c[:], cBytes[16:])
+
+	hashWithPrefix(c.revealKeys.m1[:], 2, mpi, h)
+	hashWithPrefix(c.revealKeys.m2[:], 3, mpi, h)
+	hashWithPrefix(c.sigKeys.m1[:], 4, mpi, h)
+	hashWithPrefix(c.sigKeys.m2[:], 5, mpi, h)
+}
+
+func hashWithPrefix(out []byte, prefix byte, in []byte, h hash.Hash) {
+	h.Reset()
+	var p [1]byte
+	p[0] = prefix
+	h.Write(p[:])
+	h.Write(in)
+	if len(out) == h.Size() {
+		h.Sum(out[:0])
+	} else {
+		digest := h.Sum(nil)
+		copy(out, digest)
+	}
+}
+
+func (c *Conversation) encode(msg []byte) [][]byte {
+	b64 := make([]byte, base64.StdEncoding.EncodedLen(len(msg))+len(msgPrefix)+1)
+	base64.StdEncoding.Encode(b64[len(msgPrefix):], msg)
+	copy(b64, msgPrefix)
+	b64[len(b64)-1] = '.'
+
+	if c.FragmentSize < minFragmentSize || len(b64) <= c.FragmentSize {
+		// We can encode this in a single fragment.
+		return [][]byte{b64}
+	}
+
+	// We have to fragment this message.
+	var ret [][]byte
+	bytesPerFragment := c.FragmentSize - minFragmentSize
+	numFragments := (len(b64) + bytesPerFragment) / bytesPerFragment
+
+	for i := 0; i < numFragments; i++ {
+		frag := []byte("?OTR," + strconv.Itoa(i+1) + "," + strconv.Itoa(numFragments) + ",")
+		todo := bytesPerFragment
+		if todo > len(b64) {
+			todo = len(b64)
+		}
+		frag = append(frag, b64[:todo]...)
+		b64 = b64[todo:]
+		frag = append(frag, ',')
+		ret = append(ret, frag)
+	}
+
+	return ret
+}
+
+func (c *Conversation) reset() {
+	c.myKeyId = 0
+
+	for i := range c.keySlots {
+		c.keySlots[i].used = false
+	}
+}
+
+type PublicKey struct {
+	dsa.PublicKey
+}
+
+func (pk *PublicKey) Parse(in []byte) ([]byte, bool) {
+	var ok bool
+	var pubKeyType uint16
+
+	if pubKeyType, in, ok = getU16(in); !ok || pubKeyType != 0 {
+		return nil, false
+	}
+	if pk.P, in, ok = getMPI(in); !ok {
+		return nil, false
+	}
+	if pk.Q, in, ok = getMPI(in); !ok {
+		return nil, false
+	}
+	if pk.G, in, ok = getMPI(in); !ok {
+		return nil, false
+	}
+	if pk.Y, in, ok = getMPI(in); !ok {
+		return nil, false
+	}
+
+	return in, true
+}
+
+func (pk *PublicKey) Serialize(in []byte) []byte {
+	in = appendU16(in, 0)
+	in = appendMPI(in, pk.P)
+	in = appendMPI(in, pk.Q)
+	in = appendMPI(in, pk.G)
+	in = appendMPI(in, pk.Y)
+	return in
+}
+
+// Fingerprint returns the 20-byte, binary fingerprint of the PublicKey.
+func (pk *PublicKey) Fingerprint() []byte {
+	b := pk.Serialize(nil)
+	h := sha1.New()
+	h.Write(b[2:])
+	return h.Sum(nil)
+}
+
+func (pk *PublicKey) Verify(hashed, sig []byte) ([]byte, bool) {
+	if len(sig) != 2*dsaSubgroupBytes {
+		return nil, false
+	}
+	r := new(big.Int).SetBytes(sig[:dsaSubgroupBytes])
+	s := new(big.Int).SetBytes(sig[dsaSubgroupBytes:])
+	ok := dsa.Verify(&pk.PublicKey, hashed, r, s)
+	return sig[dsaSubgroupBytes*2:], ok
+}
+
+type PrivateKey struct {
+	PublicKey
+	dsa.PrivateKey
+}
+
+func (priv *PrivateKey) Sign(rand io.Reader, hashed []byte) []byte {
+	r, s, err := dsa.Sign(rand, &priv.PrivateKey, hashed)
+	if err != nil {
+		panic(err.Error())
+	}
+	rBytes := r.Bytes()
+	sBytes := s.Bytes()
+	if len(rBytes) > dsaSubgroupBytes || len(sBytes) > dsaSubgroupBytes {
+		panic("DSA signature too large")
+	}
+
+	out := make([]byte, 2*dsaSubgroupBytes)
+	copy(out[dsaSubgroupBytes-len(rBytes):], rBytes)
+	copy(out[len(out)-len(sBytes):], sBytes)
+	return out
+}
+
+func (priv *PrivateKey) Serialize(in []byte) []byte {
+	in = priv.PublicKey.Serialize(in)
+	in = appendMPI(in, priv.PrivateKey.X)
+	return in
+}
+
+func (priv *PrivateKey) Parse(in []byte) ([]byte, bool) {
+	in, ok := priv.PublicKey.Parse(in)
+	if !ok {
+		return in, ok
+	}
+	priv.PrivateKey.PublicKey = priv.PublicKey.PublicKey
+	priv.PrivateKey.X, in, ok = getMPI(in)
+	return in, ok
+}
+
+func (priv *PrivateKey) Generate(rand io.Reader) {
+	if err := dsa.GenerateParameters(&priv.PrivateKey.PublicKey.Parameters, rand, dsa.L1024N160); err != nil {
+		panic(err.Error())
+	}
+	if err := dsa.GenerateKey(&priv.PrivateKey, rand); err != nil {
+		panic(err.Error())
+	}
+	priv.PublicKey.PublicKey = priv.PrivateKey.PublicKey
+}
+
+func notHex(r rune) bool {
+	if r >= '0' && r <= '9' ||
+		r >= 'a' && r <= 'f' ||
+		r >= 'A' && r <= 'F' {
+		return false
+	}
+
+	return true
+}
+
+// Import parses the contents of a libotr private key file.
+func (priv *PrivateKey) Import(in []byte) bool {
+	mpiStart := []byte(" #")
+
+	mpis := make([]*big.Int, 5)
+
+	for i := 0; i < len(mpis); i++ {
+		start := bytes.Index(in, mpiStart)
+		if start == -1 {
+			return false
+		}
+		in = in[start+len(mpiStart):]
+		end := bytes.IndexFunc(in, notHex)
+		if end == -1 {
+			return false
+		}
+		hexBytes := in[:end]
+		in = in[end:]
+
+		if len(hexBytes)&1 != 0 {
+			return false
+		}
+
+		mpiBytes := make([]byte, len(hexBytes)/2)
+		if _, err := hex.Decode(mpiBytes, hexBytes); err != nil {
+			return false
+		}
+
+		mpis[i] = new(big.Int).SetBytes(mpiBytes)
+	}
+
+	for _, mpi := range mpis {
+		if mpi.Sign() <= 0 {
+			return false
+		}
+	}
+
+	priv.PrivateKey.P = mpis[0]
+	priv.PrivateKey.Q = mpis[1]
+	priv.PrivateKey.G = mpis[2]
+	priv.PrivateKey.Y = mpis[3]
+	priv.PrivateKey.X = mpis[4]
+	priv.PublicKey.PublicKey = priv.PrivateKey.PublicKey
+
+	a := new(big.Int).Exp(priv.PrivateKey.G, priv.PrivateKey.X, priv.PrivateKey.P)
+	return a.Cmp(priv.PrivateKey.Y) == 0
+}
+
+func getU8(in []byte) (uint8, []byte, bool) {
+	if len(in) < 1 {
+		return 0, in, false
+	}
+	return in[0], in[1:], true
+}
+
+func getU16(in []byte) (uint16, []byte, bool) {
+	if len(in) < 2 {
+		return 0, in, false
+	}
+	r := uint16(in[0])<<8 | uint16(in[1])
+	return r, in[2:], true
+}
+
+func getU32(in []byte) (uint32, []byte, bool) {
+	if len(in) < 4 {
+		return 0, in, false
+	}
+	r := uint32(in[0])<<24 | uint32(in[1])<<16 | uint32(in[2])<<8 | uint32(in[3])
+	return r, in[4:], true
+}
+
+func getMPI(in []byte) (*big.Int, []byte, bool) {
+	l, in, ok := getU32(in)
+	if !ok || uint32(len(in)) < l {
+		return nil, in, false
+	}
+	r := new(big.Int).SetBytes(in[:l])
+	return r, in[l:], true
+}
+
+func getData(in []byte) ([]byte, []byte, bool) {
+	l, in, ok := getU32(in)
+	if !ok || uint32(len(in)) < l {
+		return nil, in, false
+	}
+	return in[:l], in[l:], true
+}
+
+func getNBytes(in []byte, n int) ([]byte, []byte, bool) {
+	if len(in) < n {
+		return nil, in, false
+	}
+	return in[:n], in[n:], true
+}
+
+func appendU16(out []byte, v uint16) []byte {
+	out = append(out, byte(v>>8), byte(v))
+	return out
+}
+
+func appendU32(out []byte, v uint32) []byte {
+	out = append(out, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return out
+}
+
+func appendData(out, v []byte) []byte {
+	out = appendU32(out, uint32(len(v)))
+	out = append(out, v...)
+	return out
+}
+
+func appendMPI(out []byte, v *big.Int) []byte {
+	vBytes := v.Bytes()
+	out = appendU32(out, uint32(len(vBytes)))
+	out = append(out, vBytes...)
+	return out
+}
+
+func appendMPIs(out []byte, mpis ...*big.Int) []byte {
+	for _, mpi := range mpis {
+		out = appendMPI(out, mpi)
+	}
+	return out
+}
+
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/vendor/golang.org/x/crypto/otr/smp.go
+++ b/vendor/golang.org/x/crypto/otr/smp.go
@@ -1,0 +1,572 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file implements the Socialist Millionaires Protocol as described in
+// http://www.cypherpunks.ca/otr/Protocol-v2-3.1.0.html. The protocol
+// specification is required in order to understand this code and, where
+// possible, the variable names in the code match up with the spec.
+
+package otr
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"hash"
+	"math/big"
+)
+
+type smpFailure string
+
+func (s smpFailure) Error() string {
+	return string(s)
+}
+
+var smpFailureError = smpFailure("otr: SMP protocol failed")
+var smpSecretMissingError = smpFailure("otr: mutual secret needed")
+
+const smpVersion = 1
+
+const (
+	smpState1 = iota
+	smpState2
+	smpState3
+	smpState4
+)
+
+type smpState struct {
+	state                  int
+	a2, a3, b2, b3, pb, qb *big.Int
+	g2a, g3a               *big.Int
+	g2, g3                 *big.Int
+	g3b, papb, qaqb, ra    *big.Int
+	saved                  *tlv
+	secret                 *big.Int
+	question               string
+}
+
+func (c *Conversation) startSMP(question string) (tlvs []tlv) {
+	if c.smp.state != smpState1 {
+		tlvs = append(tlvs, c.generateSMPAbort())
+	}
+	tlvs = append(tlvs, c.generateSMP1(question))
+	c.smp.question = ""
+	c.smp.state = smpState2
+	return
+}
+
+func (c *Conversation) resetSMP() {
+	c.smp.state = smpState1
+	c.smp.secret = nil
+	c.smp.question = ""
+}
+
+func (c *Conversation) processSMP(in tlv) (out tlv, complete bool, err error) {
+	data := in.data
+
+	switch in.typ {
+	case tlvTypeSMPAbort:
+		if c.smp.state != smpState1 {
+			err = smpFailureError
+		}
+		c.resetSMP()
+		return
+	case tlvTypeSMP1WithQuestion:
+		// We preprocess this into a SMP1 message.
+		nulPos := bytes.IndexByte(data, 0)
+		if nulPos == -1 {
+			err = errors.New("otr: SMP message with question didn't contain a NUL byte")
+			return
+		}
+		c.smp.question = string(data[:nulPos])
+		data = data[nulPos+1:]
+	}
+
+	numMPIs, data, ok := getU32(data)
+	if !ok || numMPIs > 20 {
+		err = errors.New("otr: corrupt SMP message")
+		return
+	}
+
+	mpis := make([]*big.Int, numMPIs)
+	for i := range mpis {
+		var ok bool
+		mpis[i], data, ok = getMPI(data)
+		if !ok {
+			err = errors.New("otr: corrupt SMP message")
+			return
+		}
+	}
+
+	switch in.typ {
+	case tlvTypeSMP1, tlvTypeSMP1WithQuestion:
+		if c.smp.state != smpState1 {
+			c.resetSMP()
+			out = c.generateSMPAbort()
+			return
+		}
+		if c.smp.secret == nil {
+			err = smpSecretMissingError
+			return
+		}
+		if err = c.processSMP1(mpis); err != nil {
+			return
+		}
+		c.smp.state = smpState3
+		out = c.generateSMP2()
+	case tlvTypeSMP2:
+		if c.smp.state != smpState2 {
+			c.resetSMP()
+			out = c.generateSMPAbort()
+			return
+		}
+		if out, err = c.processSMP2(mpis); err != nil {
+			out = c.generateSMPAbort()
+			return
+		}
+		c.smp.state = smpState4
+	case tlvTypeSMP3:
+		if c.smp.state != smpState3 {
+			c.resetSMP()
+			out = c.generateSMPAbort()
+			return
+		}
+		if out, err = c.processSMP3(mpis); err != nil {
+			return
+		}
+		c.smp.state = smpState1
+		c.smp.secret = nil
+		complete = true
+	case tlvTypeSMP4:
+		if c.smp.state != smpState4 {
+			c.resetSMP()
+			out = c.generateSMPAbort()
+			return
+		}
+		if err = c.processSMP4(mpis); err != nil {
+			out = c.generateSMPAbort()
+			return
+		}
+		c.smp.state = smpState1
+		c.smp.secret = nil
+		complete = true
+	default:
+		panic("unknown SMP message")
+	}
+
+	return
+}
+
+func (c *Conversation) calcSMPSecret(mutualSecret []byte, weStarted bool) {
+	h := sha256.New()
+	h.Write([]byte{smpVersion})
+	if weStarted {
+		h.Write(c.PrivateKey.PublicKey.Fingerprint())
+		h.Write(c.TheirPublicKey.Fingerprint())
+	} else {
+		h.Write(c.TheirPublicKey.Fingerprint())
+		h.Write(c.PrivateKey.PublicKey.Fingerprint())
+	}
+	h.Write(c.SSID[:])
+	h.Write(mutualSecret)
+	c.smp.secret = new(big.Int).SetBytes(h.Sum(nil))
+}
+
+func (c *Conversation) generateSMP1(question string) tlv {
+	var randBuf [16]byte
+	c.smp.a2 = c.randMPI(randBuf[:])
+	c.smp.a3 = c.randMPI(randBuf[:])
+	g2a := new(big.Int).Exp(g, c.smp.a2, p)
+	g3a := new(big.Int).Exp(g, c.smp.a3, p)
+	h := sha256.New()
+
+	r2 := c.randMPI(randBuf[:])
+	r := new(big.Int).Exp(g, r2, p)
+	c2 := new(big.Int).SetBytes(hashMPIs(h, 1, r))
+	d2 := new(big.Int).Mul(c.smp.a2, c2)
+	d2.Sub(r2, d2)
+	d2.Mod(d2, q)
+	if d2.Sign() < 0 {
+		d2.Add(d2, q)
+	}
+
+	r3 := c.randMPI(randBuf[:])
+	r.Exp(g, r3, p)
+	c3 := new(big.Int).SetBytes(hashMPIs(h, 2, r))
+	d3 := new(big.Int).Mul(c.smp.a3, c3)
+	d3.Sub(r3, d3)
+	d3.Mod(d3, q)
+	if d3.Sign() < 0 {
+		d3.Add(d3, q)
+	}
+
+	var ret tlv
+	if len(question) > 0 {
+		ret.typ = tlvTypeSMP1WithQuestion
+		ret.data = append(ret.data, question...)
+		ret.data = append(ret.data, 0)
+	} else {
+		ret.typ = tlvTypeSMP1
+	}
+	ret.data = appendU32(ret.data, 6)
+	ret.data = appendMPIs(ret.data, g2a, c2, d2, g3a, c3, d3)
+	return ret
+}
+
+func (c *Conversation) processSMP1(mpis []*big.Int) error {
+	if len(mpis) != 6 {
+		return errors.New("otr: incorrect number of arguments in SMP1 message")
+	}
+	g2a := mpis[0]
+	c2 := mpis[1]
+	d2 := mpis[2]
+	g3a := mpis[3]
+	c3 := mpis[4]
+	d3 := mpis[5]
+	h := sha256.New()
+
+	r := new(big.Int).Exp(g, d2, p)
+	s := new(big.Int).Exp(g2a, c2, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+	t := new(big.Int).SetBytes(hashMPIs(h, 1, r))
+	if c2.Cmp(t) != 0 {
+		return errors.New("otr: ZKP c2 incorrect in SMP1 message")
+	}
+	r.Exp(g, d3, p)
+	s.Exp(g3a, c3, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+	t.SetBytes(hashMPIs(h, 2, r))
+	if c3.Cmp(t) != 0 {
+		return errors.New("otr: ZKP c3 incorrect in SMP1 message")
+	}
+
+	c.smp.g2a = g2a
+	c.smp.g3a = g3a
+	return nil
+}
+
+func (c *Conversation) generateSMP2() tlv {
+	var randBuf [16]byte
+	b2 := c.randMPI(randBuf[:])
+	c.smp.b3 = c.randMPI(randBuf[:])
+	r2 := c.randMPI(randBuf[:])
+	r3 := c.randMPI(randBuf[:])
+	r4 := c.randMPI(randBuf[:])
+	r5 := c.randMPI(randBuf[:])
+	r6 := c.randMPI(randBuf[:])
+
+	g2b := new(big.Int).Exp(g, b2, p)
+	g3b := new(big.Int).Exp(g, c.smp.b3, p)
+
+	r := new(big.Int).Exp(g, r2, p)
+	h := sha256.New()
+	c2 := new(big.Int).SetBytes(hashMPIs(h, 3, r))
+	d2 := new(big.Int).Mul(b2, c2)
+	d2.Sub(r2, d2)
+	d2.Mod(d2, q)
+	if d2.Sign() < 0 {
+		d2.Add(d2, q)
+	}
+
+	r.Exp(g, r3, p)
+	c3 := new(big.Int).SetBytes(hashMPIs(h, 4, r))
+	d3 := new(big.Int).Mul(c.smp.b3, c3)
+	d3.Sub(r3, d3)
+	d3.Mod(d3, q)
+	if d3.Sign() < 0 {
+		d3.Add(d3, q)
+	}
+
+	c.smp.g2 = new(big.Int).Exp(c.smp.g2a, b2, p)
+	c.smp.g3 = new(big.Int).Exp(c.smp.g3a, c.smp.b3, p)
+	c.smp.pb = new(big.Int).Exp(c.smp.g3, r4, p)
+	c.smp.qb = new(big.Int).Exp(g, r4, p)
+	r.Exp(c.smp.g2, c.smp.secret, p)
+	c.smp.qb.Mul(c.smp.qb, r)
+	c.smp.qb.Mod(c.smp.qb, p)
+
+	s := new(big.Int)
+	s.Exp(c.smp.g2, r6, p)
+	r.Exp(g, r5, p)
+	s.Mul(r, s)
+	s.Mod(s, p)
+	r.Exp(c.smp.g3, r5, p)
+	cp := new(big.Int).SetBytes(hashMPIs(h, 5, r, s))
+
+	// D5 = r5 - r4 cP mod q and D6 = r6 - y cP mod q
+
+	s.Mul(r4, cp)
+	r.Sub(r5, s)
+	d5 := new(big.Int).Mod(r, q)
+	if d5.Sign() < 0 {
+		d5.Add(d5, q)
+	}
+
+	s.Mul(c.smp.secret, cp)
+	r.Sub(r6, s)
+	d6 := new(big.Int).Mod(r, q)
+	if d6.Sign() < 0 {
+		d6.Add(d6, q)
+	}
+
+	var ret tlv
+	ret.typ = tlvTypeSMP2
+	ret.data = appendU32(ret.data, 11)
+	ret.data = appendMPIs(ret.data, g2b, c2, d2, g3b, c3, d3, c.smp.pb, c.smp.qb, cp, d5, d6)
+	return ret
+}
+
+func (c *Conversation) processSMP2(mpis []*big.Int) (out tlv, err error) {
+	if len(mpis) != 11 {
+		err = errors.New("otr: incorrect number of arguments in SMP2 message")
+		return
+	}
+	g2b := mpis[0]
+	c2 := mpis[1]
+	d2 := mpis[2]
+	g3b := mpis[3]
+	c3 := mpis[4]
+	d3 := mpis[5]
+	pb := mpis[6]
+	qb := mpis[7]
+	cp := mpis[8]
+	d5 := mpis[9]
+	d6 := mpis[10]
+	h := sha256.New()
+
+	r := new(big.Int).Exp(g, d2, p)
+	s := new(big.Int).Exp(g2b, c2, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+	s.SetBytes(hashMPIs(h, 3, r))
+	if c2.Cmp(s) != 0 {
+		err = errors.New("otr: ZKP c2 failed in SMP2 message")
+		return
+	}
+
+	r.Exp(g, d3, p)
+	s.Exp(g3b, c3, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+	s.SetBytes(hashMPIs(h, 4, r))
+	if c3.Cmp(s) != 0 {
+		err = errors.New("otr: ZKP c3 failed in SMP2 message")
+		return
+	}
+
+	c.smp.g2 = new(big.Int).Exp(g2b, c.smp.a2, p)
+	c.smp.g3 = new(big.Int).Exp(g3b, c.smp.a3, p)
+
+	r.Exp(g, d5, p)
+	s.Exp(c.smp.g2, d6, p)
+	r.Mul(r, s)
+	s.Exp(qb, cp, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+
+	s.Exp(c.smp.g3, d5, p)
+	t := new(big.Int).Exp(pb, cp, p)
+	s.Mul(s, t)
+	s.Mod(s, p)
+	t.SetBytes(hashMPIs(h, 5, s, r))
+	if cp.Cmp(t) != 0 {
+		err = errors.New("otr: ZKP cP failed in SMP2 message")
+		return
+	}
+
+	var randBuf [16]byte
+	r4 := c.randMPI(randBuf[:])
+	r5 := c.randMPI(randBuf[:])
+	r6 := c.randMPI(randBuf[:])
+	r7 := c.randMPI(randBuf[:])
+
+	pa := new(big.Int).Exp(c.smp.g3, r4, p)
+	r.Exp(c.smp.g2, c.smp.secret, p)
+	qa := new(big.Int).Exp(g, r4, p)
+	qa.Mul(qa, r)
+	qa.Mod(qa, p)
+
+	r.Exp(g, r5, p)
+	s.Exp(c.smp.g2, r6, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+
+	s.Exp(c.smp.g3, r5, p)
+	cp.SetBytes(hashMPIs(h, 6, s, r))
+
+	r.Mul(r4, cp)
+	d5 = new(big.Int).Sub(r5, r)
+	d5.Mod(d5, q)
+	if d5.Sign() < 0 {
+		d5.Add(d5, q)
+	}
+
+	r.Mul(c.smp.secret, cp)
+	d6 = new(big.Int).Sub(r6, r)
+	d6.Mod(d6, q)
+	if d6.Sign() < 0 {
+		d6.Add(d6, q)
+	}
+
+	r.ModInverse(qb, p)
+	qaqb := new(big.Int).Mul(qa, r)
+	qaqb.Mod(qaqb, p)
+
+	ra := new(big.Int).Exp(qaqb, c.smp.a3, p)
+	r.Exp(qaqb, r7, p)
+	s.Exp(g, r7, p)
+	cr := new(big.Int).SetBytes(hashMPIs(h, 7, s, r))
+
+	r.Mul(c.smp.a3, cr)
+	d7 := new(big.Int).Sub(r7, r)
+	d7.Mod(d7, q)
+	if d7.Sign() < 0 {
+		d7.Add(d7, q)
+	}
+
+	c.smp.g3b = g3b
+	c.smp.qaqb = qaqb
+
+	r.ModInverse(pb, p)
+	c.smp.papb = new(big.Int).Mul(pa, r)
+	c.smp.papb.Mod(c.smp.papb, p)
+	c.smp.ra = ra
+
+	out.typ = tlvTypeSMP3
+	out.data = appendU32(out.data, 8)
+	out.data = appendMPIs(out.data, pa, qa, cp, d5, d6, ra, cr, d7)
+	return
+}
+
+func (c *Conversation) processSMP3(mpis []*big.Int) (out tlv, err error) {
+	if len(mpis) != 8 {
+		err = errors.New("otr: incorrect number of arguments in SMP3 message")
+		return
+	}
+	pa := mpis[0]
+	qa := mpis[1]
+	cp := mpis[2]
+	d5 := mpis[3]
+	d6 := mpis[4]
+	ra := mpis[5]
+	cr := mpis[6]
+	d7 := mpis[7]
+	h := sha256.New()
+
+	r := new(big.Int).Exp(g, d5, p)
+	s := new(big.Int).Exp(c.smp.g2, d6, p)
+	r.Mul(r, s)
+	s.Exp(qa, cp, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+
+	s.Exp(c.smp.g3, d5, p)
+	t := new(big.Int).Exp(pa, cp, p)
+	s.Mul(s, t)
+	s.Mod(s, p)
+	t.SetBytes(hashMPIs(h, 6, s, r))
+	if t.Cmp(cp) != 0 {
+		err = errors.New("otr: ZKP cP failed in SMP3 message")
+		return
+	}
+
+	r.ModInverse(c.smp.qb, p)
+	qaqb := new(big.Int).Mul(qa, r)
+	qaqb.Mod(qaqb, p)
+
+	r.Exp(qaqb, d7, p)
+	s.Exp(ra, cr, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+
+	s.Exp(g, d7, p)
+	t.Exp(c.smp.g3a, cr, p)
+	s.Mul(s, t)
+	s.Mod(s, p)
+	t.SetBytes(hashMPIs(h, 7, s, r))
+	if t.Cmp(cr) != 0 {
+		err = errors.New("otr: ZKP cR failed in SMP3 message")
+		return
+	}
+
+	var randBuf [16]byte
+	r7 := c.randMPI(randBuf[:])
+	rb := new(big.Int).Exp(qaqb, c.smp.b3, p)
+
+	r.Exp(qaqb, r7, p)
+	s.Exp(g, r7, p)
+	cr = new(big.Int).SetBytes(hashMPIs(h, 8, s, r))
+
+	r.Mul(c.smp.b3, cr)
+	d7 = new(big.Int).Sub(r7, r)
+	d7.Mod(d7, q)
+	if d7.Sign() < 0 {
+		d7.Add(d7, q)
+	}
+
+	out.typ = tlvTypeSMP4
+	out.data = appendU32(out.data, 3)
+	out.data = appendMPIs(out.data, rb, cr, d7)
+
+	r.ModInverse(c.smp.pb, p)
+	r.Mul(pa, r)
+	r.Mod(r, p)
+	s.Exp(ra, c.smp.b3, p)
+	if r.Cmp(s) != 0 {
+		err = smpFailureError
+	}
+
+	return
+}
+
+func (c *Conversation) processSMP4(mpis []*big.Int) error {
+	if len(mpis) != 3 {
+		return errors.New("otr: incorrect number of arguments in SMP4 message")
+	}
+	rb := mpis[0]
+	cr := mpis[1]
+	d7 := mpis[2]
+	h := sha256.New()
+
+	r := new(big.Int).Exp(c.smp.qaqb, d7, p)
+	s := new(big.Int).Exp(rb, cr, p)
+	r.Mul(r, s)
+	r.Mod(r, p)
+
+	s.Exp(g, d7, p)
+	t := new(big.Int).Exp(c.smp.g3b, cr, p)
+	s.Mul(s, t)
+	s.Mod(s, p)
+	t.SetBytes(hashMPIs(h, 8, s, r))
+	if t.Cmp(cr) != 0 {
+		return errors.New("otr: ZKP cR failed in SMP4 message")
+	}
+
+	r.Exp(rb, c.smp.a3, p)
+	if r.Cmp(c.smp.papb) != 0 {
+		return smpFailureError
+	}
+
+	return nil
+}
+
+func (c *Conversation) generateSMPAbort() tlv {
+	return tlv{typ: tlvTypeSMPAbort}
+}
+
+func hashMPIs(h hash.Hash, magic byte, mpis ...*big.Int) []byte {
+	if h != nil {
+		h.Reset()
+	} else {
+		h = sha256.New()
+	}
+
+	h.Write([]byte{magic})
+	for _, mpi := range mpis {
+		h.Write(appendMPI(nil, mpi))
+	}
+	return h.Sum(nil)
+}

--- a/vendor/golang.org/x/crypto/ssh/terminal/terminal.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/terminal.go
@@ -1,0 +1,951 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package terminal
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"unicode/utf8"
+)
+
+// EscapeCodes contains escape sequences that can be written to the terminal in
+// order to achieve different styles of text.
+type EscapeCodes struct {
+	// Foreground colors
+	Black, Red, Green, Yellow, Blue, Magenta, Cyan, White []byte
+
+	// Reset all attributes
+	Reset []byte
+}
+
+var vt100EscapeCodes = EscapeCodes{
+	Black:   []byte{keyEscape, '[', '3', '0', 'm'},
+	Red:     []byte{keyEscape, '[', '3', '1', 'm'},
+	Green:   []byte{keyEscape, '[', '3', '2', 'm'},
+	Yellow:  []byte{keyEscape, '[', '3', '3', 'm'},
+	Blue:    []byte{keyEscape, '[', '3', '4', 'm'},
+	Magenta: []byte{keyEscape, '[', '3', '5', 'm'},
+	Cyan:    []byte{keyEscape, '[', '3', '6', 'm'},
+	White:   []byte{keyEscape, '[', '3', '7', 'm'},
+
+	Reset: []byte{keyEscape, '[', '0', 'm'},
+}
+
+// Terminal contains the state for running a VT100 terminal that is capable of
+// reading lines of input.
+type Terminal struct {
+	// AutoCompleteCallback, if non-null, is called for each keypress with
+	// the full input line and the current position of the cursor (in
+	// bytes, as an index into |line|). If it returns ok=false, the key
+	// press is processed normally. Otherwise it returns a replacement line
+	// and the new cursor position.
+	AutoCompleteCallback func(line string, pos int, key rune) (newLine string, newPos int, ok bool)
+
+	// Escape contains a pointer to the escape codes for this terminal.
+	// It's always a valid pointer, although the escape codes themselves
+	// may be empty if the terminal doesn't support them.
+	Escape *EscapeCodes
+
+	// lock protects the terminal and the state in this object from
+	// concurrent processing of a key press and a Write() call.
+	lock sync.Mutex
+
+	c      io.ReadWriter
+	prompt []rune
+
+	// line is the current line being entered.
+	line []rune
+	// pos is the logical position of the cursor in line
+	pos int
+	// echo is true if local echo is enabled
+	echo bool
+	// pasteActive is true iff there is a bracketed paste operation in
+	// progress.
+	pasteActive bool
+
+	// cursorX contains the current X value of the cursor where the left
+	// edge is 0. cursorY contains the row number where the first row of
+	// the current line is 0.
+	cursorX, cursorY int
+	// maxLine is the greatest value of cursorY so far.
+	maxLine int
+
+	termWidth, termHeight int
+
+	// outBuf contains the terminal data to be sent.
+	outBuf []byte
+	// remainder contains the remainder of any partial key sequences after
+	// a read. It aliases into inBuf.
+	remainder []byte
+	inBuf     [256]byte
+
+	// history contains previously entered commands so that they can be
+	// accessed with the up and down keys.
+	history stRingBuffer
+	// historyIndex stores the currently accessed history entry, where zero
+	// means the immediately previous entry.
+	historyIndex int
+	// When navigating up and down the history it's possible to return to
+	// the incomplete, initial line. That value is stored in
+	// historyPending.
+	historyPending string
+}
+
+// NewTerminal runs a VT100 terminal on the given ReadWriter. If the ReadWriter is
+// a local terminal, that terminal must first have been put into raw mode.
+// prompt is a string that is written at the start of each input line (i.e.
+// "> ").
+func NewTerminal(c io.ReadWriter, prompt string) *Terminal {
+	return &Terminal{
+		Escape:       &vt100EscapeCodes,
+		c:            c,
+		prompt:       []rune(prompt),
+		termWidth:    80,
+		termHeight:   24,
+		echo:         true,
+		historyIndex: -1,
+	}
+}
+
+const (
+	keyCtrlD     = 4
+	keyCtrlU     = 21
+	keyEnter     = '\r'
+	keyEscape    = 27
+	keyBackspace = 127
+	keyUnknown   = 0xd800 /* UTF-16 surrogate area */ + iota
+	keyUp
+	keyDown
+	keyLeft
+	keyRight
+	keyAltLeft
+	keyAltRight
+	keyHome
+	keyEnd
+	keyDeleteWord
+	keyDeleteLine
+	keyClearScreen
+	keyPasteStart
+	keyPasteEnd
+)
+
+var (
+	crlf       = []byte{'\r', '\n'}
+	pasteStart = []byte{keyEscape, '[', '2', '0', '0', '~'}
+	pasteEnd   = []byte{keyEscape, '[', '2', '0', '1', '~'}
+)
+
+// bytesToKey tries to parse a key sequence from b. If successful, it returns
+// the key and the remainder of the input. Otherwise it returns utf8.RuneError.
+func bytesToKey(b []byte, pasteActive bool) (rune, []byte) {
+	if len(b) == 0 {
+		return utf8.RuneError, nil
+	}
+
+	if !pasteActive {
+		switch b[0] {
+		case 1: // ^A
+			return keyHome, b[1:]
+		case 5: // ^E
+			return keyEnd, b[1:]
+		case 8: // ^H
+			return keyBackspace, b[1:]
+		case 11: // ^K
+			return keyDeleteLine, b[1:]
+		case 12: // ^L
+			return keyClearScreen, b[1:]
+		case 23: // ^W
+			return keyDeleteWord, b[1:]
+		}
+	}
+
+	if b[0] != keyEscape {
+		if !utf8.FullRune(b) {
+			return utf8.RuneError, b
+		}
+		r, l := utf8.DecodeRune(b)
+		return r, b[l:]
+	}
+
+	if !pasteActive && len(b) >= 3 && b[0] == keyEscape && b[1] == '[' {
+		switch b[2] {
+		case 'A':
+			return keyUp, b[3:]
+		case 'B':
+			return keyDown, b[3:]
+		case 'C':
+			return keyRight, b[3:]
+		case 'D':
+			return keyLeft, b[3:]
+		case 'H':
+			return keyHome, b[3:]
+		case 'F':
+			return keyEnd, b[3:]
+		}
+	}
+
+	if !pasteActive && len(b) >= 6 && b[0] == keyEscape && b[1] == '[' && b[2] == '1' && b[3] == ';' && b[4] == '3' {
+		switch b[5] {
+		case 'C':
+			return keyAltRight, b[6:]
+		case 'D':
+			return keyAltLeft, b[6:]
+		}
+	}
+
+	if !pasteActive && len(b) >= 6 && bytes.Equal(b[:6], pasteStart) {
+		return keyPasteStart, b[6:]
+	}
+
+	if pasteActive && len(b) >= 6 && bytes.Equal(b[:6], pasteEnd) {
+		return keyPasteEnd, b[6:]
+	}
+
+	// If we get here then we have a key that we don't recognise, or a
+	// partial sequence. It's not clear how one should find the end of a
+	// sequence without knowing them all, but it seems that [a-zA-Z~] only
+	// appears at the end of a sequence.
+	for i, c := range b[0:] {
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '~' {
+			return keyUnknown, b[i+1:]
+		}
+	}
+
+	return utf8.RuneError, b
+}
+
+// queue appends data to the end of t.outBuf
+func (t *Terminal) queue(data []rune) {
+	t.outBuf = append(t.outBuf, []byte(string(data))...)
+}
+
+var eraseUnderCursor = []rune{' ', keyEscape, '[', 'D'}
+var space = []rune{' '}
+
+func isPrintable(key rune) bool {
+	isInSurrogateArea := key >= 0xd800 && key <= 0xdbff
+	return key >= 32 && !isInSurrogateArea
+}
+
+// moveCursorToPos appends data to t.outBuf which will move the cursor to the
+// given, logical position in the text.
+func (t *Terminal) moveCursorToPos(pos int) {
+	if !t.echo {
+		return
+	}
+
+	x := visualLength(t.prompt) + pos
+	y := x / t.termWidth
+	x = x % t.termWidth
+
+	up := 0
+	if y < t.cursorY {
+		up = t.cursorY - y
+	}
+
+	down := 0
+	if y > t.cursorY {
+		down = y - t.cursorY
+	}
+
+	left := 0
+	if x < t.cursorX {
+		left = t.cursorX - x
+	}
+
+	right := 0
+	if x > t.cursorX {
+		right = x - t.cursorX
+	}
+
+	t.cursorX = x
+	t.cursorY = y
+	t.move(up, down, left, right)
+}
+
+func (t *Terminal) move(up, down, left, right int) {
+	movement := make([]rune, 3*(up+down+left+right))
+	m := movement
+	for i := 0; i < up; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'A'
+		m = m[3:]
+	}
+	for i := 0; i < down; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'B'
+		m = m[3:]
+	}
+	for i := 0; i < left; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'D'
+		m = m[3:]
+	}
+	for i := 0; i < right; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'C'
+		m = m[3:]
+	}
+
+	t.queue(movement)
+}
+
+func (t *Terminal) clearLineToRight() {
+	op := []rune{keyEscape, '[', 'K'}
+	t.queue(op)
+}
+
+const maxLineLength = 4096
+
+func (t *Terminal) setLine(newLine []rune, newPos int) {
+	if t.echo {
+		t.moveCursorToPos(0)
+		t.writeLine(newLine)
+		for i := len(newLine); i < len(t.line); i++ {
+			t.writeLine(space)
+		}
+		t.moveCursorToPos(newPos)
+	}
+	t.line = newLine
+	t.pos = newPos
+}
+
+func (t *Terminal) advanceCursor(places int) {
+	t.cursorX += places
+	t.cursorY += t.cursorX / t.termWidth
+	if t.cursorY > t.maxLine {
+		t.maxLine = t.cursorY
+	}
+	t.cursorX = t.cursorX % t.termWidth
+
+	if places > 0 && t.cursorX == 0 {
+		// Normally terminals will advance the current position
+		// when writing a character. But that doesn't happen
+		// for the last character in a line. However, when
+		// writing a character (except a new line) that causes
+		// a line wrap, the position will be advanced two
+		// places.
+		//
+		// So, if we are stopping at the end of a line, we
+		// need to write a newline so that our cursor can be
+		// advanced to the next line.
+		t.outBuf = append(t.outBuf, '\r', '\n')
+	}
+}
+
+func (t *Terminal) eraseNPreviousChars(n int) {
+	if n == 0 {
+		return
+	}
+
+	if t.pos < n {
+		n = t.pos
+	}
+	t.pos -= n
+	t.moveCursorToPos(t.pos)
+
+	copy(t.line[t.pos:], t.line[n+t.pos:])
+	t.line = t.line[:len(t.line)-n]
+	if t.echo {
+		t.writeLine(t.line[t.pos:])
+		for i := 0; i < n; i++ {
+			t.queue(space)
+		}
+		t.advanceCursor(n)
+		t.moveCursorToPos(t.pos)
+	}
+}
+
+// countToLeftWord returns then number of characters from the cursor to the
+// start of the previous word.
+func (t *Terminal) countToLeftWord() int {
+	if t.pos == 0 {
+		return 0
+	}
+
+	pos := t.pos - 1
+	for pos > 0 {
+		if t.line[pos] != ' ' {
+			break
+		}
+		pos--
+	}
+	for pos > 0 {
+		if t.line[pos] == ' ' {
+			pos++
+			break
+		}
+		pos--
+	}
+
+	return t.pos - pos
+}
+
+// countToRightWord returns then number of characters from the cursor to the
+// start of the next word.
+func (t *Terminal) countToRightWord() int {
+	pos := t.pos
+	for pos < len(t.line) {
+		if t.line[pos] == ' ' {
+			break
+		}
+		pos++
+	}
+	for pos < len(t.line) {
+		if t.line[pos] != ' ' {
+			break
+		}
+		pos++
+	}
+	return pos - t.pos
+}
+
+// visualLength returns the number of visible glyphs in s.
+func visualLength(runes []rune) int {
+	inEscapeSeq := false
+	length := 0
+
+	for _, r := range runes {
+		switch {
+		case inEscapeSeq:
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscapeSeq = false
+			}
+		case r == '\x1b':
+			inEscapeSeq = true
+		default:
+			length++
+		}
+	}
+
+	return length
+}
+
+// handleKey processes the given key and, optionally, returns a line of text
+// that the user has entered.
+func (t *Terminal) handleKey(key rune) (line string, ok bool) {
+	if t.pasteActive && key != keyEnter {
+		t.addKeyToLine(key)
+		return
+	}
+
+	switch key {
+	case keyBackspace:
+		if t.pos == 0 {
+			return
+		}
+		t.eraseNPreviousChars(1)
+	case keyAltLeft:
+		// move left by a word.
+		t.pos -= t.countToLeftWord()
+		t.moveCursorToPos(t.pos)
+	case keyAltRight:
+		// move right by a word.
+		t.pos += t.countToRightWord()
+		t.moveCursorToPos(t.pos)
+	case keyLeft:
+		if t.pos == 0 {
+			return
+		}
+		t.pos--
+		t.moveCursorToPos(t.pos)
+	case keyRight:
+		if t.pos == len(t.line) {
+			return
+		}
+		t.pos++
+		t.moveCursorToPos(t.pos)
+	case keyHome:
+		if t.pos == 0 {
+			return
+		}
+		t.pos = 0
+		t.moveCursorToPos(t.pos)
+	case keyEnd:
+		if t.pos == len(t.line) {
+			return
+		}
+		t.pos = len(t.line)
+		t.moveCursorToPos(t.pos)
+	case keyUp:
+		entry, ok := t.history.NthPreviousEntry(t.historyIndex + 1)
+		if !ok {
+			return "", false
+		}
+		if t.historyIndex == -1 {
+			t.historyPending = string(t.line)
+		}
+		t.historyIndex++
+		runes := []rune(entry)
+		t.setLine(runes, len(runes))
+	case keyDown:
+		switch t.historyIndex {
+		case -1:
+			return
+		case 0:
+			runes := []rune(t.historyPending)
+			t.setLine(runes, len(runes))
+			t.historyIndex--
+		default:
+			entry, ok := t.history.NthPreviousEntry(t.historyIndex - 1)
+			if ok {
+				t.historyIndex--
+				runes := []rune(entry)
+				t.setLine(runes, len(runes))
+			}
+		}
+	case keyEnter:
+		t.moveCursorToPos(len(t.line))
+		t.queue([]rune("\r\n"))
+		line = string(t.line)
+		ok = true
+		t.line = t.line[:0]
+		t.pos = 0
+		t.cursorX = 0
+		t.cursorY = 0
+		t.maxLine = 0
+	case keyDeleteWord:
+		// Delete zero or more spaces and then one or more characters.
+		t.eraseNPreviousChars(t.countToLeftWord())
+	case keyDeleteLine:
+		// Delete everything from the current cursor position to the
+		// end of line.
+		for i := t.pos; i < len(t.line); i++ {
+			t.queue(space)
+			t.advanceCursor(1)
+		}
+		t.line = t.line[:t.pos]
+		t.moveCursorToPos(t.pos)
+	case keyCtrlD:
+		// Erase the character under the current position.
+		// The EOF case when the line is empty is handled in
+		// readLine().
+		if t.pos < len(t.line) {
+			t.pos++
+			t.eraseNPreviousChars(1)
+		}
+	case keyCtrlU:
+		t.eraseNPreviousChars(t.pos)
+	case keyClearScreen:
+		// Erases the screen and moves the cursor to the home position.
+		t.queue([]rune("\x1b[2J\x1b[H"))
+		t.queue(t.prompt)
+		t.cursorX, t.cursorY = 0, 0
+		t.advanceCursor(visualLength(t.prompt))
+		t.setLine(t.line, t.pos)
+	default:
+		if t.AutoCompleteCallback != nil {
+			prefix := string(t.line[:t.pos])
+			suffix := string(t.line[t.pos:])
+
+			t.lock.Unlock()
+			newLine, newPos, completeOk := t.AutoCompleteCallback(prefix+suffix, len(prefix), key)
+			t.lock.Lock()
+
+			if completeOk {
+				t.setLine([]rune(newLine), utf8.RuneCount([]byte(newLine)[:newPos]))
+				return
+			}
+		}
+		if !isPrintable(key) {
+			return
+		}
+		if len(t.line) == maxLineLength {
+			return
+		}
+		t.addKeyToLine(key)
+	}
+	return
+}
+
+// addKeyToLine inserts the given key at the current position in the current
+// line.
+func (t *Terminal) addKeyToLine(key rune) {
+	if len(t.line) == cap(t.line) {
+		newLine := make([]rune, len(t.line), 2*(1+len(t.line)))
+		copy(newLine, t.line)
+		t.line = newLine
+	}
+	t.line = t.line[:len(t.line)+1]
+	copy(t.line[t.pos+1:], t.line[t.pos:])
+	t.line[t.pos] = key
+	if t.echo {
+		t.writeLine(t.line[t.pos:])
+	}
+	t.pos++
+	t.moveCursorToPos(t.pos)
+}
+
+func (t *Terminal) writeLine(line []rune) {
+	for len(line) != 0 {
+		remainingOnLine := t.termWidth - t.cursorX
+		todo := len(line)
+		if todo > remainingOnLine {
+			todo = remainingOnLine
+		}
+		t.queue(line[:todo])
+		t.advanceCursor(visualLength(line[:todo]))
+		line = line[todo:]
+	}
+}
+
+// writeWithCRLF writes buf to w but replaces all occurrences of \n with \r\n.
+func writeWithCRLF(w io.Writer, buf []byte) (n int, err error) {
+	for len(buf) > 0 {
+		i := bytes.IndexByte(buf, '\n')
+		todo := len(buf)
+		if i >= 0 {
+			todo = i
+		}
+
+		var nn int
+		nn, err = w.Write(buf[:todo])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		buf = buf[todo:]
+
+		if i >= 0 {
+			if _, err = w.Write(crlf); err != nil {
+				return n, err
+			}
+			n++
+			buf = buf[1:]
+		}
+	}
+
+	return n, nil
+}
+
+func (t *Terminal) Write(buf []byte) (n int, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if t.cursorX == 0 && t.cursorY == 0 {
+		// This is the easy case: there's nothing on the screen that we
+		// have to move out of the way.
+		return writeWithCRLF(t.c, buf)
+	}
+
+	// We have a prompt and possibly user input on the screen. We
+	// have to clear it first.
+	t.move(0 /* up */, 0 /* down */, t.cursorX /* left */, 0 /* right */)
+	t.cursorX = 0
+	t.clearLineToRight()
+
+	for t.cursorY > 0 {
+		t.move(1 /* up */, 0, 0, 0)
+		t.cursorY--
+		t.clearLineToRight()
+	}
+
+	if _, err = t.c.Write(t.outBuf); err != nil {
+		return
+	}
+	t.outBuf = t.outBuf[:0]
+
+	if n, err = writeWithCRLF(t.c, buf); err != nil {
+		return
+	}
+
+	t.writeLine(t.prompt)
+	if t.echo {
+		t.writeLine(t.line)
+	}
+
+	t.moveCursorToPos(t.pos)
+
+	if _, err = t.c.Write(t.outBuf); err != nil {
+		return
+	}
+	t.outBuf = t.outBuf[:0]
+	return
+}
+
+// ReadPassword temporarily changes the prompt and reads a password, without
+// echo, from the terminal.
+func (t *Terminal) ReadPassword(prompt string) (line string, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	oldPrompt := t.prompt
+	t.prompt = []rune(prompt)
+	t.echo = false
+
+	line, err = t.readLine()
+
+	t.prompt = oldPrompt
+	t.echo = true
+
+	return
+}
+
+// ReadLine returns a line of input from the terminal.
+func (t *Terminal) ReadLine() (line string, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.readLine()
+}
+
+func (t *Terminal) readLine() (line string, err error) {
+	// t.lock must be held at this point
+
+	if t.cursorX == 0 && t.cursorY == 0 {
+		t.writeLine(t.prompt)
+		t.c.Write(t.outBuf)
+		t.outBuf = t.outBuf[:0]
+	}
+
+	lineIsPasted := t.pasteActive
+
+	for {
+		rest := t.remainder
+		lineOk := false
+		for !lineOk {
+			var key rune
+			key, rest = bytesToKey(rest, t.pasteActive)
+			if key == utf8.RuneError {
+				break
+			}
+			if !t.pasteActive {
+				if key == keyCtrlD {
+					if len(t.line) == 0 {
+						return "", io.EOF
+					}
+				}
+				if key == keyPasteStart {
+					t.pasteActive = true
+					if len(t.line) == 0 {
+						lineIsPasted = true
+					}
+					continue
+				}
+			} else if key == keyPasteEnd {
+				t.pasteActive = false
+				continue
+			}
+			if !t.pasteActive {
+				lineIsPasted = false
+			}
+			line, lineOk = t.handleKey(key)
+		}
+		if len(rest) > 0 {
+			n := copy(t.inBuf[:], rest)
+			t.remainder = t.inBuf[:n]
+		} else {
+			t.remainder = nil
+		}
+		t.c.Write(t.outBuf)
+		t.outBuf = t.outBuf[:0]
+		if lineOk {
+			if t.echo {
+				t.historyIndex = -1
+				t.history.Add(line)
+			}
+			if lineIsPasted {
+				err = ErrPasteIndicator
+			}
+			return
+		}
+
+		// t.remainder is a slice at the beginning of t.inBuf
+		// containing a partial key sequence
+		readBuf := t.inBuf[len(t.remainder):]
+		var n int
+
+		t.lock.Unlock()
+		n, err = t.c.Read(readBuf)
+		t.lock.Lock()
+
+		if err != nil {
+			return
+		}
+
+		t.remainder = t.inBuf[:n+len(t.remainder)]
+	}
+}
+
+// SetPrompt sets the prompt to be used when reading subsequent lines.
+func (t *Terminal) SetPrompt(prompt string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.prompt = []rune(prompt)
+}
+
+func (t *Terminal) clearAndRepaintLinePlusNPrevious(numPrevLines int) {
+	// Move cursor to column zero at the start of the line.
+	t.move(t.cursorY, 0, t.cursorX, 0)
+	t.cursorX, t.cursorY = 0, 0
+	t.clearLineToRight()
+	for t.cursorY < numPrevLines {
+		// Move down a line
+		t.move(0, 1, 0, 0)
+		t.cursorY++
+		t.clearLineToRight()
+	}
+	// Move back to beginning.
+	t.move(t.cursorY, 0, 0, 0)
+	t.cursorX, t.cursorY = 0, 0
+
+	t.queue(t.prompt)
+	t.advanceCursor(visualLength(t.prompt))
+	t.writeLine(t.line)
+	t.moveCursorToPos(t.pos)
+}
+
+func (t *Terminal) SetSize(width, height int) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if width == 0 {
+		width = 1
+	}
+
+	oldWidth := t.termWidth
+	t.termWidth, t.termHeight = width, height
+
+	switch {
+	case width == oldWidth:
+		// If the width didn't change then nothing else needs to be
+		// done.
+		return nil
+	case len(t.line) == 0 && t.cursorX == 0 && t.cursorY == 0:
+		// If there is nothing on current line and no prompt printed,
+		// just do nothing
+		return nil
+	case width < oldWidth:
+		// Some terminals (e.g. xterm) will truncate lines that were
+		// too long when shinking. Others, (e.g. gnome-terminal) will
+		// attempt to wrap them. For the former, repainting t.maxLine
+		// works great, but that behaviour goes badly wrong in the case
+		// of the latter because they have doubled every full line.
+
+		// We assume that we are working on a terminal that wraps lines
+		// and adjust the cursor position based on every previous line
+		// wrapping and turning into two. This causes the prompt on
+		// xterms to move upwards, which isn't great, but it avoids a
+		// huge mess with gnome-terminal.
+		if t.cursorX >= t.termWidth {
+			t.cursorX = t.termWidth - 1
+		}
+		t.cursorY *= 2
+		t.clearAndRepaintLinePlusNPrevious(t.maxLine * 2)
+	case width > oldWidth:
+		// If the terminal expands then our position calculations will
+		// be wrong in the future because we think the cursor is
+		// |t.pos| chars into the string, but there will be a gap at
+		// the end of any wrapped line.
+		//
+		// But the position will actually be correct until we move, so
+		// we can move back to the beginning and repaint everything.
+		t.clearAndRepaintLinePlusNPrevious(t.maxLine)
+	}
+
+	_, err := t.c.Write(t.outBuf)
+	t.outBuf = t.outBuf[:0]
+	return err
+}
+
+type pasteIndicatorError struct{}
+
+func (pasteIndicatorError) Error() string {
+	return "terminal: ErrPasteIndicator not correctly handled"
+}
+
+// ErrPasteIndicator may be returned from ReadLine as the error, in addition
+// to valid line data. It indicates that bracketed paste mode is enabled and
+// that the returned line consists only of pasted data. Programs may wish to
+// interpret pasted data more literally than typed data.
+var ErrPasteIndicator = pasteIndicatorError{}
+
+// SetBracketedPasteMode requests that the terminal bracket paste operations
+// with markers. Not all terminals support this but, if it is supported, then
+// enabling this mode will stop any autocomplete callback from running due to
+// pastes. Additionally, any lines that are completely pasted will be returned
+// from ReadLine with the error set to ErrPasteIndicator.
+func (t *Terminal) SetBracketedPasteMode(on bool) {
+	if on {
+		io.WriteString(t.c, "\x1b[?2004h")
+	} else {
+		io.WriteString(t.c, "\x1b[?2004l")
+	}
+}
+
+// stRingBuffer is a ring buffer of strings.
+type stRingBuffer struct {
+	// entries contains max elements.
+	entries []string
+	max     int
+	// head contains the index of the element most recently added to the ring.
+	head int
+	// size contains the number of elements in the ring.
+	size int
+}
+
+func (s *stRingBuffer) Add(a string) {
+	if s.entries == nil {
+		const defaultNumEntries = 100
+		s.entries = make([]string, defaultNumEntries)
+		s.max = defaultNumEntries
+	}
+
+	s.head = (s.head + 1) % s.max
+	s.entries[s.head] = a
+	if s.size < s.max {
+		s.size++
+	}
+}
+
+// NthPreviousEntry returns the value passed to the nth previous call to Add.
+// If n is zero then the immediately prior value is returned, if one, then the
+// next most recent, and so on. If such an element doesn't exist then ok is
+// false.
+func (s *stRingBuffer) NthPreviousEntry(n int) (value string, ok bool) {
+	if n >= s.size {
+		return "", false
+	}
+	index := s.head - n
+	if index < 0 {
+		index += s.max
+	}
+	return s.entries[index], true
+}
+
+// readPasswordLine reads from reader until it finds \n or io.EOF.
+// The slice returned does not include the \n.
+// readPasswordLine also ignores any \r it finds.
+func readPasswordLine(reader io.Reader) ([]byte, error) {
+	var buf [1]byte
+	var ret []byte
+
+	for {
+		n, err := reader.Read(buf[:])
+		if n > 0 {
+			switch buf[0] {
+			case '\n':
+				return ret, nil
+			case '\r':
+				// remove \r from passwords on Windows
+			default:
+				ret = append(ret, buf[0])
+			}
+			continue
+		}
+		if err != nil {
+			if err == io.EOF && len(ret) > 0 {
+				return ret, nil
+			}
+			return ret, err
+		}
+	}
+}

--- a/vendor/golang.org/x/crypto/ssh/terminal/util.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util.go
@@ -1,0 +1,114 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal // import "golang.org/x/crypto/ssh/terminal"
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// State contains the state of a terminal.
+type State struct {
+	termios unix.Termios
+}
+
+// IsTerminal returns whether the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	return err == nil
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	termios, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	if err != nil {
+		return nil, err
+	}
+
+	oldState := State{termios: *termios}
+
+	// This attempts to replicate the behaviour documented for cfmakeraw in
+	// the termios(3) manpage.
+	termios.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
+	termios.Oflag &^= unix.OPOST
+	termios.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	termios.Cflag &^= unix.CSIZE | unix.PARENB
+	termios.Cflag |= unix.CS8
+	termios.Cc[unix.VMIN] = 1
+	termios.Cc[unix.VTIME] = 0
+	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, termios); err != nil {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	termios, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	if err != nil {
+		return nil, err
+	}
+
+	return &State{termios: *termios}, nil
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	return unix.IoctlSetTermios(fd, ioctlWriteTermios, &state.termios)
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+	if err != nil {
+		return -1, -1, err
+	}
+	return int(ws.Col), int(ws.Row), nil
+}
+
+// passwordReader is an io.Reader that reads from a specific file descriptor.
+type passwordReader int
+
+func (r passwordReader) Read(buf []byte) (int, error) {
+	return unix.Read(int(r), buf)
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	termios, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	if err != nil {
+		return nil, err
+	}
+
+	newState := *termios
+	newState.Lflag &^= unix.ECHO
+	newState.Lflag |= unix.ICANON | unix.ISIG
+	newState.Iflag |= unix.ICRNL
+	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, &newState); err != nil {
+		return nil, err
+	}
+
+	defer unix.IoctlSetTermios(fd, ioctlWriteTermios, termios)
+
+	return readPasswordLine(passwordReader(fd))
+}

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_aix.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_aix.go
@@ -1,0 +1,12 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build aix
+
+package terminal
+
+import "golang.org/x/sys/unix"
+
+const ioctlReadTermios = unix.TCGETS
+const ioctlWriteTermios = unix.TCSETS

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_bsd.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_bsd.go
@@ -1,0 +1,12 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package terminal
+
+import "golang.org/x/sys/unix"
+
+const ioctlReadTermios = unix.TIOCGETA
+const ioctlWriteTermios = unix.TIOCSETA

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_linux.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_linux.go
@@ -1,0 +1,10 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package terminal
+
+import "golang.org/x/sys/unix"
+
+const ioctlReadTermios = unix.TCGETS
+const ioctlWriteTermios = unix.TCSETS

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_plan9.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_plan9.go
@@ -1,0 +1,58 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type State struct{}
+
+// IsTerminal returns whether the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	return false
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	return nil, fmt.Errorf("terminal: MakeRaw not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	return nil, fmt.Errorf("terminal: GetState not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	return fmt.Errorf("terminal: Restore not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	return 0, 0, fmt.Errorf("terminal: GetSize not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	return nil, fmt.Errorf("terminal: ReadPassword not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_solaris.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_solaris.go
@@ -1,0 +1,124 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build solaris
+
+package terminal // import "golang.org/x/crypto/ssh/terminal"
+
+import (
+	"golang.org/x/sys/unix"
+	"io"
+	"syscall"
+)
+
+// State contains the state of a terminal.
+type State struct {
+	termios unix.Termios
+}
+
+// IsTerminal returns whether the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	_, err := unix.IoctlGetTermio(fd, unix.TCGETA)
+	return err == nil
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	// see also: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libast/common/uwin/getpass.c
+	val, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+	oldState := *val
+
+	newState := oldState
+	newState.Lflag &^= syscall.ECHO
+	newState.Lflag |= syscall.ICANON | syscall.ISIG
+	newState.Iflag |= syscall.ICRNL
+	err = unix.IoctlSetTermios(fd, unix.TCSETS, &newState)
+	if err != nil {
+		return nil, err
+	}
+
+	defer unix.IoctlSetTermios(fd, unix.TCSETS, &oldState)
+
+	var buf [16]byte
+	var ret []byte
+	for {
+		n, err := syscall.Read(fd, buf[:])
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			if len(ret) == 0 {
+				return nil, io.EOF
+			}
+			break
+		}
+		if buf[n-1] == '\n' {
+			n--
+		}
+		ret = append(ret, buf[:n]...)
+		if n < len(buf) {
+			break
+		}
+	}
+
+	return ret, nil
+}
+
+// MakeRaw puts the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+// see http://cr.illumos.org/~webrev/andy_js/1060/
+func MakeRaw(fd int) (*State, error) {
+	termios, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+
+	oldState := State{termios: *termios}
+
+	termios.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
+	termios.Oflag &^= unix.OPOST
+	termios.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	termios.Cflag &^= unix.CSIZE | unix.PARENB
+	termios.Cflag |= unix.CS8
+	termios.Cc[unix.VMIN] = 1
+	termios.Cc[unix.VTIME] = 0
+
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, termios); err != nil {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, oldState *State) error {
+	return unix.IoctlSetTermios(fd, unix.TCSETS, &oldState.termios)
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	termios, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+
+	return &State{termios: *termios}, nil
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(ws.Col), int(ws.Row), nil
+}

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_windows.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_windows.go
@@ -1,0 +1,103 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+type State struct {
+	mode uint32
+}
+
+// IsTerminal returns whether the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	var st uint32
+	err := windows.GetConsoleMode(windows.Handle(fd), &st)
+	return err == nil
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	var st uint32
+	if err := windows.GetConsoleMode(windows.Handle(fd), &st); err != nil {
+		return nil, err
+	}
+	raw := st &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_OUTPUT)
+	if err := windows.SetConsoleMode(windows.Handle(fd), raw); err != nil {
+		return nil, err
+	}
+	return &State{st}, nil
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	var st uint32
+	if err := windows.GetConsoleMode(windows.Handle(fd), &st); err != nil {
+		return nil, err
+	}
+	return &State{st}, nil
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	return windows.SetConsoleMode(windows.Handle(fd), state.mode)
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	var info windows.ConsoleScreenBufferInfo
+	if err := windows.GetConsoleScreenBufferInfo(windows.Handle(fd), &info); err != nil {
+		return 0, 0, err
+	}
+	return int(info.Size.X), int(info.Size.Y), nil
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	var st uint32
+	if err := windows.GetConsoleMode(windows.Handle(fd), &st); err != nil {
+		return nil, err
+	}
+	old := st
+
+	st &^= (windows.ENABLE_ECHO_INPUT)
+	st |= (windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_OUTPUT)
+	if err := windows.SetConsoleMode(windows.Handle(fd), st); err != nil {
+		return nil, err
+	}
+
+	defer windows.SetConsoleMode(windows.Handle(fd), old)
+
+	var h windows.Handle
+	p, _ := windows.GetCurrentProcess()
+	if err := windows.DuplicateHandle(p, windows.Handle(fd), p, &h, 0, false, windows.DUPLICATE_SAME_ACCESS); err != nil {
+		return nil, err
+	}
+
+	f := os.NewFile(uintptr(h), "stdin")
+	defer f.Close()
+	return readPasswordLine(f)
+}

--- a/vendor/golang.org/x/crypto/ssh/test/doc.go
+++ b/vendor/golang.org/x/crypto/ssh/test/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package test contains integration tests for the
+// golang.org/x/crypto/ssh package.
+package test // import "golang.org/x/crypto/ssh/test"

--- a/vendor/golang.org/x/crypto/ssh/test/sshd_test_pw.c
+++ b/vendor/golang.org/x/crypto/ssh/test/sshd_test_pw.c
@@ -1,0 +1,173 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// sshd_test_pw.c
+// Wrapper to inject test password data for sshd PAM authentication
+//
+// This wrapper implements custom versions of getpwnam, getpwnam_r,
+// getspnam and getspnam_r. These functions first call their real
+// libc versions, then check if the requested user matches test user
+// specified in env variable TEST_USER and if so replace the password
+// with crypted() value of TEST_PASSWD env variable.
+//
+// Compile:
+// gcc -Wall -shared -o sshd_test_pw.so -fPIC sshd_test_pw.c
+//
+// Compile with debug:
+// gcc -DVERBOSE -Wall -shared -o sshd_test_pw.so -fPIC sshd_test_pw.c
+//
+// Run sshd:
+// LD_PRELOAD="sshd_test_pw.so" TEST_USER="..." TEST_PASSWD="..." sshd ...
+
+// +build ignore
+
+#define _GNU_SOURCE
+#include <string.h>
+#include <pwd.h>
+#include <shadow.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#ifdef VERBOSE
+#define DEBUG(X...) fprintf(stderr, X)
+#else
+#define DEBUG(X...) while (0) { }
+#endif
+
+/* crypt() password */
+static char *
+pwhash(char *passwd) {
+  return strdup(crypt(passwd, "$6$"));
+}
+
+/* Pointers to real functions in libc */
+static struct passwd * (*real_getpwnam)(const char *) = NULL;
+static int (*real_getpwnam_r)(const char *, struct passwd *, char *, size_t, struct passwd **) = NULL;
+static struct spwd * (*real_getspnam)(const char *) = NULL;
+static int (*real_getspnam_r)(const char *, struct spwd *, char *, size_t, struct spwd **) = NULL;
+
+/* Cached test user and test password */
+static char *test_user = NULL;
+static char *test_passwd_hash = NULL;
+
+static void
+init(void) {
+  /* Fetch real libc function pointers */
+  real_getpwnam = dlsym(RTLD_NEXT, "getpwnam");
+  real_getpwnam_r = dlsym(RTLD_NEXT, "getpwnam_r");
+  real_getspnam = dlsym(RTLD_NEXT, "getspnam");
+  real_getspnam_r = dlsym(RTLD_NEXT, "getspnam_r");
+  
+  /* abort if env variables are not defined */
+  if (getenv("TEST_USER") == NULL || getenv("TEST_PASSWD") == NULL) {
+    fprintf(stderr, "env variables TEST_USER and TEST_PASSWD are missing\n");
+    abort();
+  }
+
+  /* Fetch test user and test password from env */
+  test_user = strdup(getenv("TEST_USER"));
+  test_passwd_hash = pwhash(getenv("TEST_PASSWD"));
+
+  DEBUG("sshd_test_pw init():\n");
+  DEBUG("\treal_getpwnam: %p\n", real_getpwnam);
+  DEBUG("\treal_getpwnam_r: %p\n", real_getpwnam_r);
+  DEBUG("\treal_getspnam: %p\n", real_getspnam);
+  DEBUG("\treal_getspnam_r: %p\n", real_getspnam_r);
+  DEBUG("\tTEST_USER: '%s'\n", test_user);
+  DEBUG("\tTEST_PASSWD: '%s'\n", getenv("TEST_PASSWD"));
+  DEBUG("\tTEST_PASSWD_HASH: '%s'\n", test_passwd_hash);
+}
+
+static int
+is_test_user(const char *name) {
+  if (test_user != NULL && strcmp(test_user, name) == 0)
+    return 1;
+  return 0;
+}
+
+/* getpwnam */
+
+struct passwd *
+getpwnam(const char *name) {
+  struct passwd *pw;
+
+  DEBUG("sshd_test_pw getpwnam(%s)\n", name);
+  
+  if (real_getpwnam == NULL)
+    init();
+  if ((pw = real_getpwnam(name)) == NULL)
+    return NULL;
+
+  if (is_test_user(name))
+    pw->pw_passwd = strdup(test_passwd_hash);
+      
+  return pw;
+}
+
+/* getpwnam_r */
+
+int
+getpwnam_r(const char *name,
+	   struct passwd *pwd,
+	   char *buf,
+	   size_t buflen,
+	   struct passwd **result) {
+  int r;
+
+  DEBUG("sshd_test_pw getpwnam_r(%s)\n", name);
+  
+  if (real_getpwnam_r == NULL)
+    init();
+  if ((r = real_getpwnam_r(name, pwd, buf, buflen, result)) != 0 || *result == NULL)
+    return r;
+
+  if (is_test_user(name))
+    pwd->pw_passwd = strdup(test_passwd_hash);
+  
+  return 0;
+}
+
+/* getspnam */
+
+struct spwd *
+getspnam(const char *name) {
+  struct spwd *sp;
+
+  DEBUG("sshd_test_pw getspnam(%s)\n", name);
+  
+  if (real_getspnam == NULL)
+    init();
+  if ((sp = real_getspnam(name)) == NULL)
+    return NULL;
+
+  if (is_test_user(name))
+    sp->sp_pwdp = strdup(test_passwd_hash);
+  
+  return sp;
+}
+
+/* getspnam_r */
+
+int
+getspnam_r(const char *name,
+	   struct spwd *spbuf,
+	   char *buf,
+	   size_t buflen,
+	   struct spwd **spbufp) {
+  int r;
+
+  DEBUG("sshd_test_pw getspnam_r(%s)\n", name);
+  
+  if (real_getspnam_r == NULL)
+    init();
+  if ((r = real_getspnam_r(name, spbuf, buf, buflen, spbufp)) != 0)
+    return r;
+
+  if (is_test_user(name))
+    spbuf->sp_pwdp = strdup(test_passwd_hash);
+  
+  return r;
+}


### PR DESCRIPTION
When copying images and the output is not a tty (e.g., when piping to a
file) print single lines instead of using progress bars.  This avoids
long and hard to parse output.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>