### PR TITLE
Makefile: set GO111MODULE=off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all binary build-container docs docs-in-container build-local clean install install-binary install-completions shell test-integration .install.vndr vendor
 
 export GO15VENDOREXPERIMENT=1
+export GO111MODULE=off
 
 ifeq ($(shell uname),Darwin)
 PREFIX ?= ${DESTDIR}/usr/local


### PR DESCRIPTION
Turn of go modules to avoid breaking build environments to accidentally
try pulling the dependencies instead of using the ./vendor directory.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>