### PR TITLE
README.md: command to install on openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ Obtaining skopeo
 ```sh
 $ sudo dnf install skopeo
 ```
+for openSUSE:
+```sh
+$ sudo zypper install skopeo
+```
+
 
 Otherwise, read on for building and installing it from source:
 
@@ -179,6 +184,9 @@ sudo apt install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev libost
 
 # macOS:
 brew install gpgme
+
+# openSUSE
+sudo zypper install libgpgme-devel device-mapper-devel libbtrfs-devel glib2-devel
 ```
 
 Make sure to clone this repository in your `GOPATH` - otherwise compilation fails.


### PR DESCRIPTION
Adds a simple documentation how to install skopeo on an openSUSE
distribution

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>