### PR TITLE
[WIP] List all repos with tags

### DIFF
--- a/cmd/skopeo/list.go
+++ b/cmd/skopeo/list.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/urfave/cli"
+)
+
+type listOptions struct {
+	global      *globalOptions
+	image       *imageOptions
+	regUsername string
+	regPassword string
+}
+
+func listCmd(global *globalOptions) cli.Command {
+	sharedFlags, sharedOpts := sharedImageFlags()
+	imageFlags, imageOpts := imageFlags(global, sharedOpts, "", "")
+	opts := listOptions{
+		global: global,
+		image:  imageOpts,
+	}
+	return cli.Command{
+		Name:  "list",
+		Usage: "Get list of repos of REGISTRY-NAME",
+		Description: fmt.Sprint(`
+		Get list of repos of REGISTRY-NAME
+
+		Supports Docker v2 registries only.
+
+		See skopeo(1) section "REGISTRY-NAMES" for the expected format
+		`),
+		ArgsUsage: "REGISTRY-NAME",
+		Before:    needsRexec,
+		Action:    commandAction(opts.run),
+		// Flags:     append(sharedFlags, imageFlags...),
+		Flags: append(append([]cli.Flag{
+			cli.StringFlag{
+				Name:        "username, u",
+				Usage:       "Registry username, defaults to empty string",
+				Destination: &opts.regUsername,
+			},
+			cli.StringFlag{
+				Name:        "password, p",
+				Usage:       "Registry password, defaults to empty string",
+				Destination: &opts.regPassword,
+			},
+		}, sharedFlags...), imageFlags...),
+	}
+}
+
+func (opts *listOptions) run(args []string, stdout io.Writer) error {
+	if len(args) != 1 {
+		return errors.New("Usage: list registryURL")
+	}
+
+	reg := NewRegistry(args[0])
+	reg.getAllReposWithTags()
+
+	return nil
+}

--- a/cmd/skopeo/list.go
+++ b/cmd/skopeo/list.go
@@ -33,7 +33,6 @@ func listCmd(global *globalOptions) cli.Command {
 		See skopeo(1) section "REGISTRY-NAMES" for the expected format
 		`),
 		ArgsUsage: "REGISTRY-NAME",
-		Before:    needsRexec,
 		Action:    commandAction(opts.run),
 		// Flags:     append(sharedFlags, imageFlags...),
 		Flags: append(append([]cli.Flag{
@@ -56,7 +55,10 @@ func (opts *listOptions) run(args []string, stdout io.Writer) error {
 		return errors.New("Usage: list registryURL")
 	}
 
-	reg := NewRegistry(args[0])
+	reg, err := NewRegistry(args[0])
+	if err != nil {
+		return err
+	}
 	reg.getAllReposWithTags()
 
 	return nil

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -94,6 +94,7 @@ func createApp() (*cli.App, *globalOptions) {
 	app.Before = opts.before
 	app.Commands = []cli.Command{
 		copyCmd(&opts),
+		listCmd(&opts),
 		inspectCmd(&opts),
 		layersCmd(&opts),
 		deleteCmd(&opts),

--- a/cmd/skopeo/registry_utils.go
+++ b/cmd/skopeo/registry_utils.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"text/tabwriter"
+)
+
+// Registry stores information about the targeted docker registry to
+// to optimize the numerous calls to registry API
+type Registry struct {
+	baseURL      string
+	catalogURL   string
+	authType     string
+	regUsername  string
+	regPassword  string
+	repos        []string
+	catalogToken string
+}
+
+const (
+	tokenAuth string = "token"
+	basicAuth string = "basic"
+	noneAuth  string = "none"
+)
+
+// NewRegistry creates a new Registry struct with parsed/sanitized URLs
+func NewRegistry(rawURL string) Registry {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		fmt.Errorf("Failed to parse URL: %v", err)
+	}
+	baseURL := parsedURL.String()
+	parsedURL.Path = path.Join(parsedURL.Path, "v2/_catalog")
+	catalogURL := parsedURL.String()
+
+	return Registry{baseURL: baseURL, catalogURL: catalogURL}
+}
+
+// Determines auth type to optimize later registry calls
+func (r *Registry) getAuthType() {
+	resp, err := http.Get(r.catalogURL)
+	if err != nil {
+		fmt.Errorf("Failed to connect to Catalog URL: %v", err)
+	}
+
+	headerAuth := resp.Header.Get("www-authenticate")
+	headerAuthLower := strings.ToLower(headerAuth)
+
+	if strings.Count(headerAuthLower, "bearer") > 0 {
+		fmt.Println("Using Bearer Auth")
+		r.authType = tokenAuth
+	} else if strings.Count(headerAuthLower, "basic") > 0 {
+		fmt.Println("Using Basic Auth")
+		r.authType = basicAuth
+	} else {
+		fmt.Println("Using No Auth")
+		r.authType = noneAuth
+	}
+}
+
+// Uses r.authType to abstract Authentication
+func (r *Registry) applyAuth(req *http.Request) {
+	if r.authType == tokenAuth {
+		var token string
+		// Each catalog request returns a limit of 100 repos at a time.
+		// This conditional saves a few requests for large registry catalogs.
+		// By resetting r.catalogToken at end of getV2Catalog(), this
+		// can also be used to handle auth for getting tags.
+		// This could could be improved.
+		if len(r.catalogToken) > 0 {
+			token = r.catalogToken
+		} else {
+			token = getToken(req.URL.String())
+			r.catalogToken = token
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else if r.authType == basicAuth {
+		req.SetBasicAuth(r.regUsername, r.regPassword)
+	} else {
+		// Do Nothing
+	}
+}
+
+// Prints list of registry repos with all available tags
+func (r *Registry) getAllReposWithTags() {
+	r.getAuthType()
+	r.getV2Catalog()
+
+	var wg sync.WaitGroup
+	var lock sync.Mutex
+	wg.Add(len(r.repos))
+	reposWithTags := make(map[string][]string)
+
+	// Alphabetize repos
+	sort.Strings(r.repos)
+
+	for _, repo := range r.repos {
+		go func(repo string) {
+			defer wg.Done()
+			tags := r.getRepoTags(repo)
+			lock.Lock()
+			reposWithTags[repo] = tags
+			lock.Unlock()
+		}(repo)
+	}
+	wg.Wait()
+
+	// Display repos with tags - format to be optimized later
+	// Consider using https://github.com/olekukonko/tablewriter
+	fmt.Println()
+	w := tabwriter.NewWriter(os.Stdout, 10, 0, 1, ' ', tabwriter.TabIndent|tabwriter.Debug)
+	fmt.Fprintln(w, "\t REPO \t TAGS \t")
+	fmt.Fprintln(w, "\t - - - - - - - - - - \t - - - - - - - - - - \t")
+	for _, repo := range r.repos {
+		tags := strings.Join(reposWithTags[repo], "  ")
+		// Shorten tag output for testing
+		// if len(tags) > 45 {
+		// 	fmt.Fprintf(w, "\t %s\t %v\t\n", repo, tags[:45])
+		// } else {
+		// 	fmt.Fprintf(w, "\t %s\t %v\t\n", repo, tags)
+		// }
+		fmt.Fprintf(w, "\t %s\t %v\t\n", repo, tags)
+	}
+	w.Flush()
+}
+
+// Gets repo catalog from a registry
+func (r *Registry) getV2Catalog() {
+	req, err := http.NewRequest("GET", r.catalogURL, nil)
+	if err != nil {
+		fmt.Errorf("Failed to connect to Catalog URL: %v", err)
+	}
+
+	r.applyAuth(req)
+
+	res, _ := http.DefaultClient.Do(req)
+	bodyBytes, _ := ioutil.ReadAll(res.Body)
+
+	var repositories []string
+	var replacer = strings.NewReplacer("<", "", ">", "")
+
+	if res.StatusCode >= 200 && res.StatusCode <= 299 {
+		var f map[string][]string
+		_ = json.Unmarshal(bodyBytes, &f)
+		repositories = append(repositories, f["repositories"]...)
+		// Look for more paginated repo link in header and follow
+		headerLink := res.Header.Get("Link")
+		for len(headerLink) != 0 {
+			guardedLink := strings.Split(headerLink, ";")[0]
+			cleanedLink := replacer.Replace(guardedLink)
+			parsedBaseURL, _ := url.Parse(r.baseURL)
+			parsedBaseURL.Path = path.Join(parsedBaseURL.Path, cleanedLink)
+			unescapedURL, _ := url.QueryUnescape(parsedBaseURL.String())
+			req2, _ := http.NewRequest("GET", unescapedURL, nil)
+			r.applyAuth(req2)
+			res2, _ := http.DefaultClient.Do(req2)
+			bodyBytes2, _ := ioutil.ReadAll(res2.Body)
+			_ = json.Unmarshal(bodyBytes2, &f)
+			repositories = append(repositories, f["repositories"]...)
+			headerLink = res2.Header.Get("Link")
+		}
+	} else {
+		fmt.Println("Failed to get repository list")
+	}
+
+	// fmt.Println(len(repositories))  // Remove later
+	r.repos = repositories
+	r.catalogToken = ""
+}
+
+// Gets tags for a repo
+func (r *Registry) getRepoTags(repo string) []string {
+	parsedURL, _ := url.Parse(r.baseURL)
+	parsedURL.Path = path.Join(parsedURL.Path, "v2/", repo, "/tags/list")
+	req, _ := http.NewRequest("GET", parsedURL.String(), nil)
+	r.applyAuth(req)
+	res, _ := http.DefaultClient.Do(req)
+	bodyBytes, _ := ioutil.ReadAll(res.Body)
+	var f map[string][]string
+	_ = json.Unmarshal(bodyBytes, &f)
+
+	return f["tags"]
+}
+
+// Gets Bearer Token for registries using Token Authentication
+func getToken(baseURL string) string {
+	// Request to gather auth parameters
+	resp, err := http.Get(baseURL)
+	if err != nil {
+		fmt.Errorf("Failed to connect to Base URL: %v", err)
+	}
+
+	headerAuth := resp.Header.Get("www-authenticate")
+
+	headerAuthSlice := strings.Split(headerAuth, ",")
+	var authRealm, authService, authScope string
+	for _, elem := range headerAuthSlice {
+		if strings.Count(strings.ToLower(elem), "bearer") == 1 {
+			elem = strings.Split(elem, " ")[1]
+		}
+		elem := strings.Replace(elem, "\"", "", -1)
+		elemSplit := strings.Split(elem, "=")
+		if len(elemSplit) != 2 {
+			fmt.Printf("Incorrectly formatted Header Auth: %s\n", headerAuth)
+		}
+		authKey := elemSplit[0]
+		authValue := elemSplit[1]
+		switch authKey {
+		case "realm":
+			authRealm = authValue
+		case "service":
+			authService = authValue
+		case "scope":
+			authScope = authValue
+		}
+	}
+
+	parsedRealm, err := url.Parse(authRealm)
+	if err != nil {
+		fmt.Errorf("Failed to parse Auth Realm URL: %v", err)
+	}
+
+	// Build query for token
+	q := parsedRealm.Query()
+	q.Set("service", authService)
+	q.Set("scope", authScope)
+	parsedRealm.RawQuery = q.Encode()
+
+	// Make request for token
+	resp2, err := http.Get(parsedRealm.String())
+	if err != nil {
+		fmt.Errorf("Failed to connect to Auth Realm URL: %v", err)
+	}
+
+	// Extract token
+	body, _ := ioutil.ReadAll(resp2.Body)
+	var f map[string]string
+	_ = json.Unmarshal(body, &f)
+	token := f["token"]
+
+	return token
+}

--- a/cmd/skopeo/registry_utils.go
+++ b/cmd/skopeo/registry_utils.go
@@ -219,7 +219,7 @@ func (r *Registry) getRepoTags(repo string) ([]string, error) {
 	parsedURL.Path = path.Join(parsedURL.Path, "v2/", repo, "/tags/list")
 	req, err := http.NewRequest("GET", parsedURL.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to build requset when retrieving tags for %s: %v", err)
+		return nil, fmt.Errorf("Failed to build requset when retrieving tags for %s: %v", repo, err)
 	}
 	r.applyAuth(req)
 	res, err := http.DefaultClient.Do(req)

--- a/cmd/skopeo/registry_utils_test.go
+++ b/cmd/skopeo/registry_utils_test.go
@@ -51,7 +51,7 @@ func TestGetToken(t *testing.T) {
 	}))
 	defer func() { testServer2.Close() }()
 
-	token := getToken(testServer2.URL)
+	token, _ := getToken(testServer2.URL)
 	assert.Equal(t, "abcdefg", token)
 }
 
@@ -70,7 +70,7 @@ func TestGetRepoTags(t *testing.T) {
 
 	reg, _ := NewRegistry(testServer.URL)
 	reg.getAuthType()
-	repoTags := reg.getRepoTags(repo)
+	repoTags, _ := reg.getRepoTags(repo)
 	assert.Contains(t, repoTags, "15.1")
 }
 

--- a/cmd/skopeo/registry_utils_test.go
+++ b/cmd/skopeo/registry_utils_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAuthTypeNone(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer func() { testServer.Close() }()
+
+	reg := NewRegistry(testServer.URL)
+	reg.getAuthType()
+	assert.Contains(t, reg.authType, noneAuth)
+}
+
+func TestGetAuthTypeToken(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Add("www-authenticate", "Bearer realm=\"www.example.com\",service=\"SUSE Linux Docker Registry\",scope=\"registry:catalog:*\",error=\"invalid_token\"")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer func() { testServer.Close() }()
+
+	reg := NewRegistry(testServer.URL)
+	reg.getAuthType()
+	assert.Contains(t, reg.authType, tokenAuth)
+}
+
+func TestGetToken(t *testing.T) {
+
+	// Test server to deliver token
+	testServer1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"token":"abcdefg"}`))
+	}))
+	defer func() { testServer1.Close() }()
+
+	// Second test server needed to deliver header containing URL of first test server
+	testServer2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Add("www-authenticate", "Bearer realm=\""+testServer1.URL+"\",service=\"SUSE Linux Docker Registry\",scope=\"registry:catalog:*\",error=\"invalid_token\"")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer func() { testServer2.Close() }()
+
+	token := getToken(testServer2.URL)
+	assert.Equal(t, "abcdefg", token)
+}
+
+func TestGetRepoTags(t *testing.T) {
+
+	repo := "opensuse/leap"
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		outMap := map[string][]string{
+			"tags": {"15.0", "15.1", "latest"},
+		}
+		j, _ := json.Marshal(outMap)
+		w.Write([]byte(j))
+	}))
+	defer func() { testServer.Close() }()
+
+	reg := NewRegistry(testServer.URL)
+	reg.getAuthType()
+	repoTags := reg.getRepoTags(repo)
+	assert.Contains(t, repoTags, "15.1")
+}
+
+func TestGetV2Catalog(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		outMap := map[string][]string{
+			"repositories": {"opensuse/leap", "opensuse/tumbleweed", "not/a/real/repo"},
+		}
+		j, _ := json.Marshal(outMap)
+		w.Write([]byte(j))
+	}))
+	defer func() { testServer.Close() }()
+
+	reg := NewRegistry(testServer.URL)
+	reg.authType = noneAuth
+	reg.getV2Catalog()
+	assert.Contains(t, reg.repos, "opensuse/tumbleweed")
+}
+
+func TestGetAllReposWithTags(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		outMap := map[string][]string{
+			"repositories": {"opensuse/leap"},
+			"tags":         {"15.0", "15.1", "latest"},
+		}
+		j, _ := json.Marshal(outMap)
+		w.Write([]byte(j))
+	}))
+	defer func() { testServer.Close() }()
+
+	reg := NewRegistry(testServer.URL)
+
+	// Capture Stdout
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	reg.getAllReposWithTags()
+
+	w.Close()
+	out, _ := ioutil.ReadAll(r)
+	os.Stdout = rescueStdout
+
+	matchedRepo, _ := regexp.MatchString("opensuse/leap", string(out))
+	matchedTag, _ := regexp.MatchString("15.1", string(out))
+
+	assert.True(t, matchedRepo)
+	assert.True(t, matchedTag)
+}

--- a/cmd/skopeo/registry_utils_test.go
+++ b/cmd/skopeo/registry_utils_test.go
@@ -18,7 +18,7 @@ func TestGetAuthTypeNone(t *testing.T) {
 	}))
 	defer func() { testServer.Close() }()
 
-	reg := NewRegistry(testServer.URL)
+	reg, _ := NewRegistry(testServer.URL)
 	reg.getAuthType()
 	assert.Contains(t, reg.authType, noneAuth)
 }
@@ -30,7 +30,7 @@ func TestGetAuthTypeToken(t *testing.T) {
 	}))
 	defer func() { testServer.Close() }()
 
-	reg := NewRegistry(testServer.URL)
+	reg, _ := NewRegistry(testServer.URL)
 	reg.getAuthType()
 	assert.Contains(t, reg.authType, tokenAuth)
 }
@@ -68,7 +68,7 @@ func TestGetRepoTags(t *testing.T) {
 	}))
 	defer func() { testServer.Close() }()
 
-	reg := NewRegistry(testServer.URL)
+	reg, _ := NewRegistry(testServer.URL)
 	reg.getAuthType()
 	repoTags := reg.getRepoTags(repo)
 	assert.Contains(t, repoTags, "15.1")
@@ -85,7 +85,7 @@ func TestGetV2Catalog(t *testing.T) {
 	}))
 	defer func() { testServer.Close() }()
 
-	reg := NewRegistry(testServer.URL)
+	reg, _ := NewRegistry(testServer.URL)
 	reg.authType = noneAuth
 	reg.getV2Catalog()
 	assert.Contains(t, reg.repos, "opensuse/tumbleweed")
@@ -103,7 +103,7 @@ func TestGetAllReposWithTags(t *testing.T) {
 	}))
 	defer func() { testServer.Close() }()
 
-	reg := NewRegistry(testServer.URL)
+	reg, _ := NewRegistry(testServer.URL)
 
 	// Capture Stdout
 	rescueStdout := os.Stdout

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -150,7 +150,7 @@ func (opts *imageOptions) newSystemContext() (*types.SystemContext, error) {
 	return ctx, nil
 }
 
-// imageDestOptions is a superset of imageOptions specialized for iamge destinations.
+// imageDestOptions is a superset of imageOptions specialized for image destinations.
 type imageDestOptions struct {
 	*imageOptions
 	osTreeTmpDir        string // A directory to use for OSTree temporary files


### PR DESCRIPTION
Add the ability to list all repos and tags in a registry with the `list` subcommand.  This could also be used as a precursor for registry search.

Some items still in progress:
- Documentation
- Error handling
- Formatting of output - long repo names and tag slices can overwhelm Stdout as is
- Architecture of helper struct/methods currently in registry_utils.go - I chose to break this out from utils.go due to the size of the added content and specific application to registries
- Consider utilizing docker libs for auth - though it appears easier to re-write as I have done, but still prefer to rely on existing libs if possible