### PR TITLE
Partial image encryption support

### DIFF
--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -98,12 +98,12 @@ To copy and sign an image:
 
 To encrypt an image:
 ```sh
-skopeo copy docker://docker.io/library/nginx:latest oci:local_nginx:latest
+skopeo copy docker://docker.io/library/nginx:1.17.8 oci:local_nginx:1.17.8
 
 openssl genrsa -out private.key 1024
 openssl rsa -in private.key -pubout > public.key
 
-skopeo  copy --encryption-key jwe:./public.key oci:local_nginx:latest oci:try-encrypt:encrypted
+skopeo  copy --encryption-key jwe:./public.key oci:local_nginx:1.17.8 oci:try-encrypt:encrypted
 ```
 
 To decrypt an image:
@@ -120,6 +120,14 @@ To decrypt an image that requires more than one key:
 ```sh
 skopeo copy --decryption-key ./private1.key --decryption-key ./private2.key --decryption-key ./private3.key oci:try-encrypt:encrypted oci:try-decrypt:decrypted
 ```
+
+Container images can also be partially encrypted by specifying the index of the layer. Layers are 0-indexed indices, with support for negative indexing. i.e. 0 is the first layer, -1 is the last layer.
+
+Let's say out of 3 layers that the image `docker.io/library/nginx:1.17.8` is made up of, we only want to encrypt the 2nd layer,
+```sh
+skopeo  copy --encryption-key jwe:./public.key --encrypt-layer 1 oci:local_nginx:1.17.8 oci:try-encrypt:encrypted
+```
+
 ## SEE ALSO
 skopeo(1), podman-login(1), docker-login(1)
 


### PR DESCRIPTION
While https://github.com/containers/skopeo/pull/732 brought in image encryption support in skopeo, this PR adds the support for partial image encryption. 

User will be able to select which layer of the image they want to encrypt instead of encrypting an entire image. This is very useful from the layer reusability point of view. e.g. User can take a standard `ubuntu:18:04` image and add their custom layer which they will like to protect with the encryption. 
 When that image is saved in the snapshotter of the runtime, the layers that aren't encrypted end up getting reused which results in better disk space utilization as well as faster downloads (only have to download encrypted layers if the rest of the layers are already present in the snapshotter)

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>