### PR TITLE
Fix build on Ubuntu

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,7 +2,7 @@ FROM ubuntu:18.10
 
 RUN apt-get update && apt-get install -y \
     golang \
-    btrfs-tools \
+    libbtrfs-dev \
     git-core \
     libdevmapper-dev \
     libgpgme11-dev \

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Building without a container requires a bit more manual work and setup in your e
 Install the necessary dependencies:
 ```sh
 Fedora$ sudo dnf install gpgme-devel libassuan-devel btrfs-progs-devel device-mapper-devel ostree-devel
-Ubuntu$ sudo apt install libgpgme-dev libassuan-dev btrfs-progs libdevmapper-dev libostree-dev
+Ubuntu$ sudo apt install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev libostree-dev
 macOS$ brew install gpgme
 ```
 


### PR DESCRIPTION
`btrfs/ioctl.h` is in `libbtrfs-dev` (now?), `btrfs-tools` does not pull it in.

Fixes #663.