### PR TITLE
Dockerfile: use golang-github-cpuguy83-go-md2man

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora
 
-RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-go-md2man \
+RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-md2man \
 	# storage deps
 	btrfs-progs-devel \
 	device-mapper-devel \


### PR DESCRIPTION
the package was renamed on Fedora 31.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>