### PR TITLE
completions: Introduce transports completions

### DIFF
--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -5,11 +5,12 @@
 _complete_() {
     local options_with_args=$1
     local boolean_options="$2 -h --help"
+    local transports=$3
 
     local option_with_args
-    for option_with_args in $options_with_args
+    for option_with_args in $options_with_args $transports
     do
-        if [ "$option_with_args" == "$prev" ]
+        if [ "$option_with_args" == "$prev" -o "$option_with_args" == "$cur" ]
         then
             return
         fi
@@ -19,7 +20,20 @@ _complete_() {
 	-*)
 	    COMPREPLY=( $( compgen -W "$boolean_options $options_with_args" -- "$cur" ) )
 	    ;;
+        *)
+            if [ -n "$transports" ]
+            then
+                compopt -o nospace
+                COMPREPLY=( $( compgen -W "$transports" -- "$cur" ) )
+            fi
+            ;;
     esac
+}
+
+_skopeo_supported_transports() {
+    local subcommand=$1
+
+    ${PROG} $subcommand --help | grep "Supported transports" -A 1 | tail -n 1 | sed -e 's/,/:/g' -e 's/$/:/'
 }
 
 _skopeo_copy() {
@@ -43,7 +57,11 @@ _skopeo_copy() {
     --remove-signatures
     "
 
-    _complete_ "$options_with_args" "$boolean_options"
+    local transports="
+    $(_skopeo_supported_transports $(echo $FUNCNAME | sed 's/_skopeo_//'))
+    "
+
+    _complete_ "$options_with_args" "$boolean_options" "$transports"
 }
 
 _skopeo_inspect() {
@@ -56,7 +74,12 @@ _skopeo_inspect() {
      --raw
      --tls-verify
     "
-    _complete_ "$options_with_args" "$boolean_options"
+
+    local transports="
+    $(_skopeo_supported_transports $(echo $FUNCNAME | sed 's/_skopeo_//'))
+    "
+
+    _complete_ "$options_with_args" "$boolean_options" "$transports"
 }
 
 _skopeo_standalone_sign() {
@@ -93,7 +116,12 @@ _skopeo_delete() {
      local boolean_options="
      --tls-verify
      "
-    _complete_ "$options_with_args" "$boolean_options"
+
+    local transports="
+    $(_skopeo_supported_transports $(echo $FUNCNAME | sed 's/_skopeo_//'))
+    "
+
+    _complete_ "$options_with_args" "$boolean_options" "$transports"
 }
 
 _skopeo_layers() {


### PR DESCRIPTION
As follows, adds bash completions for transports which commands (copy, delete, and inspect) support.

```
$ skopeo copy 
containers-storage:  docker-archive:      docker:              oci:                 tarball: 
dir:                 docker-daemon:       oci-archive:         ostree: 
```