### PR TITLE
Makefile: use go proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: all binary build-container docs docs-in-container build-local clean install install-binary install-completions shell test-integration .install.vndr vendor
 
+export GOPROXY=https://proxy.golang.org
+
 ifeq ($(shell uname),Darwin)
 PREFIX ?= ${DESTDIR}/usr/local
 DARWIN_BUILD_TAG=containers_image_ostree_stub


### PR DESCRIPTION
Use GOPROXY=https://proxy.golang.org to speed up fetching dependencies.
Setting it makes `make vendor` six times faster in my local env.

For details please refer to https://proxy.golang.org/.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>