### PR TITLE
Fixing static binary build using container

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,8 +1,14 @@
 FROM ubuntu:18.10
 
-RUN apt-get update && apt-get install -y \
-    golang \
-    libbtrfs-dev \
+RUN apt-get update && apt-get install -y wget
+RUN wget -P /tmp/ https://dl.google.com/go/go1.11.linux-amd64.tar.gz && \
+    tar -xvf /tmp/go1.11.linux-amd64.tar.gz -C /usr/local/
+
+ENV GOROOT /usr/local/go
+ENV GOPATH /
+ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
+
+RUN apt-get install -y libbtrfs-dev \
     git-core \
     libdevmapper-dev \
     libgpgme11-dev \
@@ -10,5 +16,4 @@ RUN apt-get update && apt-get install -y \
     libglib2.0-dev \
     libostree-dev
 
-ENV GOPATH=/
 WORKDIR /src/github.com/containers/skopeo

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ LOCAL_BUILD_TAGS = $(BTRFS_BUILD_TAG) $(LIBDM_BUILD_TAG) $(OSTREE_BUILD_TAG) $(D
 BUILDTAGS += $(LOCAL_BUILD_TAGS)
 
 ifeq ($(DISABLE_CGO), 1)
-	override BUILDTAGS = containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp
+	override BUILDTAGS = netgo osusergo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp
 endif
 
 #   make all DEBUG=1


### PR DESCRIPTION
 1. LookupId panics on Linux+glibc static build (https://github.com/golang/go/issues/24787)
 2. Updated go version to 1.11.0 in Dockerfile.build
 3. added go build tags netgo osusergo in static binary