### PR TITLE
Skip systemtest/050-signing.bats if skopeo can't create signatures

### DIFF
--- a/systemtest/050-signing.bats
+++ b/systemtest/050-signing.bats
@@ -82,6 +82,15 @@ END_POLICY_JSON
 }
 
 @test "signing" {
+    run_skopeo '?' standalone-sign /dev/null busybox alice@test.redhat.com -o /dev/null
+    if [[ "$output" =~ 'signing is not supported' ]]; then
+        skip "skopeo built without support for creating signatures"
+        return 1
+    fi
+    if [ "$status" -ne 0 ]; then
+        die "exit code is $status; expected $expected_rc"
+    fi
+
     # Cache local copy
     run_skopeo copy docker://busybox:latest dir:$TESTDIR/busybox
 


### PR DESCRIPTION
This does not happen in this repo's tests, but containers/image's `make test-skopeo` fails in the `containers_image_openpgp` configuration with

```
not ok 10 signing
...
# time="2019-06-11T20:59:32Z" level=fatal msg="Signing not supported: signing is not supported in github.com/containers/image built with the containers_image_openpgp build tag"
```

To reproduce/test this:
```sh
make test-system BUILDTAGS='ostree containers_image_openpgp'
```

Cc: @edsantiago 