### PR TITLE
copy: add a --all/-a flag

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -24,7 +24,7 @@ type copyOptions struct {
 	signByFingerprint string          // Sign the image using a GPG key with the specified fingerprint
 	format            optionalString  // Force conversion of the image to a specified format
 	quiet             bool            // Suppress output information when copying images
-
+	all               bool            // Copy all of the images if the source is a list
 }
 
 func copyCmd(global *globalOptions) cli.Command {
@@ -61,6 +61,11 @@ func copyCmd(global *globalOptions) cli.Command {
 				Name:        "quiet, q",
 				Usage:       "Suppress output information when copying images",
 				Destination: &opts.quiet,
+			},
+			cli.BoolFlag{
+				Name:        "all, a",
+				Usage:       "Copy all images if SOURCE-IMAGE is a list",
+				Destination: &opts.all,
 			},
 			cli.BoolFlag{
 				Name:        "remove-signatures",
@@ -147,6 +152,10 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) error {
 	if opts.quiet {
 		stdout = nil
 	}
+	imageListSelection := copy.CopySystemImage
+	if opts.all {
+		imageListSelection = copy.CopyAllImages
+	}
 	_, err = copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{
 		RemoveSignatures:      opts.removeSignatures,
 		SignBy:                opts.signByFingerprint,
@@ -154,6 +163,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) error {
 		SourceCtx:             sourceCtx,
 		DestinationCtx:        destinationCtx,
 		ForceManifestMIMEType: manifestType,
+		ImageListSelection:    imageListSelection,
 	})
 	return err
 }

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -142,9 +142,9 @@ func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if err != nil {
 		return err
 	}
-	if err := dest.PutManifest(ctx, manifest); err != nil {
+	if err := dest.PutManifest(ctx, manifest, nil); err != nil {
 		return err
 	}
 
-	return dest.Commit(ctx)
+	return dest.Commit(ctx, image.UnparsedInstance(rawSource, nil))
 }

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -51,6 +51,7 @@ _skopeo_copy() {
     "
 
     local boolean_options="
+    --all
     --dest-compress
     --remove-signatures
     --src-no-creds

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -17,6 +17,12 @@ Uses the system's trust policy to validate images, rejects images not trusted by
 
 ## OPTIONS
 
+**--all**
+
+If _source-image_ refers to a list of images, instead of copying just the image which matches the current OS and
+architecture (subject to the use of the global --override-os and --override-arch options), attempt to copy all of
+the images in the list, and the list itself.
+
 **--authfile** _path_
 
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/containers/buildah v1.8.4
-	github.com/containers/image/v4 v4.0.1
+	github.com/containers/image/v4 v4.0.2-0.20191021195858-69340234bfc6
 	github.com/containers/storage v1.13.4
 	github.com/docker/docker v0.0.0-20180522102801-da99009bbb11
 	github.com/dsnet/compress v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/containers/buildah v1.8.4 h1:06c+UNeEWMa2wA1Z7muZ0ZqUzE91sDuZJbB0BiZa
 github.com/containers/buildah v1.8.4/go.mod h1:1CsiLJvyU+h+wOjnqJJOWuJCVcMxZOr5HN/gHGdzJxY=
 github.com/containers/image/v4 v4.0.1 h1:idNGHChj0Pyv3vLrxul2oSVMZLeFqpoq3CjLeVgapSQ=
 github.com/containers/image/v4 v4.0.1/go.mod h1:0ASJH1YgJiX/eqFZObqepgsvIA4XjCgpyfwn9pDGafA=
+github.com/containers/image/v4 v4.0.2-0.20191021195858-69340234bfc6 h1:sFL2cwC0xjphJHpa6DXhka2jTLGI5HwbnAUSAKFhg2M=
+github.com/containers/image/v4 v4.0.2-0.20191021195858-69340234bfc6/go.mod h1:0ASJH1YgJiX/eqFZObqepgsvIA4XjCgpyfwn9pDGafA=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/storage v1.13.4 h1:j0bBaJDKbUHtAW1MXPFnwXJtqcH+foWeuXK1YaBV5GA=

--- a/integration/decompress-dirs.sh
+++ b/integration/decompress-dirs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+# Account for differences between dir: images that are solely due to one being
+# compressed (fresh from a registry) and the other not being compressed (read
+# from storage, which decompressed it and had to reassemble the layer blobs).
+for dir in "$@" ; do
+    # Updating the manifest's blob digests may change the formatting, so
+    # use jq to get them into similar shape.
+    jq -M . "${dir}"/manifest.json > "${dir}"/manifest.json.tmp && mv "${dir}"/manifest.json.tmp "${dir}"/manifest.json
+    for candidate in "${dir}"/???????????????????????????????????????????????????????????????? ; do
+        # If a digest-identified file looks like it was compressed,
+        # decompress it, and replace its hash and size in the manifest
+        # with the values for their decompressed versions.
+        uncompressed=`zcat "${candidate}" 2> /dev/null | sha256sum | cut -c1-64`
+        if test $? -eq 0 ; then
+            if test "$uncompressed" != e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 ; then
+                zcat "${candidate}" > "${dir}"/${uncompressed}
+                sed -r -i -e "s#sha256:$(basename ${candidate})#sha256:${uncompressed}#g" "${dir}"/manifest.json
+                sed -r -i -e "s#\"size\": $(wc -c < ${candidate}),#\"size\": $(wc -c < ${dir}/${uncompressed}),#g" "${dir}"/manifest.json
+                rm -f "${candidate}"
+            fi
+        fi
+    done
+done

--- a/vendor/github.com/containers/image/v4/directory/directory_transport.go
+++ b/vendor/github.com/containers/image/v4/directory/directory_transport.go
@@ -166,18 +166,24 @@ func (ref dirReference) DeleteImage(ctx context.Context, sys *types.SystemContex
 }
 
 // manifestPath returns a path for the manifest within a directory using our conventions.
-func (ref dirReference) manifestPath() string {
+func (ref dirReference) manifestPath(instanceDigest *digest.Digest) string {
+	if instanceDigest != nil {
+		return filepath.Join(ref.path, instanceDigest.Encoded()+".manifest.json")
+	}
 	return filepath.Join(ref.path, "manifest.json")
 }
 
 // layerPath returns a path for a layer tarball within a directory using our conventions.
 func (ref dirReference) layerPath(digest digest.Digest) string {
 	// FIXME: Should we keep the digest identification?
-	return filepath.Join(ref.path, digest.Hex())
+	return filepath.Join(ref.path, digest.Encoded())
 }
 
 // signaturePath returns a path for a signature within a directory using our conventions.
-func (ref dirReference) signaturePath(index int) string {
+func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) string {
+	if instanceDigest != nil {
+		return filepath.Join(ref.path, fmt.Sprintf(instanceDigest.Encoded()+".signature-%d", index+1))
+	}
 	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1))
 }
 

--- a/vendor/github.com/containers/image/v4/docker/archive/dest.go
+++ b/vendor/github.com/containers/image/v4/docker/archive/dest.go
@@ -67,6 +67,6 @@ func (d *archiveImageDestination) Close() error {
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-func (d *archiveImageDestination) Commit(ctx context.Context) error {
+func (d *archiveImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	return d.Destination.Commit(ctx)
 }

--- a/vendor/github.com/containers/image/v4/docker/archive/src.go
+++ b/vendor/github.com/containers/image/v4/docker/archive/src.go
@@ -33,8 +33,3 @@ func newImageSource(ctx context.Context, ref archiveReference) (types.ImageSourc
 func (s *archiveImageSource) Reference() types.ImageReference {
 	return s.ref
 }
-
-// LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *archiveImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
-	return nil, nil
-}

--- a/vendor/github.com/containers/image/v4/docker/daemon/daemon_dest.go
+++ b/vendor/github.com/containers/image/v4/docker/daemon/daemon_dest.go
@@ -124,7 +124,7 @@ func (d *daemonImageDestination) Reference() types.ImageReference {
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-func (d *daemonImageDestination) Commit(ctx context.Context) error {
+func (d *daemonImageDestination) Commit(ctx context.Context, unparsedToplevel types.UnparsedImage) error {
 	logrus.Debugf("docker-daemon: Closing tar stream")
 	if err := d.Destination.Commit(ctx); err != nil {
 		return err

--- a/vendor/github.com/containers/image/v4/docker/daemon/daemon_src.go
+++ b/vendor/github.com/containers/image/v4/docker/daemon/daemon_src.go
@@ -55,8 +55,3 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonRef
 func (s *daemonImageSource) Reference() types.ImageReference {
 	return s.ref
 }
-
-// LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *daemonImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
-	return nil, nil
-}

--- a/vendor/github.com/containers/image/v4/docker/docker_image.go
+++ b/vendor/github.com/containers/image/v4/docker/docker_image.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -71,9 +70,8 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 			return nil, err
 		}
 		defer res.Body.Close()
-		if res.StatusCode != http.StatusOK {
-			// print url also
-			return nil, errors.Errorf("Invalid status code returned when fetching tags list %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
+		if err := httpResponseToError(res); err != nil {
+			return nil, err
 		}
 
 		var tagsHolder struct {

--- a/vendor/github.com/containers/image/v4/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/v4/docker/docker_image_dest.go
@@ -19,7 +19,7 @@ import (
 	"github.com/containers/image/v4/pkg/blobinfocache/none"
 	"github.com/containers/image/v4/types"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/distribution/registry/api/v2"
+	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -61,6 +61,8 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 	return []string{
 		imgspecv1.MediaTypeImageManifest,
 		manifest.DockerV2Schema2MediaType,
+		imgspecv1.MediaTypeImageIndex,
+		manifest.DockerV2ListMediaType,
 		manifest.DockerV2Schema1SignedMediaType,
 		manifest.DockerV2Schema1MediaType,
 	}
@@ -343,20 +345,47 @@ func (d *dockerImageDestination) TryReusingBlob(ctx context.Context, info types.
 }
 
 // PutManifest writes manifest to the destination.
+// When the primary manifest is a manifest list, if instanceDigest is nil, we're saving the list
+// itself, else instanceDigest contains a digest of the specific manifest instance to overwrite the
+// manifest for; when the primary manifest is not a manifest list, instanceDigest should always be nil.
 // FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 // If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
-func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte) error {
-	digest, err := manifest.Digest(m)
-	if err != nil {
-		return err
+func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, instanceDigest *digest.Digest) error {
+	refTail := ""
+	if instanceDigest != nil {
+		// If the instanceDigest is provided, then use it as the refTail, because the reference,
+		// whether it includes a tag or a digest, refers to the list as a whole, and not this
+		// particular instance.
+		refTail = instanceDigest.String()
+		// Double-check that the manifest we've been given matches the digest we've been given.
+		matches, err := manifest.MatchesDigest(m, *instanceDigest)
+		if err != nil {
+			return errors.Wrapf(err, "error digesting manifest in PutManifest")
+		}
+		if !matches {
+			manifestDigest, merr := manifest.Digest(m)
+			if merr != nil {
+				return errors.Wrapf(err, "Attempted to PutManifest using an explicitly specified digest (%q) that didn't match the manifest's digest (%v attempting to compute it)", instanceDigest.String(), merr)
+			}
+			return errors.Errorf("Attempted to PutManifest using an explicitly specified digest (%q) that didn't match the manifest's digest (%q)", instanceDigest.String(), manifestDigest.String())
+		}
+	} else {
+		// Compute the digest of the main manifest, or the list if it's a list, so that we
+		// have a digest value to use if we're asked to save a signature for the manifest.
+		digest, err := manifest.Digest(m)
+		if err != nil {
+			return err
+		}
+		d.manifestDigest = digest
+		// The refTail should be either a digest (which we expect to match the value we just
+		// computed) or a tag name.
+		refTail, err = d.ref.tagOrDigest()
+		if err != nil {
+			return err
+		}
 	}
-	d.manifestDigest = digest
 
-	refTail, err := d.ref.tagOrDigest()
-	if err != nil {
-		return err
-	}
 	path := fmt.Sprintf(manifestPath, reference.Path(d.ref.ref), refTail)
 
 	headers := map[string][]string{}
@@ -416,19 +445,30 @@ func isManifestInvalidError(err error) bool {
 	}
 }
 
-func (d *dockerImageDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
+// PutSignatures uploads a set of signatures to the relevant lookaside or API extension point.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to upload the signatures for (when
+// the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
+func (d *dockerImageDestination) PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
 	// Do not fail if we don’t really need to support signatures.
 	if len(signatures) == 0 {
 		return nil
 	}
+	if instanceDigest == nil {
+		if d.manifestDigest.String() == "" {
+			// This shouldn’t happen, ImageDestination users are required to call PutManifest before PutSignatures
+			return errors.Errorf("Unknown manifest digest, can't add signatures")
+		}
+		instanceDigest = &d.manifestDigest
+	}
+
 	if err := d.c.detectProperties(ctx); err != nil {
 		return err
 	}
 	switch {
 	case d.c.signatureBase != nil:
-		return d.putSignaturesToLookaside(signatures)
+		return d.putSignaturesToLookaside(signatures, instanceDigest)
 	case d.c.supportsSignatures:
-		return d.putSignaturesToAPIExtension(ctx, signatures)
+		return d.putSignaturesToAPIExtension(ctx, signatures, instanceDigest)
 	default:
 		return errors.Errorf("X-Registry-Supports-Signatures extension not supported, and lookaside is not configured")
 	}
@@ -436,7 +476,7 @@ func (d *dockerImageDestination) PutSignatures(ctx context.Context, signatures [
 
 // putSignaturesToLookaside implements PutSignatures() from the lookaside location configured in s.c.signatureBase,
 // which is not nil.
-func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte) error {
+func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte, instanceDigest *digest.Digest) error {
 	// FIXME? This overwrites files one at a time, definitely not atomic.
 	// A failure when updating signatures with a reordered copy could lose some of them.
 
@@ -445,14 +485,9 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte) e
 		return nil
 	}
 
-	if d.manifestDigest.String() == "" {
-		// This shouldn’t happen, ImageDestination users are required to call PutManifest before PutSignatures
-		return errors.Errorf("Unknown manifest digest, can't add signatures")
-	}
-
 	// NOTE: Keep this in sync with docs/signature-protocols.md!
 	for i, signature := range signatures {
-		url := signatureStorageURL(d.c.signatureBase, d.manifestDigest, i)
+		url := signatureStorageURL(d.c.signatureBase, *instanceDigest, i)
 		if url == nil {
 			return errors.Errorf("Internal error: signatureStorageURL with non-nil base returned nil")
 		}
@@ -467,7 +502,7 @@ func (d *dockerImageDestination) putSignaturesToLookaside(signatures [][]byte) e
 	// is enough for dockerImageSource to stop looking for other signatures, so that
 	// is sufficient.
 	for i := len(signatures); ; i++ {
-		url := signatureStorageURL(d.c.signatureBase, d.manifestDigest, i)
+		url := signatureStorageURL(d.c.signatureBase, *instanceDigest, i)
 		if url == nil {
 			return errors.Errorf("Internal error: signatureStorageURL with non-nil base returned nil")
 		}
@@ -527,22 +562,17 @@ func (c *dockerClient) deleteOneSignature(url *url.URL) (missing bool, err error
 }
 
 // putSignaturesToAPIExtension implements PutSignatures() using the X-Registry-Supports-Signatures API extension.
-func (d *dockerImageDestination) putSignaturesToAPIExtension(ctx context.Context, signatures [][]byte) error {
+func (d *dockerImageDestination) putSignaturesToAPIExtension(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error {
 	// Skip dealing with the manifest digest, or reading the old state, if not necessary.
 	if len(signatures) == 0 {
 		return nil
-	}
-
-	if d.manifestDigest.String() == "" {
-		// This shouldn’t happen, ImageDestination users are required to call PutManifest before PutSignatures
-		return errors.Errorf("Unknown manifest digest, can't add signatures")
 	}
 
 	// Because image signatures are a shared resource in Atomic Registry, the default upload
 	// always adds signatures.  Eventually we should also allow removing signatures,
 	// but the X-Registry-Supports-Signatures API extension does not support that yet.
 
-	existingSignatures, err := d.c.getExtensionsSignatures(ctx, d.ref, d.manifestDigest)
+	existingSignatures, err := d.c.getExtensionsSignatures(ctx, d.ref, *instanceDigest)
 	if err != nil {
 		return err
 	}
@@ -567,7 +597,7 @@ sigExists:
 			if err != nil || n != 16 {
 				return errors.Wrapf(err, "Error generating random signature len %d", n)
 			}
-			signatureName = fmt.Sprintf("%s@%032x", d.manifestDigest.String(), randBytes)
+			signatureName = fmt.Sprintf("%s@%032x", instanceDigest.String(), randBytes)
 			if _, ok := existingSigNames[signatureName]; !ok {
 				break
 			}
@@ -606,6 +636,6 @@ sigExists:
 // WARNING: This does not have any transactional semantics:
 // - Uploaded data MAY be visible to others before Commit() is called
 // - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-func (d *dockerImageDestination) Commit(ctx context.Context) error {
+func (d *dockerImageDestination) Commit(context.Context, types.UnparsedImage) error {
 	return nil
 }

--- a/vendor/github.com/containers/image/v4/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/v4/docker/docker_image_src.go
@@ -103,8 +103,15 @@ func (s *dockerImageSource) Close() error {
 	return nil
 }
 
-// LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *dockerImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer
+// blobsums that are listed in the image's manifest.  If values are returned, they should be used when using GetBlob()
+// to read the image's layers.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve BlobInfos for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (s *dockerImageSource) LayerInfosForCopy(context.Context, *digest.Digest) ([]types.BlobInfo, error) {
 	return nil, nil
 }
 
@@ -232,9 +239,8 @@ func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, ca
 	if err != nil {
 		return nil, 0, err
 	}
-	if res.StatusCode != http.StatusOK {
-		// print url also
-		return nil, 0, errors.Errorf("Invalid status code returned when fetching blob %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
+	if err := httpResponseToError(res); err != nil {
+		return nil, 0, err
 	}
 	cache.RecordKnownLocation(s.ref.Transport(), bicTransportScope(s.ref), info.Digest, newBICLocationReference(s.ref))
 	return res.Body, getBlobSize(res), nil

--- a/vendor/github.com/containers/image/v4/docker/errors.go
+++ b/vendor/github.com/containers/image/v4/docker/errors.go
@@ -1,0 +1,33 @@
+package docker
+
+import (
+	"errors"
+	"net/http"
+
+	perrors "github.com/pkg/errors"
+)
+
+var (
+	// ErrV1NotSupported is returned when we're trying to talk to a
+	// docker V1 registry.
+	ErrV1NotSupported = errors.New("can't talk to a V1 docker registry")
+	// ErrUnauthorizedForCredentials is returned when the status code returned is 401
+	ErrUnauthorizedForCredentials = errors.New("unable to retrieve auth token: invalid username/password")
+	// ErrTooManyRequests is returned when the status code returned is 429
+	ErrTooManyRequests = errors.New("too many request to registry")
+)
+
+// httpResponseToError translates the https.Response into an error. It returns
+// nil if the response is not considered an error.
+func httpResponseToError(res *http.Response) error {
+	switch res.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusTooManyRequests:
+		return ErrTooManyRequests
+	case http.StatusUnauthorized:
+		return ErrUnauthorizedForCredentials
+	default:
+		return perrors.Errorf("invalid status code from registry %d (%s)", res.StatusCode, http.StatusText(res.StatusCode))
+	}
+}

--- a/vendor/github.com/containers/image/v4/image/manifest.go
+++ b/vendor/github.com/containers/image/v4/image/manifest.go
@@ -58,6 +58,8 @@ func manifestInstanceFromBlob(ctx context.Context, sys *types.SystemContext, src
 		return manifestSchema2FromManifest(src, manblob)
 	case manifest.DockerV2ListMediaType:
 		return manifestSchema2FromManifestList(ctx, sys, src, manblob)
+	case imgspecv1.MediaTypeImageIndex:
+		return manifestOCI1FromImageIndex(ctx, sys, src, manblob)
 	default: // Note that this may not be reachable, manifest.NormalizedMIMEType has a default for unknown values.
 		return nil, fmt.Errorf("Unimplemented manifest MIME type %s", mt)
 	}

--- a/vendor/github.com/containers/image/v4/image/oci_index.go
+++ b/vendor/github.com/containers/image/v4/image/oci_index.go
@@ -8,12 +8,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func manifestSchema2FromManifestList(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
-	list, err := manifest.Schema2ListFromManifest(manblob)
+func manifestOCI1FromImageIndex(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
+	index, err := manifest.OCI1IndexFromManifest(manblob)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error parsing schema2 manifest list")
+		return nil, errors.Wrapf(err, "Error parsing OCI1 index")
 	}
-	targetManifestDigest, err := list.ChooseInstance(sys)
+	targetManifestDigest, err := index.ChooseInstance(sys)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error choosing image instance")
 	}

--- a/vendor/github.com/containers/image/v4/image/sourced.go
+++ b/vendor/github.com/containers/image/v4/image/sourced.go
@@ -100,5 +100,5 @@ func (i *sourcedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 }
 
 func (i *sourcedImage) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
-	return i.UnparsedImage.src.LayerInfosForCopy(ctx)
+	return i.UnparsedImage.src.LayerInfosForCopy(ctx, i.UnparsedImage.instanceDigest)
 }

--- a/vendor/github.com/containers/image/v4/manifest/docker_schema2_list.go
+++ b/vendor/github.com/containers/image/v4/manifest/docker_schema2_list.go
@@ -1,0 +1,216 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/containers/image/v4/types"
+	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// Schema2PlatformSpec describes the platform which a particular manifest is
+// specialized for.
+type Schema2PlatformSpec struct {
+	Architecture string   `json:"architecture"`
+	OS           string   `json:"os"`
+	OSVersion    string   `json:"os.version,omitempty"`
+	OSFeatures   []string `json:"os.features,omitempty"`
+	Variant      string   `json:"variant,omitempty"`
+	Features     []string `json:"features,omitempty"` // removed in OCI
+}
+
+// Schema2ManifestDescriptor references a platform-specific manifest.
+type Schema2ManifestDescriptor struct {
+	Schema2Descriptor
+	Platform Schema2PlatformSpec `json:"platform"`
+}
+
+// Schema2List is a list of platform-specific manifests.
+type Schema2List struct {
+	SchemaVersion int                         `json:"schemaVersion"`
+	MediaType     string                      `json:"mediaType"`
+	Manifests     []Schema2ManifestDescriptor `json:"manifests"`
+}
+
+// MIMEType returns the MIME type of this particular manifest list.
+func (list *Schema2List) MIMEType() string {
+	return list.MediaType
+}
+
+// Instances returns a slice of digests of the manifests that this list knows of.
+func (list *Schema2List) Instances() []digest.Digest {
+	results := make([]digest.Digest, len(list.Manifests))
+	for i, m := range list.Manifests {
+		results[i] = m.Digest
+	}
+	return results
+}
+
+// Instance returns the ListUpdate of a particular instance in the list.
+func (list *Schema2List) Instance(instanceDigest digest.Digest) (ListUpdate, error) {
+	for _, manifest := range list.Manifests {
+		if manifest.Digest == instanceDigest {
+			return ListUpdate{
+				Digest:    manifest.Digest,
+				Size:      manifest.Size,
+				MediaType: manifest.MediaType,
+			}, nil
+		}
+	}
+	return ListUpdate{}, errors.Errorf("unable to find instance %s passed to Schema2List.Instances", instanceDigest)
+}
+
+// UpdateInstances updates the sizes, digests, and media types of the manifests
+// which the list catalogs.
+func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
+	if len(updates) != len(list.Manifests) {
+		return errors.Errorf("incorrect number of update entries passed to Schema2List.UpdateInstances: expected %d, got %d", len(list.Manifests), len(updates))
+	}
+	for i := range updates {
+		if err := updates[i].Digest.Validate(); err != nil {
+			return errors.Wrapf(err, "update %d of %d passed to Schema2List.UpdateInstances contained an invalid digest", i+1, len(updates))
+		}
+		list.Manifests[i].Digest = updates[i].Digest
+		if updates[i].Size < 0 {
+			return errors.Errorf("update %d of %d passed to Schema2List.UpdateInstances had an invalid size (%d)", i+1, len(updates), updates[i].Size)
+		}
+		list.Manifests[i].Size = updates[i].Size
+		if updates[i].MediaType == "" {
+			return errors.Errorf("update %d of %d passed to Schema2List.UpdateInstances had no media type (was %q)", i+1, len(updates), list.Manifests[i].MediaType)
+		}
+		if err := SupportedSchema2MediaType(updates[i].MediaType); err != nil && SupportedOCI1MediaType(updates[i].MediaType) != nil {
+			return errors.Wrapf(err, "update %d of %d passed to Schema2List.UpdateInstances had an unsupported media type (was %q): %q", i+1, len(updates), list.Manifests[i].MediaType, updates[i].MediaType)
+		}
+		list.Manifests[i].MediaType = updates[i].MediaType
+	}
+	return nil
+}
+
+// ChooseInstance parses blob as a schema2 manifest list, and returns the digest
+// of the image which is appropriate for the current environment.
+func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
+	wantedArch := runtime.GOARCH
+	if ctx != nil && ctx.ArchitectureChoice != "" {
+		wantedArch = ctx.ArchitectureChoice
+	}
+	wantedOS := runtime.GOOS
+	if ctx != nil && ctx.OSChoice != "" {
+		wantedOS = ctx.OSChoice
+	}
+
+	for _, d := range list.Manifests {
+		if d.Platform.Architecture == wantedArch && d.Platform.OS == wantedOS {
+			return d.Digest, nil
+		}
+	}
+	return "", fmt.Errorf("no image found in manifest list for architecture %s, OS %s", wantedArch, wantedOS)
+}
+
+// Serialize returns the list in a blob format.
+// NOTE: Serialize() does not in general reproduce the original blob if this object was loaded from one, even if no modifications were made!
+func (list *Schema2List) Serialize() ([]byte, error) {
+	buf, err := json.Marshal(list)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error marshaling Schema2List %#v", list)
+	}
+	return buf, nil
+}
+
+// Schema2ListFromComponents creates a Schema2 manifest list instance from the
+// supplied data.
+func Schema2ListFromComponents(components []Schema2ManifestDescriptor) *Schema2List {
+	list := Schema2List{
+		SchemaVersion: 2,
+		MediaType:     DockerV2ListMediaType,
+		Manifests:     make([]Schema2ManifestDescriptor, len(components)),
+	}
+	for i, component := range components {
+		m := Schema2ManifestDescriptor{
+			Schema2Descriptor{
+				MediaType: component.MediaType,
+				Size:      component.Size,
+				Digest:    component.Digest,
+				URLs:      dupStringSlice(component.URLs),
+			},
+			Schema2PlatformSpec{
+				Architecture: component.Platform.Architecture,
+				OS:           component.Platform.OS,
+				OSVersion:    component.Platform.OSVersion,
+				OSFeatures:   dupStringSlice(component.Platform.OSFeatures),
+				Variant:      component.Platform.Variant,
+				Features:     dupStringSlice(component.Platform.Features),
+			},
+		}
+		list.Manifests[i] = m
+	}
+	return &list
+}
+
+// Schema2ListClone creates a deep copy of the passed-in list.
+func Schema2ListClone(list *Schema2List) *Schema2List {
+	return Schema2ListFromComponents(list.Manifests)
+}
+
+// ToOCI1Index returns the list encoded as an OCI1 index.
+func (list *Schema2List) ToOCI1Index() (*OCI1Index, error) {
+	components := make([]imgspecv1.Descriptor, 0, len(list.Manifests))
+	for _, manifest := range list.Manifests {
+		converted := imgspecv1.Descriptor{
+			MediaType: manifest.MediaType,
+			Size:      manifest.Size,
+			Digest:    manifest.Digest,
+			URLs:      dupStringSlice(manifest.URLs),
+			Platform: &imgspecv1.Platform{
+				OS:           manifest.Platform.OS,
+				Architecture: manifest.Platform.Architecture,
+				OSFeatures:   dupStringSlice(manifest.Platform.OSFeatures),
+				OSVersion:    manifest.Platform.OSVersion,
+				Variant:      manifest.Platform.Variant,
+			},
+		}
+		components = append(components, converted)
+	}
+	oci := OCI1IndexFromComponents(components, nil)
+	return oci, nil
+}
+
+// ToSchema2List returns the list encoded as a Schema2 list.
+func (list *Schema2List) ToSchema2List() (*Schema2List, error) {
+	return Schema2ListClone(list), nil
+}
+
+// Schema2ListFromManifest creates a Schema2 manifest list instance from marshalled
+// JSON, presumably generated by encoding a Schema2 manifest list.
+func Schema2ListFromManifest(manifest []byte) (*Schema2List, error) {
+	list := Schema2List{
+		Manifests: []Schema2ManifestDescriptor{},
+	}
+	if err := json.Unmarshal(manifest, &list); err != nil {
+		return nil, errors.Wrapf(err, "error unmarshaling Schema2List %q", string(manifest))
+	}
+	return &list, nil
+}
+
+// Clone returns a deep copy of this list and its contents.
+func (list *Schema2List) Clone() List {
+	return Schema2ListClone(list)
+}
+
+// ConvertToMIMEType converts the passed-in manifest list to a manifest
+// list of the specified type.
+func (list *Schema2List) ConvertToMIMEType(manifestMIMEType string) (List, error) {
+	switch normalized := NormalizedMIMEType(manifestMIMEType); normalized {
+	case DockerV2ListMediaType:
+		return list.Clone(), nil
+	case imgspecv1.MediaTypeImageIndex:
+		return list.ToOCI1Index()
+	case DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, imgspecv1.MediaTypeImageManifest, DockerV2Schema2MediaType:
+		return nil, fmt.Errorf("Can not convert manifest list to MIME type %q, which is not a list type", manifestMIMEType)
+	default:
+		// Note that this may not be reachable, NormalizedMIMEType has a default for unknown values.
+		return nil, fmt.Errorf("Unimplemented manifest list MIME type %s", manifestMIMEType)
+	}
+}

--- a/vendor/github.com/containers/image/v4/manifest/list.go
+++ b/vendor/github.com/containers/image/v4/manifest/list.go
@@ -1,0 +1,106 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/containers/image/v4/types"
+	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+var (
+	// SupportedListMIMETypes is a list of the manifest list types that we know how to
+	// read/manipulate/write.
+	SupportedListMIMETypes = []string{
+		DockerV2ListMediaType,
+		imgspecv1.MediaTypeImageIndex,
+	}
+)
+
+// List is an interface for parsing, modifying lists of image manifests.
+// Callers can either use this abstract interface without understanding the details of the formats,
+// or instantiate a specific implementation (e.g. manifest.OCI1Index) and access the public members
+// directly.
+type List interface {
+	// MIMEType returns the MIME type of this particular manifest list.
+	MIMEType() string
+
+	// Instances returns a list of the manifests that this list knows of, other than its own.
+	Instances() []digest.Digest
+
+	// Update information about the list's instances.  The length of the passed-in slice must
+	// match the length of the list of instances which the list already contains, and every field
+	// must be specified.
+	UpdateInstances([]ListUpdate) error
+
+	// Instance returns the size and MIME type of a particular instance in the list.
+	Instance(digest.Digest) (ListUpdate, error)
+
+	// ChooseInstance selects which manifest is most appropriate for the platform described by the
+	// SystemContext, or for the current platform if the SystemContext doesn't specify any details.
+	ChooseInstance(ctx *types.SystemContext) (digest.Digest, error)
+
+	// Serialize returns the list in a blob format.
+	// NOTE: Serialize() does not in general reproduce the original blob if this object was loaded
+	// from, even if no modifications were made!
+	Serialize() ([]byte, error)
+
+	// ConvertToMIMEType returns the list rebuilt to the specified MIME type, or an error.
+	ConvertToMIMEType(mimeType string) (List, error)
+
+	// Clone returns a deep copy of this list and its contents.
+	Clone() List
+}
+
+// ListUpdate includes the fields which a List's UpdateInstances() method will modify.
+type ListUpdate struct {
+	Digest    digest.Digest
+	Size      int64
+	MediaType string
+}
+
+// dupStringSlice returns a deep copy of a slice of strings, or nil if the
+// source slice is empty.
+func dupStringSlice(list []string) []string {
+	if len(list) == 0 {
+		return nil
+	}
+	dup := make([]string, len(list))
+	for i := range list {
+		dup[i] = list[i]
+	}
+	return dup
+}
+
+// dupStringStringMap returns a deep copy of a map[string]string, or nil if the
+// passed-in map is nil or has no keys.
+func dupStringStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	result := make(map[string]string)
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+// ListFromBlob parses a list of manifests.
+func ListFromBlob(manifest []byte, manifestMIMEType string) (List, error) {
+	normalized := NormalizedMIMEType(manifestMIMEType)
+	switch normalized {
+	case DockerV2ListMediaType:
+		return Schema2ListFromManifest(manifest)
+	case imgspecv1.MediaTypeImageIndex:
+		return OCI1IndexFromManifest(manifest)
+	case DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, imgspecv1.MediaTypeImageManifest, DockerV2Schema2MediaType:
+		return nil, fmt.Errorf("Treating single images as manifest lists is not implemented")
+	}
+	return nil, fmt.Errorf("Unimplemented manifest list MIME type %s (normalized as %s)", manifestMIMEType, normalized)
+}
+
+// ConvertListToMIMEType converts the passed-in manifest list to a manifest
+// list of the specified type.
+func ConvertListToMIMEType(list List, manifestMIMEType string) (List, error) {
+	return list.ConvertToMIMEType(manifestMIMEType)
+}

--- a/vendor/github.com/containers/image/v4/manifest/oci_index.go
+++ b/vendor/github.com/containers/image/v4/manifest/oci_index.go
@@ -1,0 +1,221 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/containers/image/v4/types"
+	"github.com/opencontainers/go-digest"
+	imgspec "github.com/opencontainers/image-spec/specs-go"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// OCI1Index is just an alias for the OCI index type, but one which we can
+// provide methods for.
+type OCI1Index struct {
+	imgspecv1.Index
+}
+
+// MIMEType returns the MIME type of this particular manifest index.
+func (index *OCI1Index) MIMEType() string {
+	return imgspecv1.MediaTypeImageIndex
+}
+
+// Instances returns a slice of digests of the manifests that this index knows of.
+func (index *OCI1Index) Instances() []digest.Digest {
+	results := make([]digest.Digest, len(index.Manifests))
+	for i, m := range index.Manifests {
+		results[i] = m.Digest
+	}
+	return results
+}
+
+// Instance returns the ListUpdate of a particular instance in the index.
+func (index *OCI1Index) Instance(instanceDigest digest.Digest) (ListUpdate, error) {
+	for _, manifest := range index.Manifests {
+		if manifest.Digest == instanceDigest {
+			return ListUpdate{
+				Digest:    manifest.Digest,
+				Size:      manifest.Size,
+				MediaType: manifest.MediaType,
+			}, nil
+		}
+	}
+	return ListUpdate{}, errors.Errorf("unable to find instance %s in OCI1Index", instanceDigest)
+}
+
+// UpdateInstances updates the sizes, digests, and media types of the manifests
+// which the list catalogs.
+func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
+	if len(updates) != len(index.Manifests) {
+		return errors.Errorf("incorrect number of update entries passed to OCI1Index.UpdateInstances: expected %d, got %d", len(index.Manifests), len(updates))
+	}
+	for i := range updates {
+		if err := updates[i].Digest.Validate(); err != nil {
+			return errors.Wrapf(err, "update %d of %d passed to OCI1Index.UpdateInstances contained an invalid digest", i+1, len(updates))
+		}
+		index.Manifests[i].Digest = updates[i].Digest
+		if updates[i].Size < 0 {
+			return errors.Errorf("update %d of %d passed to OCI1Index.UpdateInstances had an invalid size (%d)", i+1, len(updates), updates[i].Size)
+		}
+		index.Manifests[i].Size = updates[i].Size
+		if updates[i].MediaType == "" {
+			return errors.Errorf("update %d of %d passed to OCI1Index.UpdateInstances had no media type (was %q)", i+1, len(updates), index.Manifests[i].MediaType)
+		}
+		if err := SupportedOCI1MediaType(updates[i].MediaType); err != nil && SupportedSchema2MediaType(updates[i].MediaType) != nil && updates[i].MediaType != imgspecv1.MediaTypeImageIndex {
+			return errors.Wrapf(err, "update %d of %d passed to OCI1Index.UpdateInstances had an unsupported media type (was %q): %q", i+1, len(updates), index.Manifests[i].MediaType, updates[i].MediaType)
+		}
+		index.Manifests[i].MediaType = updates[i].MediaType
+	}
+	return nil
+}
+
+// ChooseInstance parses blob as an oci v1 manifest index, and returns the digest
+// of the image which is appropriate for the current environment.
+func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
+	wantedArch := runtime.GOARCH
+	if ctx != nil && ctx.ArchitectureChoice != "" {
+		wantedArch = ctx.ArchitectureChoice
+	}
+	wantedOS := runtime.GOOS
+	if ctx != nil && ctx.OSChoice != "" {
+		wantedOS = ctx.OSChoice
+	}
+
+	for _, d := range index.Manifests {
+		if d.Platform != nil && d.Platform.Architecture == wantedArch && d.Platform.OS == wantedOS {
+			return d.Digest, nil
+		}
+	}
+	for _, d := range index.Manifests {
+		if d.Platform == nil {
+			return d.Digest, nil
+		}
+	}
+	return "", fmt.Errorf("no image found in image index for architecture %s, OS %s", wantedArch, wantedOS)
+}
+
+// Serialize returns the index in a blob format.
+// NOTE: Serialize() does not in general reproduce the original blob if this object was loaded from one, even if no modifications were made!
+func (index *OCI1Index) Serialize() ([]byte, error) {
+	buf, err := json.Marshal(index)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error marshaling OCI1Index %#v", index)
+	}
+	return buf, nil
+}
+
+// OCI1IndexFromComponents creates an OCI1 image index instance from the
+// supplied data.
+func OCI1IndexFromComponents(components []imgspecv1.Descriptor, annotations map[string]string) *OCI1Index {
+	index := OCI1Index{
+		imgspecv1.Index{
+			Versioned:   imgspec.Versioned{SchemaVersion: 2},
+			Manifests:   make([]imgspecv1.Descriptor, len(components)),
+			Annotations: dupStringStringMap(annotations),
+		},
+	}
+	for i, component := range components {
+		var platform *imgspecv1.Platform
+		if component.Platform != nil {
+			platform = &imgspecv1.Platform{
+				Architecture: component.Platform.Architecture,
+				OS:           component.Platform.OS,
+				OSVersion:    component.Platform.OSVersion,
+				OSFeatures:   dupStringSlice(component.Platform.OSFeatures),
+				Variant:      component.Platform.Variant,
+			}
+		}
+		m := imgspecv1.Descriptor{
+			MediaType:   component.MediaType,
+			Size:        component.Size,
+			Digest:      component.Digest,
+			URLs:        dupStringSlice(component.URLs),
+			Annotations: dupStringStringMap(component.Annotations),
+			Platform:    platform,
+		}
+		index.Manifests[i] = m
+	}
+	return &index
+}
+
+// OCI1IndexClone creates a deep copy of the passed-in index.
+func OCI1IndexClone(index *OCI1Index) *OCI1Index {
+	return OCI1IndexFromComponents(index.Manifests, index.Annotations)
+}
+
+// ToOCI1Index returns the index encoded as an OCI1 index.
+func (index *OCI1Index) ToOCI1Index() (*OCI1Index, error) {
+	return OCI1IndexClone(index), nil
+}
+
+// ToSchema2List returns the index encoded as a Schema2 list.
+func (index *OCI1Index) ToSchema2List() (*Schema2List, error) {
+	components := make([]Schema2ManifestDescriptor, 0, len(index.Manifests))
+	for _, manifest := range index.Manifests {
+		platform := manifest.Platform
+		if platform == nil {
+			platform = &imgspecv1.Platform{
+				OS:           runtime.GOOS,
+				Architecture: runtime.GOARCH,
+			}
+		}
+		converted := Schema2ManifestDescriptor{
+			Schema2Descriptor{
+				MediaType: manifest.MediaType,
+				Size:      manifest.Size,
+				Digest:    manifest.Digest,
+				URLs:      dupStringSlice(manifest.URLs),
+			},
+			Schema2PlatformSpec{
+				OS:           platform.OS,
+				Architecture: platform.Architecture,
+				OSFeatures:   dupStringSlice(platform.OSFeatures),
+				OSVersion:    platform.OSVersion,
+				Variant:      platform.Variant,
+			},
+		}
+		components = append(components, converted)
+	}
+	s2 := Schema2ListFromComponents(components)
+	return s2, nil
+}
+
+// OCI1IndexFromManifest creates an OCI1 manifest index instance from marshalled
+// JSON, presumably generated by encoding a OCI1 manifest index.
+func OCI1IndexFromManifest(manifest []byte) (*OCI1Index, error) {
+	index := OCI1Index{
+		Index: imgspecv1.Index{
+			Versioned:   imgspec.Versioned{SchemaVersion: 2},
+			Manifests:   []imgspecv1.Descriptor{},
+			Annotations: make(map[string]string),
+		},
+	}
+	if err := json.Unmarshal(manifest, &index); err != nil {
+		return nil, errors.Wrapf(err, "error unmarshaling OCI1Index %q", string(manifest))
+	}
+	return &index, nil
+}
+
+// Clone returns a deep copy of this list and its contents.
+func (index *OCI1Index) Clone() List {
+	return OCI1IndexClone(index)
+}
+
+// ConvertToMIMEType converts the passed-in image index to a manifest list of
+// the specified type.
+func (index *OCI1Index) ConvertToMIMEType(manifestMIMEType string) (List, error) {
+	switch normalized := NormalizedMIMEType(manifestMIMEType); normalized {
+	case DockerV2ListMediaType:
+		return index.ToSchema2List()
+	case imgspecv1.MediaTypeImageIndex:
+		return index.Clone(), nil
+	case DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, imgspecv1.MediaTypeImageManifest, DockerV2Schema2MediaType:
+		return nil, fmt.Errorf("Can not convert image index to MIME type %q, which is not a list type", manifestMIMEType)
+	default:
+		// Note that this may not be reachable, NormalizedMIMEType has a default for unknown values.
+		return nil, fmt.Errorf("Unimplemented manifest MIME type %s", manifestMIMEType)
+	}
+}

--- a/vendor/github.com/containers/image/v4/oci/archive/oci_src.go
+++ b/vendor/github.com/containers/image/v4/oci/archive/oci_src.go
@@ -96,7 +96,14 @@ func (s *ociArchiveImageSource) GetSignatures(ctx context.Context, instanceDiges
 	return s.unpackedSrc.GetSignatures(ctx, instanceDigest)
 }
 
-// LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (s *ociArchiveImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
-	return nil, nil
+// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer
+// blobsums that are listed in the image's manifest.  If values are returned, they should be used when using GetBlob()
+// to read the image's layers.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve BlobInfos for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (s *ociArchiveImageSource) LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]types.BlobInfo, error) {
+	return s.unpackedSrc.LayerInfosForCopy(ctx, instanceDigest)
 }

--- a/vendor/github.com/containers/image/v4/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/v4/oci/layout/oci_transport.go
@@ -195,10 +195,10 @@ func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
 	} else {
 		// if image specified, look through all manifests for a match
 		for _, md := range index.Manifests {
-			if md.MediaType != imgspecv1.MediaTypeImageManifest {
+			if md.MediaType != imgspecv1.MediaTypeImageManifest && md.MediaType != imgspecv1.MediaTypeImageIndex {
 				continue
 			}
-			refName, ok := md.Annotations["org.opencontainers.image.ref.name"]
+			refName, ok := md.Annotations[imgspecv1.AnnotationRefName]
 			if !ok {
 				continue
 			}

--- a/vendor/github.com/containers/image/v4/storage/storage_transport.go
+++ b/vendor/github.com/containers/image/v4/storage/storage_transport.go
@@ -288,7 +288,7 @@ func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageRefe
 	}
 	if sref, ok := ref.(*storageReference); ok {
 		tmpRef := *sref
-		if img, err := tmpRef.resolveImage(); err == nil {
+		if img, err := tmpRef.resolveImage(&types.SystemContext{}); err == nil {
 			return img, nil
 		}
 	}

--- a/vendor/github.com/containers/image/v4/tarball/tarball_src.go
+++ b/vendor/github.com/containers/image/v4/tarball/tarball_src.go
@@ -248,9 +248,8 @@ func (is *tarballImageSource) GetManifest(ctx context.Context, instanceDigest *d
 }
 
 // GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
-// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
-// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
-// (e.g. if the source never returns manifest lists).
+// This source implementation does not support manifest lists, so the passed-in instanceDigest should always be nil,
+// as there can be no secondary manifests.
 func (*tarballImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
 	if instanceDigest != nil {
 		return nil, fmt.Errorf("manifest lists are not supported by the %q transport", transportName)
@@ -262,7 +261,14 @@ func (is *tarballImageSource) Reference() types.ImageReference {
 	return &is.reference
 }
 
-// LayerInfosForCopy() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
-func (*tarballImageSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer
+// blobsums that are listed in the image's manifest.  If values are returned, they should be used when using GetBlob()
+// to read the image's layers.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve BlobInfos for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+// The Digest field is guaranteed to be provided; Size may be -1.
+// WARNING: The list may contain duplicates, and they are semantically relevant.
+func (*tarballImageSource) LayerInfosForCopy(context.Context, *digest.Digest) ([]types.BlobInfo, error) {
 	return nil, nil
 }

--- a/vendor/github.com/containers/image/v4/types/types.go
+++ b/vendor/github.com/containers/image/v4/types/types.go
@@ -227,10 +227,15 @@ type ImageSource interface {
 	// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
 	// (e.g. if the source never returns manifest lists).
 	GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error)
-	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer blobsums that are listed in the image's manifest.
+	// LayerInfosForCopy returns either nil (meaning the values in the manifest are fine), or updated values for the layer
+	// blobsums that are listed in the image's manifest.  If values are returned, they should be used when using GetBlob()
+	// to read the image's layers.
+	// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve BlobInfos for
+	// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+	// (e.g. if the source never returns manifest lists).
 	// The Digest field is guaranteed to be provided; Size may be -1.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
-	LayerInfosForCopy(ctx context.Context) ([]BlobInfo, error)
+	LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]BlobInfo, error)
 }
 
 // ImageDestination is a service, possibly remote (= slow), to store components of a single image.
@@ -286,16 +291,24 @@ type ImageDestination interface {
 	// May use and/or update cache.
 	TryReusingBlob(ctx context.Context, info BlobInfo, cache BlobInfoCache, canSubstitute bool) (bool, BlobInfo, error)
 	// PutManifest writes manifest to the destination.
+	// If instanceDigest is not nil, it contains a digest of the specific manifest instance to write the manifest for
+	// (when the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
+	// It is expected but not enforced that the instanceDigest, when specified, matches the digest of `manifest` as generated
+	// by `manifest.Digest()`.
 	// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 	// If the destination is in principle available, refuses this manifest type (e.g. it does not recognize the schema),
 	// but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
-	PutManifest(ctx context.Context, manifest []byte) error
-	PutSignatures(ctx context.Context, signatures [][]byte) error
+	PutManifest(ctx context.Context, manifest []byte, instanceDigest *digest.Digest) error
+	// PutSignatures writes a set of signatures to the destination.
+	// If instanceDigest is not nil, it contains a digest of the specific manifest instance to write or overwrite the signatures for
+	// (when the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
+	// MUST be called after PutManifest (signatures may reference manifest contents).
+	PutSignatures(ctx context.Context, signatures [][]byte, instanceDigest *digest.Digest) error
 	// Commit marks the process of storing the image as successful and asks for the image to be persisted.
 	// WARNING: This does not have any transactional semantics:
 	// - Uploaded data MAY be visible to others before Commit() is called
 	// - Uploaded data MAY be removed or MAY remain around if Close() is called without Commit() (i.e. rollback is allowed but not guaranteed)
-	Commit(ctx context.Context) error
+	Commit(ctx context.Context, unparsedToplevel UnparsedImage) error
 }
 
 // ManifestTypeRejectedError is returned by ImageDestination.PutManifest if the destination is in principle available,
@@ -462,8 +475,15 @@ type SystemContext struct {
 	RegistriesDirPath string
 	// Path to the system-wide registries configuration file
 	SystemRegistriesConfPath string
-	// If not "", overrides the default path for the authentication file
+	// If not "", overrides the default path for the authentication file, but only new format files
 	AuthFilePath string
+	// if not "", overrides the default path for the authentication file, but with the legacy format;
+	// the code currently will by default look for legacy format files like .dockercfg in the $HOME dir;
+	// but in addition to the home dir, openshift may mount .dockercfg files (via secret mount)
+	// in locations other than the home dir; openshift components should then set this field in those cases;
+	// this field is ignored if `AuthFilePath` is set (we favor the newer format);
+	// only reading of this data is supported;
+	LegacyFormatAuthFilePath string
 	// If not "", overrides the use of platform.GOARCH when choosing an image or verifying architecture match.
 	ArchitectureChoice string
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.

--- a/vendor/github.com/containers/image/v4/version/version.go
+++ b/vendor/github.com/containers/image/v4/version/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -26,7 +26,7 @@ github.com/VividCortex/ewma
 github.com/containerd/continuity/pathdriver
 # github.com/containers/buildah v1.8.4
 github.com/containers/buildah/pkg/unshare
-# github.com/containers/image/v4 v4.0.1
+# github.com/containers/image/v4 v4.0.2-0.20191021195858-69340234bfc6
 github.com/containers/image/v4/copy
 github.com/containers/image/v4/directory
 github.com/containers/image/v4/docker


### PR DESCRIPTION
Add a `--all`/`-a` flag to instruct us to attempt to copy all of the instances in the source image, if the source image specified to `skopeo copy` is actually a list of images.  Previously, we'd just try to locate    one for our preferred OS/arch combination.

This vendors the branch from https://github.com/containers/image/pull/400 and a temporary workaround for https://github.com/containers/libpod/issues/4227, so it is not ready for merging in its current form.