### PR TITLE
add specific authfile options to copy (and sync) command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.1
 /layers-*
 /skopeo
+
+# ignore JetBrains IDEs (GoLand) config folder
+.idea

--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -54,6 +54,7 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 		"--override-os", "overridden-os",
 	}, []string{
 		"--authfile", "/srv/authfile",
+		"--dest-authfile", "/srv/dest-authfile",
 		"--dest-cert-dir", "/srv/cert-dir",
 		"--dest-shared-blob-dir", "/srv/shared-blob-dir",
 		"--dest-daemon-host", "daemon-host.example.com",
@@ -64,7 +65,7 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &types.SystemContext{
 		RegistriesDirPath:                 "/srv/registries.d",
-		AuthFilePath:                      "/srv/authfile",
+		AuthFilePath:                      "/srv/dest-authfile",
 		ArchitectureChoice:                "overridden-arch",
 		OSChoice:                          "overridden-os",
 		OCISharedBlobDirPath:              "/srv/shared-blob-dir",
@@ -179,4 +180,48 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 	opts = fakeImageDestOptions(t, "dest-", []string{}, []string{"--dest-creds", ""})
 	_, err = opts.newSystemContext()
 	assert.Error(t, err)
+}
+
+// since there is a shared authfile image option and a non-shared (prefixed) one, make sure the override logic
+// works correctly.
+func TestImageOptionsAuthfileOverride(t *testing.T) {
+
+	for _, testCase := range []struct {
+		flagPrefix           string
+		cmdFlags             []string
+		expectedAuthfilePath string
+	}{
+		// if there is no prefix, only authfile is allowed.
+		{"",
+			[]string{
+				"--authfile", "/srv/authfile",
+			}, "/srv/authfile"},
+		// if authfile and dest-authfile is provided, dest-authfile wins
+		{"dest-",
+			[]string{
+				"--authfile", "/srv/authfile",
+				"--dest-authfile", "/srv/dest-authfile",
+			}, "/srv/dest-authfile",
+		},
+		// if only the shared authfile is provided, authfile must be present in system context
+		{"dest-",
+			[]string{
+				"--authfile", "/srv/authfile",
+			}, "/srv/authfile",
+		},
+		// if only the dest authfile is provided, dest-authfile must be present in system context
+		{"dest-",
+			[]string{
+				"--dest-authfile", "/srv/dest-authfile",
+			}, "/srv/dest-authfile",
+		},
+	} {
+		opts := fakeImageOptions(t, testCase.flagPrefix, []string{}, testCase.cmdFlags)
+		res, err := opts.newSystemContext()
+		require.NoError(t, err)
+
+		assert.Equal(t, &types.SystemContext{
+			AuthFilePath: testCase.expectedAuthfilePath,
+		}, res)
+	}
 }

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -37,6 +37,8 @@ _skopeo_supported_transports() {
 _skopeo_copy() {
     local options_with_args="
     --authfile
+    --src-authfile
+    --dest-authfile
     --format -f
     --sign-by
     --src-creds --screds

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -28,6 +28,14 @@ the images in the list, and the list itself.
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
+**--src-authfile** _path_
+
+Path of the authentication file for the source registry. Uses path given by `--authfile`, if not provided.
+
+**--dest-authfile** _path_
+
+Path of the authentication file for the destination registry. Uses path given by `--authfile`, if not provided.
+
 **--format, -f** _manifest-type_ Manifest type (oci, v2s1, or v2s2) to use when saving image to directory using the 'dir:' transport (default is manifest type of source)
 
 **--quiet, -q** suppress output information when copying images

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -37,6 +37,14 @@ name can be stored at _destination_.
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
+**--src-authfile** _path_
+
+Path of the authentication file for the source registry. Uses path given by `--authfile`, if not provided.
+
+**--dest-authfile** _path_
+
+Path of the authentication file for the destination registry. Uses path given by `--authfile`, if not provided.
+
 **--src** _transport_ Transport for the source repository.
 
 **--dest** _transport_ Destination transport.


### PR DESCRIPTION
With additional prefixed flags for authfiles, it is possible to override the shared authfile flag to use different authfiles for src and dest registries. This is an important feature if the two registries have the same domain (but different paths) and require separate credentials.

Closes #773.

Signed-off-by: Daniel Strobusch <1847260+dastrobu@users.noreply.github.com>