### PR TITLE
System tests: various fixes

### DIFF
--- a/systemtest/020-copy.bats
+++ b/systemtest/020-copy.bats
@@ -45,7 +45,7 @@ function setup() {
 }
 
 # Compression zstd
-@test "copy: oci, round trip" {
+@test "copy: oci, round trip, zstd" {
     local remote_image=docker://busybox:latest
 
     local dir=$TESTDIR/dir


### PR DESCRIPTION
 - zstd test - give unique name.

   a36d81c copy/pasted an existing test but didn't give
   the new test a new name, leading to bats warning:
      duplicate test name(s) in [...]/020-copy.bats

 - start_registry() - use bash builtins, not curl, to test
   if registry port is open.

   curl on Fedora now barfs with "Received HTTP/0.9 when not
   allowed" when the registry is run with SSL, because the
   response is not valid HTTP. One workaround would be 'curl
   --http0.9' but (surprise) that option doesn't exist on rhel8;
   and even with that option we would need --output /dev/null
   to silence a different curl warning. Curl is overkill
   for this purpose anyway, all we really need is netcat
   or some simple binary is-port-listening-or-not test.
   Fortunately, bash provides a /dev/tcp/<host>/<port>
   emulator that does the right thing and works on Fedora
   as well as RHEL8.

 - new log_and_run() helper

   This is the noisiest yet least critical part of this PR.
   I'm sorry. It's motivated by my frustration in trying
   to reproduce the curl problem above: getting just the
   right incantation of openssl + podman-run cost me time.
   With this enhancement, important commands are logged
   as part of the output of failing tests, making it
   easy[*] for maintenance programmers to figure out a
   recipe for reproducing the failure.

     [*] "easy" as long as the test-writing developer
         uses log_and_run() wisely.

Signed-off-by: Ed Santiago <santiago@redhat.com>