### PR TITLE
Add --quiet option to skopeo copy

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -23,6 +23,8 @@ type copyOptions struct {
 	removeSignatures  bool            // Do not copy signatures from the source image
 	signByFingerprint string          // Sign the image using a GPG key with the specified fingerprint
 	format            optionalString  // Force conversion of the image to a specified format
+	quiet             bool            // Suppress output information when copying images
+
 }
 
 func copyCmd(global *globalOptions) cli.Command {
@@ -54,6 +56,11 @@ func copyCmd(global *globalOptions) cli.Command {
 				Name:  "additional-tag",
 				Usage: "additional tags (supports docker-archive)",
 				Value: &opts.additionalTags, // Surprisingly StringSliceFlag does not support Destination:, but modifies Value: in place.
+			},
+			cli.BoolFlag{
+				Name:        "quiet, q",
+				Usage:       "Suppress output information when copying images",
+				Destination: &opts.quiet,
 			},
 			cli.BoolFlag{
 				Name:        "remove-signatures",
@@ -132,6 +139,9 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) error {
 	ctx, cancel := opts.global.commandTimeoutContext()
 	defer cancel()
 
+	if opts.quiet {
+		stdout = nil
+	}
 	_, err = copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{
 		RemoveSignatures:      opts.removeSignatures,
 		SignBy:                opts.signByFingerprint,

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -85,6 +85,7 @@ Uses the system's trust policy to validate images, rejects images not trusted by
 
   **--format, -f** _manifest-type_ Manifest type (oci, v2s1, or v2s2) to use when saving image to directory using the 'dir:' transport (default is manifest type of source)
 
+  **--quiet, -q** suppress output information when copying images
   **--remove-signatures** do not copy signatures, if any, from _source-image_. Necessary when copying a signed image to a destination which does not support signatures.
 
   **--sign-by=**_key-id_ add a signature using that key ID for an image name corresponding to _destination-image_


### PR DESCRIPTION
People are using skopeo copy in batch commands and do not need
all of the logging.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>