### PR TITLE
Revert "Travis: use go 1.12.x"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ matrix:
        - docker
   -  os: osx
 
-go:
-        - 1.12.x
-
 notifications:
   email: false
 


### PR DESCRIPTION
This reverts commit d6270f4691e6f83179ebefe445a199ee756fe159.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>