### PR TITLE
Modify .gitignore for generated man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/docs/skopeo.1
+*.1
 /layers-*
 /skopeo


### PR DESCRIPTION
Modify .gitigare to target any man page since skopeo man page was split up in #598.

