### PR TITLE
 Vendor update container/storage

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -9,7 +9,7 @@ github.com/mattn/go-isatty v0.0.4
 github.com/VividCortex/ewma v1.1.1
 golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
-github.com/containers/storage v1.12.2
+github.com/containers/storage v1.12.3
 github.com/sirupsen/logrus v1.0.0
 github.com/go-check/check v1
 github.com/stretchr/testify v1.1.3

--- a/vendor/github.com/containers/storage/drivers/devmapper/device_setup.go
+++ b/vendor/github.com/containers/storage/drivers/devmapper/device_setup.go
@@ -119,10 +119,17 @@ func checkDevHasFS(dev string) error {
 }
 
 func verifyBlockDevice(dev string, force bool) error {
-	if err := checkDevAvailable(dev); err != nil {
+	realPath, err := filepath.Abs(dev)
+	if err != nil {
+		return errors.Errorf("unable to get absolute path for %s: %s", dev, err)
+	}
+	if realPath, err = filepath.EvalSymlinks(realPath); err != nil {
+		return errors.Errorf("failed to canonicalise path for %s: %s", dev, err)
+	}
+	if err := checkDevAvailable(realPath); err != nil {
 		return err
 	}
-	if err := checkDevInVG(dev); err != nil {
+	if err := checkDevInVG(realPath); err != nil {
 		return err
 	}
 
@@ -130,7 +137,7 @@ func verifyBlockDevice(dev string, force bool) error {
 		return nil
 	}
 
-	if err := checkDevHasFS(dev); err != nil {
+	if err := checkDevHasFS(realPath); err != nil {
 		return err
 	}
 	return nil

--- a/vendor/github.com/containers/storage/drivers/overlay/overlay.go
+++ b/vendor/github.com/containers/storage/drivers/overlay/overlay.go
@@ -796,7 +796,17 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 
 			mountProgram := exec.Command(d.options.mountProgram, "-o", label, target)
 			mountProgram.Dir = d.home
-			return mountProgram.Run()
+			var b bytes.Buffer
+			mountProgram.Stderr = &b
+			err := mountProgram.Run()
+			if err != nil {
+				output := b.String()
+				if output == "" {
+					output = "<stderr empty>"
+				}
+				return errors.Wrapf(err, "using mount program %s: %s", d.options.mountProgram, output)
+			}
+			return nil
 		}
 	} else if len(mountData) > pageSize {
 		//FIXME: We need to figure out to get this to work with additional stores

--- a/vendor/github.com/containers/storage/utils.go
+++ b/vendor/github.com/containers/storage/utils.go
@@ -74,7 +74,7 @@ func GetRootlessRuntimeDir(rootlessUid int) (string, error) {
 	if runtimeDir == "" {
 		tmpDir := fmt.Sprintf("/run/user/%d", rootlessUid)
 		st, err := system.Stat(tmpDir)
-		if err == nil && int(st.UID()) == os.Getuid() && st.Mode() == 0700 {
+		if err == nil && int(st.UID()) == os.Getuid() && st.Mode()&0700 == 0700 && st.Mode()&0066 == 0000 {
 			return tmpDir, nil
 		}
 	}
@@ -182,14 +182,14 @@ func DefaultStoreOptions(rootless bool, rootlessUid int) (StoreOptions, error) {
 		err                      error
 	)
 	storageOpts := defaultStoreOptions
-	if rootless {
+	if rootless && rootlessUid != 0 {
 		storageOpts, err = getRootlessStorageOpts(rootlessUid)
 		if err != nil {
 			return storageOpts, err
 		}
 	}
 
-	storageConf, err := DefaultConfigFile(rootless)
+	storageConf, err := DefaultConfigFile(rootless && rootlessUid != 0)
 	if err != nil {
 		return storageOpts, err
 	}
@@ -204,7 +204,7 @@ func DefaultStoreOptions(rootless bool, rootlessUid int) (StoreOptions, error) {
 		return storageOpts, errors.Wrapf(err, "cannot stat %s", storageConf)
 	}
 
-	if rootless {
+	if rootless && rootlessUid != 0 {
 		if err == nil {
 			// If the file did not specify a graphroot or runroot,
 			// set sane defaults so we don't try and use root-owned


### PR DESCRIPTION
overlay: propagate errors from mountProgram
utils: root in a userns uses global conf file
Fix handling of additional stores
Correctly check permissions on rootless directory
Fix possible integer overflow on 32bit builds
Evaluate device path for lvm
lockfile test: make concurrent RW test determinisitc
lockfile test: make concurrent read tests deterministic

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>