### PR TITLE
use GO envvar throughout in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifeq ($(DEBUG), 1)
   override GOGCFLAGS += -N -l
 endif
 
-ifeq ($(shell go env GOOS), linux)
+ifeq ($(shell $(GO) env GOOS), linux)
   GO_DYN_FLAGS="-buildmode=pie"
 endif
 


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


When I'm using a go binary in a non-default path, running make triggers "go not found" errors.

@vrothberg @mtrmac PTAL.