### PR TITLE
Add ability to override the authfile location using env variables

### DIFF
--- a/vendor/github.com/containers/image/pkg/docker/config/config.go
+++ b/vendor/github.com/containers/image/pkg/docker/config/config.go
@@ -31,6 +31,7 @@ var (
 	xdgRuntimeDirPath       = filepath.FromSlash("containers/auth.json")
 	dockerHomePath          = filepath.FromSlash(".docker/config.json")
 	dockerLegacyHomePath    = ".dockercfg"
+	dockerConfigEnvVar      = "DOCKER_CONFIG"
 
 	// ErrNotLoggedIn is returned for users not logged into a registry
 	// that they are trying to logout of
@@ -71,6 +72,10 @@ func GetAuthentication(sys *types.SystemContext, registry string) (string, strin
 		logrus.Warnf("%v: Trying to pull image in the event that it is a public image.", err)
 	}
 	paths = append(paths, filepath.Join(homedir.Get(), dockerHomePath), dockerLegacyPath)
+
+	if dockerConfig := os.Getenv(dockerConfigEnvVar); dockerConfig != "" {
+		paths = append(paths, filepath.Join(dockerConfig, "config.json"))
+	}
 
 	for _, path := range paths {
 		legacyFormat := path == dockerLegacyPath


### PR DESCRIPTION
While the --authfile option allows to override the location where skopeo search for the docker authentication file, when building a container it would be nice to allow specifying a custom path using an environment variable.

This is mainly useful if merging skopeo in a container including also kaniko; kaniko is able to build images, while skopeo can supprot registry manipulation functions, thus providing capabilities equivalent to docker without requiring dind.

Kaniko allows to customize the search path for config.json using the variable DOCKER_CONFIG; this ccode change would allow supporting it also for skopeo.