### PR TITLE
Remove the reference to openshift/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/opencontainers/image-tools v0.0.0-20170926011501-6d941547fa1d
 	github.com/opencontainers/runtime-spec v1.0.0 // indirect
-	github.com/openshift/api v3.9.1-0.20190810003144-27fb16909b15+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday v2.0.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.4.2


### PR DESCRIPTION
This is another attempt to fix #791 after ineffective #802.

The referenced tag has been removed, which breaks dependabot (#791).

This is another attempt to fix it, by removing an explicit reference (which was added when updating Buildah, because the version seemed newer than Buildah's v0.0.0 with a newer commit).

The referenced package is never even physically vendored in here, so remove the reference:

> ```
> go mod edit -droprequire=github.com/openshift/api
> make vendor
> ```
