### PR TITLE
systemtest: copy: docker->storage->oci-archive

### DIFF
--- a/systemtest/020-copy.bats
+++ b/systemtest/020-copy.bats
@@ -76,6 +76,15 @@ function setup() {
     grep '"org.opencontainers.image.ref.name":"withtag"' $dir2/index.json
 }
 
+# Registry -> storage -> oci-archive
+@test "copy: registry -> storage -> oci-archive" {
+    local alpine=docker.io/library/alpine:latest
+    local tmp=$TESTDIR/oci
+
+    run_skopeo copy docker://$alpine containers-storage:$alpine
+    run_skopeo copy containers-storage:$alpine oci-archive:$tmp
+}
+
 # This one seems unlikely to get fixed
 @test "copy: bug 651" {
     skip "Enable this once skopeo issue #651 has been fixed"


### PR DESCRIPTION
Add a systemtest coying an image from docker to storage and then to an
oci-archive.  There are other ways to trigger the same code paths, but
this one has caught a regression in c/image in libpod's.

Fixes: #734
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>