### PR TITLE
Add context to --encryption-key / --decryption-key processing failures

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -186,7 +186,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) error {
 		encryptionKeys := opts.encryptionKeys.Value()
 		ecc, err := enchelpers.CreateCryptoConfig(encryptionKeys, []string{})
 		if err != nil {
-			return err
+			return fmt.Errorf("Invalid encryption keys: %v", err)
 		}
 		cc := encconfig.CombineCryptoConfigs([]encconfig.CryptoConfig{ecc})
 		encConfig = cc.EncryptConfig
@@ -197,7 +197,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) error {
 		decryptionKeys := opts.decryptionKeys.Value()
 		dcc, err := enchelpers.CreateCryptoConfig([]string{}, decryptionKeys)
 		if err != nil {
-			return err
+			return fmt.Errorf("Invalid decryption keys: %v", err)
 		}
 		cc := encconfig.CombineCryptoConfigs([]encconfig.CryptoConfig{dcc})
 		decConfig = cc.DecryptConfig


### PR DESCRIPTION
... to avoid context-less errors like
```console
$ skopeo copy --decryption-key foo dir:x dir:y
FATA[0000] open foo: no such file or directory
$ skopeo copy --encryption-key /dev/null dir:x dir:y
FATA[0000] Invalid recipient format
```