### PR TITLE
systemtest: support deleting image from registry

### DIFF
--- a/systemtest/060-delete.bats
+++ b/systemtest/060-delete.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+#
+# Copy tests
+#
+
+load helpers
+
+function setup() {
+    standard_setup
+
+    start_registry --enable-delete=true reg
+}
+
+# delete image from registry
+@test "delete: remove image from registry" {
+    local remote_image=docker://busybox:latest
+    local localimg=docker://localhost:5000/busybox:unsigned
+    local output=
+
+    run_skopeo copy --dest-tls-verify=false $remote_image $localimg
+    output=$(run_skopeo inspect --tls-verify=false --raw $localimg)
+    echo $output | grep "vnd.docker.distribution.manifest.v2+json"
+
+    run_skopeo delete --tls-verify=false $localimg
+
+    # make sure image is removed from registry
+    expected_rc=1
+    run_skopeo $expected_rc inspect --tls-verify=false $localimg
+}
+
+teardown() {
+    podman rm -f reg
+
+    standard_teardown
+}
+
+# vim: filetype=sh

--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -231,6 +231,7 @@ function expect_line_count() {
 #       --testuser=XXX      Require authentication; this is the username
 #       --testpassword=XXX  ...and the password (these two go together)
 #       --with-cert         Create a cert for running with TLS (not working)
+#       --enable-delete     Set allowing registry deletions (default: false)
 #
 #   NAME is the container name to assign.
 #
@@ -239,6 +240,7 @@ start_registry() {
     local testuser=
     local testpassword=
     local create_cert=
+    local enable_delete=false
 
     # option processing: recognize options for running the registry
     # in different modes.
@@ -250,6 +252,7 @@ start_registry() {
             --testuser=*)       testuser="$value";      shift;;
             --testpassword=*)   testpassword="$value";  shift;;
             --with-cert)        create_cert=1;          shift;;
+            --enable-delete=*)  enable_delete="$value"; shift;;
             -*)                 die "Invalid option '$opt'" ;;
             *)                  break;;
         esac
@@ -264,6 +267,9 @@ start_registry() {
     mkdir -p $AUTHDIR
 
     local -a reg_args=(-v $AUTHDIR:/auth:Z -p $port:5000)
+    if [[ "$enable_delete" == "true" ]]; then
+        reg_args+=( -e REGISTRY_STORAGE_DELETE_ENABLED=true)
+    fi
 
     # cgroup option necessary under podman-in-podman (CI tests),
     # and doesn't seem to do any harm otherwise.


### PR DESCRIPTION
[root@dhcp-14-124 skopeo]# bats systemtest/060-delete.bats 
 ✓ delete: remove image from registry

1 test, 0 failures

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>