### PR TITLE
Make sure we install man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ CONTAINER_RUN := $(CONTAINER_CMD) "$(IMAGE)"
 GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || true)
 
 MANPAGES_MD = $(wildcard docs/*.md)
+MANPAGES ?= $(MANPAGES_MD:%.md=%)
 
 BTRFS_BUILD_TAG = $(shell hack/btrfs_tag.sh) $(shell hack/btrfs_installed_tag.sh)
 LIBDM_BUILD_TAG = $(shell hack/libdm_tag.sh)
@@ -89,10 +90,10 @@ binary-local-static:
 build-container:
 	${CONTAINER_RUNTIME} build ${BUILD_ARGS} -t "$(IMAGE)" .
 
-docs/%.1: docs/%.1.md
+$(MANPAGES): %: %.md
 	@sed -e 's/\((skopeo.*\.md)\)//' -e 's/\[\(skopeo.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $@
 
-docs: $(MANPAGES_MD:%.md=%)
+docs: $(MANPAGES)
 
 docs-in-container:
 	${CONTAINER_RUNTIME} build ${BUILD_ARGS} -f Dockerfile.build -t skopeobuildimage .
@@ -113,9 +114,9 @@ install-binary: ./skopeo
 	install -d -m 755 ${INSTALLDIR}
 	install -m 755 skopeo ${INSTALLDIR}/skopeo
 
-install-docs: docs/skopeo.1
+install-docs: docs
 	install -d -m 755 ${MANINSTALLDIR}/man1
-	install -m 644 docs/skopeo.1 ${MANINSTALLDIR}/man1/skopeo.1
+	install -m 644 docs/*.1 ${MANINSTALLDIR}/man1/
 
 install-completions:
 	install -m 755 -d ${BASHINSTALLDIR}


### PR DESCRIPTION
Currently we are only installing the skopeo.1 man page.  This
change will generate and install all man pages.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>