### PR TITLE
Add a couple of tests for copying to/from containers-storage

### DIFF
--- a/integration/decompress-dirs.sh
+++ b/integration/decompress-dirs.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+# Account for differences between dir: images that are solely due to one being
+# compressed (fresh from a registry) and the other not being compressed (read
+# from storage, which decompressed it and had to reassemble the layer blobs).
+for dir in "$@" ; do
+    # Updating the manifest's blob digests may change the formatting, so
+    # use json_reformat to get them into similar shape.
+    json_reformat < "${dir}"/manifest.json > "${dir}"/manifest.json.tmp && mv "${dir}"/manifest.json.tmp "${dir}"/manifest.json
+    for candidate in "${dir}"/???????????????????????????????????????????????????????????????? ; do
+        # If a digest-identified file looks like it was compressed,
+        # decompress it, and replace its hash and size with the values
+        # after they're decompressed.
+        uncompressed=`zcat "${candidate}" 2> /dev/null | sha256sum | cut -c1-64`
+        if test $? -eq 0 ; then
+            if test "$uncompressed" != e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 ; then
+                zcat "${candidate}" > "${dir}"/${uncompressed}
+                sed -ri "s#`basename "${candidate}"`#${uncompressed}#g" "${dir}"/manifest.json
+                sed -ri "s#: `stat -c %s "${candidate}"`,#: `stat -c %s ${dir}/${uncompressed}`,#g" "${dir}"/manifest.json
+                rm -f "${candidate}"
+            fi
+        fi
+    done
+done

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -13,6 +13,7 @@ import (
 )
 
 const skopeoBinary = "skopeo"
+const decompressDirsBinary = "./decompress-dirs.sh"
 
 // consumeAndLogOutputStream takes (f, err) from an exec.*Pipe(), and causes all output to it to be logged to c.
 func consumeAndLogOutputStream(c *check.C, id string, f io.ReadCloser, err error) {
@@ -173,4 +174,15 @@ func fileFromFixture(c *check.C, inputPath string, edits map[string]string) stri
 	err = file.Close()
 	c.Assert(err, check.IsNil)
 	return path
+}
+
+// runDecompressDirs runs decompress-dirs.sh using exec.Command().CombinedOutput, verifies that the exit status is 0,
+// and optionally that the output matches a multi-line regexp if it is nonempty; or terminates c on failure
+func runDecompressDirs(c *check.C, regexp string, args ...string) {
+	c.Logf("Running %s %s", decompressDirsBinary, strings.Join(args, " "))
+	out, err := exec.Command(decompressDirsBinary, args...).CombinedOutput()
+	c.Assert(err, check.IsNil, check.Commentf("%s", out))
+	if regexp != "" {
+		c.Assert(string(out), check.Matches, "(?s)"+regexp) // (?s) : '.' will also match newlines
+	}
 }


### PR DESCRIPTION
Add a couple of tests to verify that we can copy an image into and then back out of containers-storage.  The contents of an image that has been copied out of containers-storage need a bit of tweaking to compensate for containers-storage's habit of returning uncompressed versions of the
layer blobs that were originally written to it, in order to be comparable to the image as it was when it was pulled from a registry.