### PR TITLE
Add --no-creds flag to skopeo inspect

### DIFF
--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -55,6 +55,8 @@ _skopeo_copy() {
     local boolean_options="
     --dest-compress
     --remove-signatures
+    --src-no-creds
+    --dest-no-creds
     "
 
     local transports="
@@ -73,6 +75,7 @@ _skopeo_inspect() {
      local boolean_options="
      --raw
      --tls-verify
+     --no-creds
     "
 
     local transports="
@@ -115,6 +118,7 @@ _skopeo_delete() {
      "
      local boolean_options="
      --tls-verify
+     --no-creds
      "
 
     local transports="

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -38,9 +38,13 @@ If the authorization state is not found there, $HOME/.docker/config.json is chec
 
 **--src-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the source registry or daemon
 
+**--src-no-creds** _bool-value_ Access the registry anonymously.
+
 **--src-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container source registry or daemon (defaults to true)
 
 **--dest-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the destination registry or daemon
+
+**--dest-no-creds** _bool-value_  Access the registry anonymously.
 
 **--dest-ostree-tmp-dir** _path_ Directory to use for OSTree temporary files.
 

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -1,7 +1,7 @@
 % skopeo-delete(1)
 
 ## NAME
-skopeo\-delete - Mark _image-name_ for deletion.  
+skopeo\-delete - Mark _image-name_ for deletion.
 
 ## SYNOPSIS
 **skopeo delete** _image-name_
@@ -29,6 +29,8 @@ $ docker exec -it registry /usr/bin/registry garbage-collect /etc/docker-distrib
 **--cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the registry
 
 **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true)
+
+**--no-creds** _bool-value_ Access the registry anonymously.
 
 Additionally, the registry must allow deletions by setting `REGISTRY_STORAGE_DELETE_ENABLED=true` for the registry daemon.
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -23,6 +23,8 @@ Return low-level information about _image-name_ in a registry
 
   **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true)
 
+  **--no-creds** _bool-value_ Access the registry anonymously.
+
 ## EXAMPLES
 
 To review information for the image fedora from the docker.io registry:

--- a/vendor/github.com/kr/pretty/go.mod
+++ b/vendor/github.com/kr/pretty/go.mod
@@ -1,0 +1,3 @@
+module "github.com/kr/pretty"
+
+require "github.com/kr/text" v0.1.0

--- a/vendor/github.com/kr/text/go.mod
+++ b/vendor/github.com/kr/text/go.mod
@@ -1,0 +1,3 @@
+module "github.com/kr/text"
+
+require "github.com/kr/pty" v1.1.1

--- a/vendor/golang.org/x/text/go.mod
+++ b/vendor/golang.org/x/text/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/text
+
+require golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e


### PR DESCRIPTION
Follow PR #433 
Close #421 
Currently skopeo inspect allows to:

- Use the default credentials in $HOME/.docker.config
- Explicitly define credentials via de --creds flag
This implements a --no-creds flag which will query docker registries anonymously.

Signed-off-by: Qi Wang <qiwan@redhat.com>