### PR TITLE
Fix lowest possible go version to be 1.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: all binary build-container docs docs-in-container build-local clean install install-binary install-completions shell test-integration .install.vndr vendor
 
-export GO15VENDOREXPERIMENT=1
 export GO111MODULE=off
 
 ifeq ($(shell uname),Darwin)
@@ -157,7 +156,7 @@ test-system: build-container
 	exit $$rc
 
 test-unit: build-container
-	# Just call (make test unit-local) here instead of worrying about environment differences, e.g. GO15VENDOREXPERIMENT.
+	# Just call (make test unit-local) here instead of worrying about environment differences
 	$(CONTAINER_RUN) make test-unit-local BUILDTAGS='$(BUILDTAGS)'
 
 validate: build-container
@@ -177,4 +176,3 @@ vendor:
 		$(GO) mod tidy && \
 		$(GO) mod vendor && \
 		$(GO) mod verify
-

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ $ sudo zypper install skopeo
 
 Otherwise, read on for building and installing it from source:
 
-To build the `skopeo` binary you need at least Go 1.5 because it uses the latest `GO15VENDOREXPERIMENT` flag.
+To build the `skopeo` binary you need at least Go 1.9.
 
 There are two ways to build skopeo: in a container, or locally without a container.  Choose the one which better matches your needs and environment.
 

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -10,6 +10,5 @@ bundle_test_integration() {
 (
 	make binary-local ${BUILDTAGS:+BUILDTAGS="$BUILDTAGS"}
 	make install
-	export GO15VENDOREXPERIMENT=1
 	bundle_test_integration
 ) 2>&1


### PR DESCRIPTION
containers/storage needs math/bits which has been added in go 1.9, so
this is now the lowest possible go version to build skopeo. We can also
remove the GO15VENDOREXPERIMENT variable since this has been enabled in
go 1.6 per default and removed in go 1.7.

Relates to https://github.com/containers/skopeo/pull/686