### PR TITLE
Explicitly disable encrypting the test GPG key

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/signature"
 	"github.com/go-check/check"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/image-tools/image"
 )
@@ -64,7 +64,7 @@ func (s *CopySuite) SetUpSuite(c *check.C) {
 	os.Setenv("GNUPGHOME", s.gpgHome)
 
 	for _, key := range []string{"personal", "official"} {
-		batchInput := fmt.Sprintf("Key-Type: RSA\nName-Real: Test key - %s\nName-email: %s@example.com\n%%commit\n",
+		batchInput := fmt.Sprintf("Key-Type: RSA\nName-Real: Test key - %s\nName-email: %s@example.com\n%%no-protection\n%%commit\n",
 			key, key)
 		runCommandWithInput(c, batchInput, gpgBinary, "--batch", "--gen-key")
 

--- a/integration/signing_test.go
+++ b/integration/signing_test.go
@@ -44,7 +44,7 @@ func (s *SigningSuite) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 	os.Setenv("GNUPGHOME", s.gpgHome)
 
-	runCommandWithInput(c, "Key-Type: RSA\nName-Real: Testing user\n%commit\n", gpgBinary, "--homedir", s.gpgHome, "--batch", "--gen-key")
+	runCommandWithInput(c, "Key-Type: RSA\nName-Real: Testing user\n%no-protection\n%commit\n", gpgBinary, "--homedir", s.gpgHome, "--batch", "--gen-key")
 
 	lines, err := exec.Command(gpgBinary, "--homedir", s.gpgHome, "--with-colons", "--no-permission-warning", "--fingerprint").Output()
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
Since GPG 2.1, GPG asks for a passphrase by default; opt out when generating the test key, to fix
```
gpg: agent_genkey failed: No pinentry
gpg: key generation failed: No pinentry
```
which happens otherwise.