### PR TITLE
rootless: don't create a namespace unless for containers-storage

### DIFF
--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -24,9 +24,8 @@ func deleteCmd(global *globalOptions) cli.Command {
 		image:  imageOpts,
 	}
 	return cli.Command{
-		Before: needsRexec,
-		Name:   "delete",
-		Usage:  "Delete image IMAGE-NAME",
+		Name:  "delete",
+		Usage: "Delete image IMAGE-NAME",
 		Description: fmt.Sprintf(`
 	Delete an "IMAGE_NAME" from a transport
 
@@ -45,10 +44,15 @@ func (opts *deleteOptions) run(args []string, stdout io.Writer) error {
 	if len(args) != 1 {
 		return errors.New("Usage: delete imageReference")
 	}
+	imageName := args[0]
 
-	ref, err := alltransports.ParseImageName(args[0])
+	if err := reexecIfNecessaryForImages(imageName); err != nil {
+		return err
+	}
+
+	ref, err := alltransports.ParseImageName(imageName)
 	if err != nil {
-		return fmt.Errorf("Invalid source name %s: %v", args[0], err)
+		return fmt.Errorf("Invalid source name %s: %v", imageName, err)
 	}
 
 	sys, err := opts.image.newSystemContext()

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -68,7 +68,6 @@ func inspectCmd(global *globalOptions) cli.Command {
 				Destination: &opts.config,
 			},
 		}, sharedFlags...), imageFlags...),
-		Before: needsRexec,
 		Action: commandAction(opts.run),
 	}
 }
@@ -80,7 +79,13 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 	if len(args) != 1 {
 		return errors.New("Exactly one argument expected")
 	}
-	img, err := parseImage(ctx, opts.image, args[0])
+	imageName := args[0]
+
+	if err := reexecIfNecessaryForImages(imageName); err != nil {
+		return err
+	}
+
+	img, err := parseImage(ctx, opts.image, imageName)
 	if err != nil {
 		return err
 	}

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -32,7 +32,6 @@ func layersCmd(global *globalOptions) cli.Command {
 		Name:      "layers",
 		Usage:     "Get layers of IMAGE-NAME",
 		ArgsUsage: "IMAGE-NAME [LAYER...]",
-		Before:    needsRexec,
 		Hidden:    true,
 		Action:    commandAction(opts.run),
 		Flags:     append(sharedFlags, imageFlags...),
@@ -44,6 +43,11 @@ func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if len(args) == 0 {
 		return errors.New("Usage: layers imageReference [layer...]")
 	}
+	imageName := args[0]
+
+	if err := reexecIfNecessaryForImages(imageName); err != nil {
+		return err
+	}
 
 	ctx, cancel := opts.global.commandTimeoutContext()
 	defer cancel()
@@ -53,7 +57,7 @@ func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 		return err
 	}
 	cache := blobinfocache.DefaultCache(sys)
-	rawSource, err := parseImageSource(ctx, opts.image, args[0])
+	rawSource, err := parseImageSource(ctx, opts.image, imageName)
 	if err != nil {
 		return err
 	}

--- a/cmd/skopeo/unshare.go
+++ b/cmd/skopeo/unshare.go
@@ -5,3 +5,7 @@ package main
 func maybeReexec() error {
 	return nil
 }
+
+func reexecIfNecessaryForImages(inputImageNames ...string) error {
+	return nil
+}

--- a/cmd/skopeo/unshare_linux.go
+++ b/cmd/skopeo/unshare_linux.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"github.com/containers/buildah/pkg/unshare"
+	"github.com/containers/image/storage"
+	"github.com/containers/image/transports/alltransports"
 	"github.com/pkg/errors"
 	"github.com/syndtr/gocapability/capability"
 )
@@ -28,6 +30,16 @@ func maybeReexec() error {
 			// We miss a capability we need, create a user namespaces
 			unshare.MaybeReexecUsingUserNamespace(true)
 			return nil
+		}
+	}
+	return nil
+}
+
+func reexecIfNecessaryForImages(imageNames ...string) error {
+	// Check if container-storage are used before doing unshare
+	for _, imageName := range imageNames {
+		if alltransports.TransportFromImageName(imageName).Name() == storage.Transport.Name() {
+			return maybeReexec()
 		}
 	}
 	return nil

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -16,10 +16,6 @@ type errorShouldDisplayUsage struct {
 	error
 }
 
-func needsRexec(c *cli.Context) error {
-	return maybeReexec()
-}
-
 // commandAction intermediates between the cli.ActionFunc interface and the real handler,
 // primarily to ensure that cli.Context is not available to the handler, which in turn
 // makes sure that the cli.String() etc. flag access functions are not used,

--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@
 github.com/urfave/cli v1.20.0
 github.com/kr/pretty v0.1.0
 github.com/kr/text v0.1.0
-github.com/containers/image ff926d3c79684793a2135666a2cb738f44ba33dc
+github.com/containers/image 2c0349c99af7d90694b3faa0e9bde404d407b145
 github.com/containers/buildah 810efa340ab43753034e2ed08ec290e4abab7e72
 github.com/vbauerster/mpb v3.3.4
 github.com/mattn/go-isatty v0.0.4

--- a/vendor/github.com/containers/image/docs/containers-signature.5.md
+++ b/vendor/github.com/containers/image/docs/containers-signature.5.md
@@ -1,10 +1,10 @@
-% atomic-signature(5) Atomic signature format
+% container-signature(5) Container signature format
 % Miloslav Trmač
 % March 2017
 
-# Atomic signature format
+# Container signature format
 
-This document describes the format of “atomic” container signatures,
+This document describes the format of container signatures,
 as implemented by the `github.com/containers/image/signature` package.
 
 Most users should be able to consume these signatures by using the `github.com/containers/image/signature` package
@@ -21,7 +21,7 @@ an automated build system as a result of an automated build,
 a company IT department approving the image for production) under a specified _identity_
 (e.g. an OS base image / specific application, with a specific version).
 
-An atomic container signature consists of a cryptographic signature which identifies
+A container signature consists of a cryptographic signature which identifies
 and authenticates who signed the image, and carries as a signed payload a JSON document.
 The JSON document identifies the image being signed, claims a specific identity of the
 image and if applicable, contains other information about the image.
@@ -34,7 +34,7 @@ associating more than one signature with an image.
 
 ## The cryptographic signature
 
-As distributed, the atomic container signature is a blob which contains a cryptographic signature
+As distributed, the container signature is a blob which contains a cryptographic signature
 in an industry-standard format, carrying a signed JSON payload (i.e. the blob contains both the
 JSON document and a signature of the JSON document; it is not a “detached signature” with
 independent blobs containing the JSON document and a cryptographic signature).
@@ -46,7 +46,7 @@ that this is not necessary and the configured expected public key provides anoth
 of the expected cryptographic signature format. Such metadata may be added in the future for
 newly added cryptographic signature formats, if necessary.)
 
-Consumers of atomic container signatures SHOULD verify the cryptographic signature
+Consumers of container signatures SHOULD verify the cryptographic signature
 against one or more trusted public keys
 (e.g. defined in a [policy.json signature verification policy file](policy.json.md))
 before parsing or processing the JSON payload in _any_ way,
@@ -89,7 +89,7 @@ and if the semantics of the invalid document, as created by such an implementati
 The top-level value of the JSON document MUST be a JSON object with exactly two members, `critical` and `optional`,
 each a JSON object.
 
-The `critical` object MUST contain a `type` member identifying the document as an atomic container signature
+The `critical` object MUST contain a `type` member identifying the document as a container signature
 (as defined [below](#criticaltype))
 and signature consumers MUST reject signatures which do not have this member or in which this member does not have the expected value.
 
@@ -210,7 +210,7 @@ Consumers still SHOULD reject any signature where a member of an `optional` obje
 
 If present, this MUST be a JSON string, identifying the name and version of the software which has created the signature.
 
-The contents of this string is not defined in detail; however each implementation creating atomic container signatures:
+The contents of this string is not defined in detail; however each implementation creating container signatures:
 
 - SHOULD define the contents to unambiguously define the software in practice (e.g. it SHOULD contain the name of the software, not only the version number)
 - SHOULD use a build and versioning process which ensures that the contents of this string (e.g. an included version number)
@@ -221,7 +221,7 @@ The contents of this string is not defined in detail; however each implementatio
   (e.g. the version of the implementation SHOULD NOT be only a git hash, because they don’t have an easily defined ordering;
   the string should contain a version number, or at least a date of the commit).
 
-Consumers of atomic container signatures MAY recognize specific values or sets of values of `optional.creator`
+Consumers of container signatures MAY recognize specific values or sets of values of `optional.creator`
 (perhaps augmented with `optional.timestamp`),
 and MAY change their processing of the signature based on these values
 (usually to acommodate violations of this specification in past versions of the signing software which cannot be fixed retroactively),

--- a/vendor/github.com/containers/image/pkg/sysregistriesv2/system_registries_v2.go
+++ b/vendor/github.com/containers/image/pkg/sysregistriesv2/system_registries_v2.go
@@ -39,26 +39,18 @@ type Endpoint struct {
 // endpoints `location` from the `ref` and creates a new named reference from it.
 // The function errors if the newly created reference is not parsable.
 func (e *Endpoint) RewriteReference(ref reference.Named, prefix string) (reference.Named, error) {
-	if ref == nil {
-		return nil, fmt.Errorf("provided reference is nil")
-	}
-	if prefix == "" {
-		return ref, nil
-	}
 	refString := ref.String()
-	if refMatchesPrefix(refString, prefix) {
-		newNamedRef := strings.Replace(refString, prefix, e.Location, 1)
-		newParsedRef, err := reference.ParseNamed(newNamedRef)
-		if newParsedRef != nil {
-			logrus.Debugf("reference rewritten from '%v' to '%v'", refString, newParsedRef.String())
-		}
-		if err != nil {
-			return nil, errors.Wrapf(err, "error rewriting reference")
-		}
-		return newParsedRef, nil
+	if !refMatchesPrefix(refString, prefix) {
+		return nil, fmt.Errorf("invalid prefix '%v' for reference '%v'", prefix, refString)
 	}
 
-	return nil, fmt.Errorf("invalid prefix '%v' for reference '%v'", prefix, refString)
+	newNamedRef := strings.Replace(refString, prefix, e.Location, 1)
+	newParsedRef, err := reference.ParseNamed(newNamedRef)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error rewriting reference")
+	}
+	logrus.Debugf("reference rewritten from '%v' to '%v'", refString, newParsedRef.String())
+	return newParsedRef, nil
 }
 
 // Registry represents a registry.

--- a/vendor/github.com/containers/image/transports/alltransports/alltransports.go
+++ b/vendor/github.com/containers/image/transports/alltransports/alltransports.go
@@ -22,6 +22,7 @@ import (
 
 // ParseImageName converts a URL-like image name to a types.ImageReference.
 func ParseImageName(imgName string) (types.ImageReference, error) {
+	// Keep this in sync with TransportFromImageName!
 	parts := strings.SplitN(imgName, ":", 2)
 	if len(parts) != 2 {
 		return nil, errors.Errorf(`Invalid image name "%s", expected colon-separated transport:reference`, imgName)
@@ -31,4 +32,15 @@ func ParseImageName(imgName string) (types.ImageReference, error) {
 		return nil, errors.Errorf(`Invalid image name "%s", unknown transport "%s"`, imgName, parts[0])
 	}
 	return transport.ParseReference(parts[1])
+}
+
+// TransportFromImageName converts an URL-like name to a types.ImageTransport or nil when
+// the transport is unknown or when the input is invalid.
+func TransportFromImageName(imageName string) types.ImageTransport {
+	// Keep this in sync with ParseImageName!
+	parts := strings.SplitN(imageName, ":", 2)
+	if len(parts) == 2 {
+		return transports.Get(parts[0])
+	}
+	return nil
 }

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -401,6 +401,7 @@ type ImageInspectInfo struct {
 }
 
 // DockerAuthConfig contains authorization information for connecting to a registry.
+// the value of Username and Password can be empty for accessing the registry anonymously
 type DockerAuthConfig struct {
 	Username string
 	Password string


### PR DESCRIPTION
This change fixes skopeo usage in restricted environment such as
bubblewrap where it doesn't need extra capabilities or user namespace
to perform its action.

Close #649

Signed-off-by: Tristan Cacqueray <tdecacqu@redhat.com>