### PR TITLE
DO NOT MERGE (prefer 677): Wait for the registry container to start up in systemtests

### DIFF
--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -310,6 +310,7 @@ start_registry() {
     fi
 
     $PODMAN run -d --name $name "${reg_args[@]}" registry:2
+    sleep 10 # Allow the registry container to start up and accept connections
 }
 
 # END   helpers for starting/stopping registries


### PR DESCRIPTION
... to attempt to avoid
```shell
$ for i in $(seq 1 10); do echo ====$i; systemtest/run-tests 040 || break; done
====1
 ✓ auth: credentials on command line
 ✗ auth: credentials via podman login
 (in test file systemtest/040-local-registry-auth.bats, line 54)
     `podman login --tls-verify=false -u $testuser -p $testpassword localhost:5000' failed with status 125
   grep: /tmp/skopeo_bats.ydmiLB/auth/htpasswd: No such file or directory
   f55c04a80cf4f9dba02cea68980c0c5d2493d7c2cf3f631c7ab7ed9dd65d0ca0
   Error: error authenticating creds for "localhost:5000": pinging docker registry returned: Get http://localhost:5000/v2/: dial tcp [::1]:5000: connect: connection refused
   f55c04a80cf4f9dba02cea68980c0c5d2493d7c2cf3f631c7ab7ed9dd65d0ca0
```

Fixes #675 , hopefully.

Cc: @edsantiago 