### PR TITLE
start_registry: wait for registry to be ready

### DIFF
--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -310,6 +310,18 @@ start_registry() {
     fi
 
     $PODMAN run -d --name $name "${reg_args[@]}" registry:2
+
+    # Wait for registry to actually come up
+    timeout=10
+    while [[ $timeout -ge 1 ]]; do
+        if curl localhost:$port/; then
+            return
+        fi
+
+        timeout=$(expr $timeout - 1)
+        sleep 1
+    done
+    die "Timed out waiting for registry container to respond on :$port"
 }
 
 # END   helpers for starting/stopping registries


### PR DESCRIPTION
The usual 'podman run -d' race condition: we've been forking
off the container but not actually making sure it's up; this
leads to flakes in which we try (and fail) to access it.

Solution: use curl to check the port; we will expect a zero
exit status once we can connect. Time out at ten seconds.

Resolves: #675

Signed-off-by: Ed Santiago <santiago@redhat.com>