### PR TITLE
ostree: use both image and & storage buildtags

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -22,7 +22,7 @@ type globalOptions struct {
 	tlsVerify          optionalBool  // Require HTTPS and verify certificates (for docker: and docker-daemon:)
 	policyPath         string        // Path to a signature verification policy file
 	insecurePolicy     bool          // Use an "allow everything" signature verification policy
-	registriesDirPath  string        // Path to a "registries.d" registry configuratio directory
+	registriesDirPath  string        // Path to a "registries.d" registry configuration directory
 	overrideArch       string        // Architecture to use for choosing images, instead of the runtime one
 	overrideOS         string        // OS to use for choosing images, instead of the runtime one
 	commandTimeout     time.Duration // Timeout for the command execution

--- a/hack/ostree_tag.sh
+++ b/hack/ostree_tag.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
-if pkg-config ostree-1 2> /dev/null ; then
-	echo containers_image_ostree
+
+if test $(${GO:-go} env GOOS) != "linux" ; then
+	exit 0
+fi
+
+if pkg-config ostree-1 &> /dev/null ; then
+	# ostree: used by containers/storage
+	# containers_image_ostree: used by containers/image
+	echo "ostree containers_image_ostree"
 fi


### PR DESCRIPTION
    The PR #700 replaced ostree buildtag with containers_image_ostree.
    However specifying the ostree buildtag is needed by containers/storage
    vfs driver.
    
/cc @mtrmac @vrothberg 