### PR TITLE
completions: Fix completions with a global option and indentation

### DIFF
--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -17,9 +17,9 @@ _complete_() {
     done
 
     case "$cur" in
-	-*)
-	    COMPREPLY=( $( compgen -W "$boolean_options $options_with_args" -- "$cur" ) )
-	    ;;
+        -*)
+            COMPREPLY=( $( compgen -W "$boolean_options $options_with_args" -- "$cur" ) )
+            ;;
         *)
             if [ -n "$transports" ]
             then
@@ -84,7 +84,7 @@ _skopeo_inspect() {
 
 _skopeo_standalone_sign() {
      local options_with_args="
-	   -o --output
+       -o --output
      "
      local boolean_options="
      "
@@ -126,44 +126,44 @@ _skopeo_delete() {
 
 _skopeo_layers() {
      local options_with_args="
-	   --creds
-	   --cert-dir
+       --creds
+       --cert-dir
      "
      local boolean_options="
-	   --tls-verify
+       --tls-verify
      "
     _complete_ "$options_with_args" "$boolean_options"
 }
 
 _skopeo_skopeo() {
      local options_with_args="
-	   --policy
-	   --registries.d
+       --policy
+       --registries.d
        --override-arch
        --override-os
        --command-timeout
      "
      local boolean_options="
-	   --insecure-policy
-	   --debug
-	   --version -v
-	   --help -h
+       --insecure-policy
+       --debug
+       --version -v
+       --help -h
      "
      commands=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
 
      case "$prev" in
-	 $main_options_with_args_glob )
-	     return
-	     ;;
+         $main_options_with_args_glob )
+             return
+             ;;
      esac
 
      case "$cur" in
-	 -*)
-	     COMPREPLY=( $( compgen -W "$boolean_options $options_with_args" -- "$cur" ) )
-	     ;;
-	 *)
-	     COMPREPLY=( $( compgen -W "${commands[*]} help" -- "$cur" ) )
-	     ;;
+         -*)
+             COMPREPLY=( $( compgen -W "$boolean_options $options_with_args" -- "$cur" ) )
+             ;;
+         *)
+             COMPREPLY=( $( compgen -W "${commands[*]} help" -- "$cur" ) )
+             ;;
      esac
 }
 
@@ -181,17 +181,17 @@ _cli_bash_autocomplete() {
      local counter=1
      counter=1
      while [ $counter -lt $cword ]; do
-	 case "${words[$counter]}" in
+         case "${words[$counter]}" in
              -*)
                 ;;
-	     *)
-		 command=$(echo "${words[$counter]}" | sed 's/-/_/g')
-		 cpos=$counter
-		 (( cpos++ ))
-		 break
-		 ;;
-	 esac
-	 (( counter++ ))
+             *)
+                 command=$(echo "${words[$counter]}" | sed 's/-/_/g')
+                 cpos=$counter
+                 (( cpos++ ))
+                 break
+                 ;;
+         esac
+         (( counter++ ))
      done
 
      local completions_func=_skopeo_${command}

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -181,7 +181,9 @@ _cli_bash_autocomplete() {
      local counter=1
      counter=1
      while [ $counter -lt $cword ]; do
-	 case "!${words[$counter]}" in
+	 case "${words[$counter]}" in
+             -*)
+                ;;
 	     *)
 		 command=$(echo "${words[$counter]}" | sed 's/-/_/g')
 		 cpos=$counter


### PR DESCRIPTION
This PR fixes the following problems: 
* bash completions does not work after specifying a global option.
* both of tabs and spaces in indentation are used.