### PR TITLE
Add integration test for invalid reference

### DIFF
--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -87,3 +87,7 @@ func (s *SkopeoSuite) TestNoNeedAuthToPrivateRegistryV2ImageNotFound(c *check.C)
 	wanted = ".*unauthorized: authentication required.*"
 	c.Assert(string(out), check.Not(check.Matches), "(?s)"+wanted) // (?s) : '.' will also match newlines
 }
+
+func (s *SkopeoSuite) TestInspectFailsWhenReferenceIsInvalid(c *check.C) {
+	assertSkopeoFails(c, `.*Invalid image name.*`, "inspect", "unknown")
+}

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -696,3 +696,7 @@ func (s *SkopeoSuite) TestFailureCopySrcWithMirrorAndPrefixUnavailable(c *check.
 	assertSkopeoFails(c, ".*no such host.*", "--registries-conf="+regConfFixture, "copy",
 		"docker://gcr.invalid/wrong/prefix/busybox", "dir:"+dir)
 }
+
+func (s *CopySuite) TestCopyFailsWhenReferenceIsInvalid(c *check.C) {
+	assertSkopeoFails(c, `.*Invalid image name.*`, "copy", "unknown:transport", "unknown:test")
+}


### PR DESCRIPTION
This change adds a couple of tests to prevent further regression
introduced by https://github.com/containers/skopeo/pull/653

Signed-off-by: Tristan Cacqueray <tdecacqu@redhat.com>