### PR TITLE
inspect: add a --config flag

### DIFF
--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -73,6 +73,7 @@ _skopeo_inspect() {
      --cert-dir
      "
      local boolean_options="
+     --config
      --raw
      --tls-verify
      --no-creds

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -4,7 +4,7 @@
 skopeo\-inspect - Return low-level information about _image-name_ in a registry
 
 ## SYNOPSIS
-**skopeo inspect** [**--raw**] _image-name_
+**skopeo inspect** [**--raw**] [**--config**] _image-name_
 
 Return low-level information about _image-name_ in a registry
 
@@ -12,14 +12,22 @@ Return low-level information about _image-name_ in a registry
 
   _image-name_ name of image to retrieve information about
 
+  **--config** output configuration in OCI format, default is to format in JSON
+
+  _image-name_ name of image to retrieve configuration for
+
+  **--config** **--raw** output configuration in raw format
+
+  _image-name_ name of image to retrieve configuration for
+
   **--authfile** _path_
 
-  Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+  Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
   If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
   **--creds** _username[:password]_ for accessing the registry
 
-  **--cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the registry
+  **--cert-dir** _path_ Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry
 
   **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true)
 


### PR DESCRIPTION
Add a --config option to "skopeo inspect" to dump an image's configuration blob in the OCI format, or the original format if --config and --raw are specified.  It's handy for me, and it might be useful for other people.