### PR TITLE
Rebase containers/image to v2.0.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@
 github.com/urfave/cli v1.20.0
 github.com/kr/pretty v0.1.0
 github.com/kr/text v0.1.0
-github.com/containers/image 2c0349c99af7d90694b3faa0e9bde404d407b145
+github.com/containers/image v2.0.0
 github.com/containers/buildah 810efa340ab43753034e2ed08ec290e4abab7e72
 github.com/vbauerster/mpb v3.3.4
 github.com/mattn/go-isatty v0.0.4

--- a/vendor/github.com/containers/image/docker/reference/README.md
+++ b/vendor/github.com/containers/image/docker/reference/README.md
@@ -1,2 +1,2 @@
-This is a copy of github.com/docker/distribution/reference as of commit fb0bebc4b64e3881cc52a2478d749845ed76d2a8,
+This is a copy of github.com/docker/distribution/reference as of commit 3226863cbcba6dbc2f6c83a37b28126c934af3f8,
 except that ParseAnyReferenceWithSet has been removed to drop the dependency on github.com/docker/distribution/digestset.

--- a/vendor/github.com/containers/image/docker/reference/normalize.go
+++ b/vendor/github.com/containers/image/docker/reference/normalize.go
@@ -55,6 +55,35 @@ func ParseNormalizedNamed(s string) (Named, error) {
 	return named, nil
 }
 
+// ParseDockerRef normalizes the image reference following the docker convention. This is added
+// mainly for backward compatibility.
+// The reference returned can only be either tagged or digested. For reference contains both tag
+// and digest, the function returns digested reference, e.g. docker.io/library/busybox:latest@
+// sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa will be returned as
+// docker.io/library/busybox@sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa.
+func ParseDockerRef(ref string) (Named, error) {
+	named, err := ParseNormalizedNamed(ref)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := named.(NamedTagged); ok {
+		if canonical, ok := named.(Canonical); ok {
+			// The reference is both tagged and digested, only
+			// return digested.
+			newNamed, err := WithName(canonical.Name())
+			if err != nil {
+				return nil, err
+			}
+			newCanonical, err := WithDigest(newNamed, canonical.Digest())
+			if err != nil {
+				return nil, err
+			}
+			return newCanonical, nil
+		}
+	}
+	return TagNameOnly(named), nil
+}
+
 // splitDockerDomain splits a repository name to domain and remotename string.
 // If no valid domain is found, the default domain is used. Repository name
 // needs to be already validated before.

--- a/vendor/github.com/containers/image/docker/reference/reference.go
+++ b/vendor/github.com/containers/image/docker/reference/reference.go
@@ -15,7 +15,7 @@
 //	tag                             := /[\w][\w.-]{0,127}/
 //
 //	digest                          := digest-algorithm ":" digest-hex
-//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]*
 //	digest-algorithm-separator      := /[+.-_]/
 //	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
 //	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
@@ -205,7 +205,7 @@ func Parse(s string) (Reference, error) {
 	var repo repository
 
 	nameMatch := anchoredNameRegexp.FindStringSubmatch(matches[1])
-	if nameMatch != nil && len(nameMatch) == 3 {
+	if len(nameMatch) == 3 {
 		repo.domain = nameMatch[1]
 		repo.path = nameMatch[2]
 	} else {

--- a/vendor/github.com/containers/image/docker/reference/regexp.go
+++ b/vendor/github.com/containers/image/docker/reference/regexp.go
@@ -20,15 +20,15 @@ var (
 		optional(repeated(separatorRegexp, alphaNumericRegexp)))
 
 	// domainComponentRegexp restricts the registry domain component of a
-	// repository name to start with a component as defined by domainRegexp
+	// repository name to start with a component as defined by DomainRegexp
 	// and followed by an optional port.
 	domainComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
 
-	// domainRegexp defines the structure of potential domain components
+	// DomainRegexp defines the structure of potential domain components
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image
 	// names.
-	domainRegexp = expression(
+	DomainRegexp = expression(
 		domainComponentRegexp,
 		optional(repeated(literal(`.`), domainComponentRegexp)),
 		optional(literal(`:`), match(`[0-9]+`)))
@@ -51,14 +51,14 @@ var (
 	// regexp has capturing groups for the domain and name part omitting
 	// the separating forward slash from either.
 	NameRegexp = expression(
-		optional(domainRegexp, literal(`/`)),
+		optional(DomainRegexp, literal(`/`)),
 		nameComponentRegexp,
 		optional(repeated(literal(`/`), nameComponentRegexp)))
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
 	anchoredNameRegexp = anchored(
-		optional(capture(domainRegexp), literal(`/`)),
+		optional(capture(DomainRegexp), literal(`/`)),
 		capture(nameComponentRegexp,
 			optional(repeated(literal(`/`), nameComponentRegexp))))
 

--- a/vendor/github.com/containers/image/docs/containers-registries.conf.5.md
+++ b/vendor/github.com/containers/image/docs/containers-registries.conf.5.md
@@ -18,57 +18,127 @@ VERSION 2 is the latest format of the `registries.conf` and is currently in
 beta. This means in general VERSION 1 should be used in production environments
 for now.
 
-Every registry can have its own mirrors configured.  The mirrors will be tested
-in order for the availability of the remote manifest.  This happens currently
-only during an image pull.  If the manifest is not reachable due to connectivity
-issues or the unavailability of the remote manifest, then the next mirror will
-be tested instead.  If no mirror is configured or contains the manifest to be
-pulled, then the initially provided reference will be used as fallback.  It is
-possible to set the `insecure` option per mirror, too.
+### GLOBAL SETTINGS
 
-Furthermore it is possible to specify a `prefix` for a registry.  The `prefix`
-is used to find the relevant target registry from where the image has to be
-pulled.  During the test for the availability of the image, the prefixed
-location will be rewritten to the correct remote location.  This applies to
-mirrors as well as the fallback `location`.  If no prefix is specified, it
-defaults to the specified `location`.  For example, if
-`prefix = "example.com/foo"`, `location = "example.com"` and the image will be
-pulled from `example.com/foo/image`, then the resulting pull will be effectively
-point to `example.com/image`.
+`unqualified-search-registries`
+: An array of _host_[`:`_port_] registries to try when pulling an unqualified image, in order.
 
-By default container runtimes use TLS when retrieving images from a registry.
-If the registry is not setup with TLS, then the container runtime will fail to
-pull images from the registry. If you set `insecure = true` for a registry or a
-mirror you overwrite the `insecure` flag for that specific entry.  This means
-that the container runtime will attempt use unencrypted HTTP to pull the image.
-It also allows you to pull from a registry with self-signed certificates.
+### NAMESPACED `[[registry]]` SETTINGS
 
-If you set the `unqualified-search = true` for the registry, then it is possible
-to omit the registry hostname when pulling images.  This feature does not work
-together with a specified `prefix`.
+The bulk of the configuration is represented as an array of `[[registry]]`
+TOML tables; the settings may therefore differ among different registries
+as well as among different namespaces/repositories within a registry.
 
-If `blocked = true` then it is not allowed to pull images from that registry.
+#### Choosing a `[[registry]]` TOML table
+
+Given an image name, a single `[[registry]]` TOML table is chosen based on its `prefix` field.
+
+`prefix`
+: A prefix of the user-specified image name, i.e. using one of the following formats:
+    - _host_[`:`_port_]
+    - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]
+    - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]`/`_repo_
+    - _host_[`:`_port_]`/`_namespace_[`/`_namespace_…]`/`_repo_(`:`_tag|`@`_digest_)
+
+    The user-specified image name must start with the specified `prefix` (and continue
+    with the appropriate separator) for a particular `[[registry]]` TOML table to be
+    considered; (only) the TOML table with the longest match is used.
+
+    As a special case, the `prefix` field can be missing; if so, it defaults to the value
+    of the `location` field (described below).
+
+#### Per-namespace settings
+
+`insecure`
+: `true` or `false`.
+    By default, container runtimes require TLS when retrieving images from a registry.
+    If `insecure` is set to `true`, unencrypted HTTP as well as TLS connections with untrusted
+    certificates are allowed.
+
+`blocked`
+: `true` or `false`.
+    If `true`, pulling images with matching names is forbidden.
+
+#### Remapping and mirroring registries
+
+The user-specified image reference is, primarily, a "logical" image name, always used for naming
+the image.  By default, the image reference also directly specifies the registry and repository
+to use, but the following options can be used to redirect the underlying accesses
+to different registry servers or locations (e.g. to support configurations with no access to the
+internet without having to change `Dockerfile`s, or to add redundancy).
+
+`location`
+: Accepts the same format as the `prefix` field, and specifies the physical location
+    of the `prefix`-rooted namespace.
+
+    By default, this equal to `prefix` (in which case `prefix` can be omitted and the
+    `[[registry]]` TOML table can only specify `location`).
+
+    Example: Given
+    ```
+    prefix = "example.com/foo"
+    location = "internal-registry-for-example.net/bar"
+    ```
+    requests for the image `example.com/foo/myimage:latest` will actually work with the
+    `internal-registry-for-example.net/bar/myimage:latest` image.
+
+`mirror`
+: An array of TOML tables specifiying (possibly-partial) mirrors for the
+    `prefix`-rooted namespace.
+
+    The mirrors are attempted in the specified order; the first one that can be
+    contacted and contains the image will be used (and if none of the mirrors contains the image,
+    the primary location specified by the `registry.location` field, or using the unmodified
+    user-specified reference, is tried last).
+
+    Each TOML table in the `mirror` array can contain the following fields, with the same semantics
+    as if specified in the `[[registry]]` TOML table directly:
+    - `location`
+    - `insecure`
+
+`mirror-by-digest-only`
+: `true` or `false`.
+    If `true`, mirrors will only be used during pulling if the image reference includes a digest.
+    Referencing an image by digest ensures that the same is always used
+    (whereas referencing an image by a tag may cause different registries to return
+    different images if the tag mapping is out of sync).
+
+    Note that if this is `true`, images referenced by a tag will only use the primary
+    registry, failing if that registry is not accessible.
+
+*Note*: Redirection and mirrors are currently processed only when reading images, not when pushing
+to a registry; that may change in the future.
 
 ### EXAMPLE
 
 ```
+unqualified-search-registries = ["example.com"]
+
 [[registry]]
-location = "example.com"
-insecure = false
 prefix = "example.com/foo"
-unqualified-search = false
+insecure = false
 blocked = false
-mirror = [
-    { location = "example-mirror-0.local", insecure = false },
-    { location = "example-mirror-1.local", insecure = true }
-]
+location = "internal-registry-for-example.com/bar"
+
+[[registry.mirror]]
+location = "example-mirror-0.local/mirror-for-foo"
+
+[[registry.mirror]]
+location = "example-mirror-1.local/mirrors/foo"
+insecure = true
 ```
+Given the above, a pull of `example.com/foo/image:latest` will try:
+    1. `example-mirror-0.local/mirror-for-foo/image:latest`
+    2. `example-mirror-1.local/mirrors/foo/image:latest`
+    3. `internal-registry-for-example.net/bar/myimage:latest`
+
+in order, and use the first one that exists.
 
 ## VERSION 1
-VERSION 1 can be used as alternative to the VERSION 2, but it is not capable in
-using registry mirrors or a prefix.
+VERSION 1 can be used as alternative to the VERSION 2, but it does not support
+using registry mirrors, longest-prefix matches, or location rewriting.
 
-The TOML_format is used to build a simple list for registries under three
+The TOML format is used to build a simple list of registries under three
 categories: `registries.search`, `registries.insecure`, and `registries.block`.
 You can list multiple registries using a comma separated list.
 
@@ -76,11 +146,11 @@ Search registries are used when the caller of a container runtime does not fully
 container image that they want to execute.  These registries are prepended onto the front
 of the specified container image until the named image is found at a registry.
 
-Note insecure registries can be used for any registry, not just the registries listed
+Note that insecure registries can be used for any registry, not just the registries listed
 under search.
 
-The fields `registries.insecure` and `registries.block` work as like as the
-`insecure` and `blocked` from VERSION 2.
+The `registries.insecure` and `registries.block` lists have the same meaning as the
+`insecure` and `blocked` fields in VERSION 2.
 
 ### EXAMPLE
 The following example configuration defines two searchable registries, one

--- a/vendor/github.com/containers/image/registries.conf
+++ b/vendor/github.com/containers/image/registries.conf
@@ -29,37 +29,54 @@ registries = []
 # The second version of the configuration format allows to specify registry
 # mirrors:
 #
+# # An array of host[:port] registries to try when pulling an unqualified image, in order.
+# unqualified-search-registries = ["example.com"]
+#
 # [[registry]]
-# # The main location of the registry
-# location = "example.com"
-#
-# # If true, certs verification will be skipped and HTTP (non-TLS) connections
-# # will be allowed.
-# insecure = false
-#
-# # Prefix is used for matching images, and to translate one namespace to
-# # another.  If `prefix = "example.com/foo"`, `location = "example.com"` and
-# # we pull from "example.com/foo/myimage:latest", the image will effectively be
-# # pulled from "example.com/myimage:latest".  If no Prefix is specified,
-# # it defaults to the specified `location`. When a prefix is used, then a pull
-# # without specifying the prefix is not possible any more.
+# # The "prefix" field is used to choose the relevant [[registry]] TOML table;
+# # (only) the TOML table with the longest match for the input image name
+# # (taking into account namespace/repo/tag/digest separators) is used.
+# #
+# # If the prefix field is missing, it defaults to be the same as the "location" field.
 # prefix = "example.com/foo"
 #
-# # If true, the registry can be used when pulling an unqualified image. If a
-# # prefix is specified, unqualified pull is not possible any more.
-# unqualified-search = false
+# # If true, unencrypted HTTP as well as TLS connections with untrusted
+# # certificates are allowed.
+# insecure = false
 #
-# # If true, pulling from the registry will be blocked.
+# # If true, pulling images with matching names is forbidden.
 # blocked = false
 #
-# # All available mirrors of the registry.  The mirrors will be evaluated in
-# # order during an image pull.  Furthermore it is possible to specify the
-# # `insecure` flag per registry mirror, too.
-# mirror = [
-#     { location = "example-mirror-0.local", insecure = false },
-#     { location = "example-mirror-1.local", insecure = true },
-#     # It is also possible to specify an additional path within the `location`.
-#     # A pull to `example.com/foo/image:latest` will then result in
-#     # `example-mirror-2.local/path/image:latest`.
-#     { location = "example-mirror-2.local/path" },
-# ]
+# # The physical location of the "prefix"-rooted namespace.
+# #
+# # By default, this equal to "prefix" (in which case "prefix" can be omitted
+# # and the [[registry]] TOML table can only specify "location").
+# #
+# # Example: Given
+# #   prefix = "example.com/foo"
+# #   location = "internal-registry-for-example.net/bar"
+# # requests for the image example.com/foo/myimage:latest will actually work with the
+# # internal-registry-for-example.net/bar/myimage:latest image.
+# location = internal-registry-for-example.com/bar"
+#
+# # (Possibly-partial) mirrors for the "prefix"-rooted namespace.
+# #
+# # The mirrors are attempted in the specified order; the first one that can be
+# # contacted and contains the image will be used (and if none of the mirrors contains the image,
+# # the primary location specified by the "registry.location" field, or using the unmodified
+# # user-specified reference, is tried last).
+# #
+# # Each TOML table in the "mirror" array can contain the following fields, with the same semantics
+# # as if specified in the [[registry]] TOML table directly:
+# # - location
+# # - insecure
+# [[registry.mirror]]
+# location = "example-mirror-0.local/mirror-for-foo"
+# [[registry.mirror]]
+# location = "example-mirror-1.local/mirrors/foo"
+# insecure = true
+# # Given the above, a pull of example.com/foo/image:latest will try:
+# # 1. example-mirror-0.local/mirror-for-foo/image:latest
+# # 2. example-mirror-1.local/mirrors/foo/image:latest
+# # 3. internal-registry-for-example.net/bar/myimage:latest
+# # in order, and use the first one that exists.

--- a/vendor/github.com/containers/image/version/version.go
+++ b/vendor/github.com/containers/image/version/version.go
@@ -4,14 +4,14 @@ import "fmt"
 
 const (
 	// VersionMajor is for an API incompatible changes
-	VersionMajor = 1
+	VersionMajor = 2
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 7
+	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This adds the mirror-by-digest-only option to mirrors, and moves the search order to an independent list.