### PR TITLE
ostree: use the correct build tags

### DIFF
--- a/hack/ostree_tag.sh
+++ b/hack/ostree_tag.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 if pkg-config ostree-1 2> /dev/null ; then
-	echo ostree
-else
-	echo containers_image_ostree_stub
+	echo containers_image_ostree
 fi


### PR DESCRIPTION
Starting from 9b902d0, the ostree transport is disabled by default,
and ostree is enabled with the tag containers_image_ostree.

/cc @vrothberg 