### PR TITLE
Don't critically fail on a 403 when listing tags

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -177,7 +177,9 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 			// some registries may decide to block the "list all tags" endpoint
 			// gracefully allow the inspect to continue in this case. Currently
 			// the IBM Bluemix container registry has this restriction.
-			if !strings.Contains(err.Error(), "401") {
+			// In addition, AWS ECR rejects it with 403 (Forbidden) if the "ecr:ListImages"
+			// action is not allowed.
+			if !strings.Contains(err.Error(), "401") && !strings.Contains(err.Error(), "403") {
 				return fmt.Errorf("Error determining repository tags: %v", err)
 			}
 			logrus.Warnf("Registry disallows tag list retrieval; skipping")


### PR DESCRIPTION
Per a report in https://github.com/containers/skopeo/issues/726 , it can happen if the user is not allowed the `ListImages` action on AWS ECR.

Should fix #726.