### PR TITLE
Skopeo crashes on any invalid transport

### DIFF
--- a/cmd/skopeo/unshare_linux.go
+++ b/cmd/skopeo/unshare_linux.go
@@ -38,7 +38,8 @@ func maybeReexec() error {
 func reexecIfNecessaryForImages(imageNames ...string) error {
 	// Check if container-storage are used before doing unshare
 	for _, imageName := range imageNames {
-		if alltransports.TransportFromImageName(imageName).Name() == storage.Transport.Name() {
+		transport := alltransports.TransportFromImageName(imageName)
+		if transport != nil && transport.Name() == storage.Transport.Name() {
 			return maybeReexec()
 		}
 	}


### PR DESCRIPTION
We need to verfy that the user entered a valid transport before attempting
to see if the transport exists,  otherwise skopeo segfaults.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>