### PR TITLE
make vendor-in-container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary build-container docs docs-in-container build-local clean install install-binary install-completions shell test-integration .install.vndr vendor
+.PHONY: all binary build-container docs docs-in-container build-local clean install install-binary install-completions shell test-integration .install.vndr vendor vendor-in-container
 
 export GOPROXY=https://proxy.golang.org
 
@@ -182,3 +182,6 @@ vendor:
 		$(GO) mod tidy && \
 		$(GO) mod vendor && \
 		$(GO) mod verify
+
+vendor-in-container:
+	podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.13 make vendor


### PR DESCRIPTION
Add a vendor-in-container make target to allow for executing make vendor
in a golang:1.13 container.  The CI is currently enforcing golang 1.13
which has a different vendoring behavior than previous versions which
can lead to failing tests as some files might be added or deleted.  The
new make target will help users who are not using 1.13 to vendor their
changes.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>