### PR TITLE
Update to github.com/mtrmac/gpgme v0.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora
 
-RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-go-md2man \
+RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-md2man \
 	# storage deps
 	btrfs-progs-devel \
 	device-mapper-devel \

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/docker v0.0.0-20180522102801-da99009bbb11
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/go-check/check v0.0.0-20180628173108-788fd7840127
+	github.com/mtrmac/gpgme v0.1.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/opencontainers/image-tools v0.0.0-20170926011501-6d941547fa1d

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/mistifyio/go-zfs v2.1.1+incompatible h1:gAMO1HM9xBRONLHHYnu5iFsOJUiJd
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c h1:xa+eQWKuJ9MbB9FBL/eoNvDFvveAkz2LQoz8PzX7Q/4=
 github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c/go.mod h1:GhAqVMEWnTcW2dxoD/SO3n2enrgWl3y6Dnx4m59GvcA=
+github.com/mtrmac/gpgme v0.1.2 h1:dNOmvYmsrakgW7LcgiprD0yfRuQQe8/C8F6Z+zogO3s=
+github.com/mtrmac/gpgme v0.1.2/go.mod h1:GYYHnGSuS7HK3zVS2n3y73y0okK/BeKzwnn5jgiVFNI=
 github.com/mtrmac/image/v4 v4.0.0-20191002203927-a64d9d2717f4 h1:AE5cilZfrGtAgMg5Ed4c2Y2KczlOsMVZAK055sSq+gc=
 github.com/mtrmac/image/v4 v4.0.0-20191002203927-a64d9d2717f4/go.mod h1:0ASJH1YgJiX/eqFZObqepgsvIA4XjCgpyfwn9pDGafA=
 github.com/mtrmac/image/v4 v4.0.0-20191003181245-f4c983e93262 h1:HMUEnWU3OPT09JRFQLn8VTp3GfdfiEhDMAEhkdX8QnA=

--- a/systemtest/040-local-registry-auth.bats
+++ b/systemtest/040-local-registry-auth.bats
@@ -14,15 +14,6 @@ function setup() {
     mkdir -p $_cred_dir/containers
     rm -f $_cred_dir/containers/auth.json
 
-    # TODO: This is here to work around
-    # https://github.com/containers/libpod/issues/4227 in the
-    # "auth: credentials via podman login" test.
-    # It should be removed once a packaged version of podman which includes
-    # that fix is available in our CI environment, since we _want_ to be
-    # checking that podman and skopeo agree on the default for where registry
-    # credentials should be stored.
-    export REGISTRY_AUTH_FILE=$_cred_dir/containers/auth.json
-
     # Start authenticated registry with random password
     testuser=testuser
     testpassword=$(random_string 15)

--- a/vendor/github.com/mtrmac/gpgme/.appveyor.yml
+++ b/vendor/github.com/mtrmac/gpgme/.appveyor.yml
@@ -1,0 +1,40 @@
+---
+version: 0.{build}
+platform: x86
+branches:
+  only:
+    - master
+
+clone_folder: c:\gopath\src\github.com\proglottis\gpgme
+
+environment:   
+  GOPATH: c:\gopath
+  GOROOT: C:\go-x86
+  CGO_LDFLAGS: -LC:\gpg\lib
+  CGO_CFLAGS: -IC:\gpg\include
+  GPG_DIR: C:\gpg
+
+install:
+  - nuget install 7ZipCLI -ExcludeVersion
+  - set PATH=%appveyor_build_folder%\7ZipCLI\tools;%PATH%
+  - appveyor DownloadFile https://www.gnupg.org/ftp/gcrypt/binary/gnupg-w32-2.1.20_20170403.exe -FileName gnupg-w32-2.1.20_20170403.exe
+  - 7z x -o%GPG_DIR% gnupg-w32-2.1.20_20170403.exe
+  - copy "%GPG_DIR%\lib\libgpg-error.imp" "%GPG_DIR%\lib\libgpg-error.a"
+  - copy "%GPG_DIR%\lib\libassuan.imp" "%GPG_DIR%\lib\libassuan.a"
+  - copy "%GPG_DIR%\lib\libgpgme.imp" "%GPG_DIR%\lib\libgpgme.a"
+  - set PATH=%GOPATH%\bin;%GOROOT%\bin;%GPG_DIR%\bin;C:\MinGW\bin;%PATH%
+  - C:\cygwin\bin\sed -i 's/"GPG_AGENT_INFO"/"GPG_AGENT_INFO="/;s/C.unsetenv(v)/C.putenv(v)/' %APPVEYOR_BUILD_FOLDER%\gpgme.go
+
+test_script:
+  - go test -v github.com/proglottis/gpgme
+
+
+build_script:
+  - go build -o example_decrypt.exe -i %APPVEYOR_BUILD_FOLDER%\examples\decrypt.go
+  - go build -o example_encrypt.exe -i %APPVEYOR_BUILD_FOLDER%\examples\encrypt.go
+
+artifacts:
+  - path: example_decrypt.exe
+    name: decrypt example binary
+  - path: example_encrypt.exe
+    name: encrypt example binary

--- a/vendor/github.com/mtrmac/gpgme/.travis.yml
+++ b/vendor/github.com/mtrmac/gpgme/.travis.yml
@@ -1,0 +1,32 @@
+---
+language: go
+os:
+  - linux
+  - osx
+  - windows
+dist: xenial
+sudo: false
+
+go:
+  - 1.11
+  - 1.12
+  - 1.13
+
+addons:
+  apt:
+    packages:
+    - libgpgme11-dev
+  homebrew:
+    packages:
+    - gnupg
+    - gnupg@1.4
+    - gpgme
+    update: true
+
+matrix:
+  allow_failures:
+    - os: windows
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install msys2; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install gpg4win; fi

--- a/vendor/github.com/mtrmac/gpgme/data.go
+++ b/vendor/github.com/mtrmac/gpgme/data.go
@@ -50,25 +50,25 @@ func gogpgme_writefunc(handle, buffer unsafe.Pointer, size C.size_t) C.ssize_t {
 }
 
 //export gogpgme_seekfunc
-func gogpgme_seekfunc(handle unsafe.Pointer, offset C.off_t, whence C.int) C.off_t {
+func gogpgme_seekfunc(handle unsafe.Pointer, offset C.gpgme_off_t, whence C.int) C.gpgme_off_t {
 	d := callbackLookup(uintptr(handle)).(*Data)
 	n, err := d.s.Seek(int64(offset), int(whence))
 	if err != nil {
 		C.gpgme_err_set_errno(C.EIO)
 		return -1
 	}
-	return C.off_t(n)
+	return C.gpgme_off_t(n)
 }
 
 // The Data buffer used to communicate with GPGME
 type Data struct {
-	dh  C.gpgme_data_t
+	dh  C.gpgme_data_t // WARNING: Call runtime.KeepAlive(d) after ANY passing of d.dh to C
 	buf []byte
 	cbs C.struct_gpgme_data_cbs
 	r   io.Reader
 	w   io.Writer
 	s   io.Seeker
-	cbc uintptr
+	cbc uintptr // WARNING: Call runtime.KeepAlive(d) after ANY use of d.cbc in C (typically via d.dh)
 }
 
 func newData() *Data {
@@ -154,12 +154,14 @@ func (d *Data) Close() error {
 		callbackDelete(d.cbc)
 	}
 	_, err := C.gpgme_data_release(d.dh)
+	runtime.KeepAlive(d)
 	d.dh = nil
 	return err
 }
 
 func (d *Data) Write(p []byte) (int, error) {
 	n, err := C.gpgme_data_write(d.dh, unsafe.Pointer(&p[0]), C.size_t(len(p)))
+	runtime.KeepAlive(d)
 	if err != nil {
 		return 0, err
 	}
@@ -171,6 +173,7 @@ func (d *Data) Write(p []byte) (int, error) {
 
 func (d *Data) Read(p []byte) (int, error) {
 	n, err := C.gpgme_data_read(d.dh, unsafe.Pointer(&p[0]), C.size_t(len(p)))
+	runtime.KeepAlive(d)
 	if err != nil {
 		return 0, err
 	}
@@ -181,11 +184,14 @@ func (d *Data) Read(p []byte) (int, error) {
 }
 
 func (d *Data) Seek(offset int64, whence int) (int64, error) {
-	n, err := C.gpgme_data_seek(d.dh, C.off_t(offset), C.int(whence))
+	n, err := C.gogpgme_data_seek(d.dh, C.gpgme_off_t(offset), C.int(whence))
+	runtime.KeepAlive(d)
 	return int64(n), err
 }
 
 // Name returns the associated filename if any
 func (d *Data) Name() string {
-	return C.GoString(C.gpgme_data_get_file_name(d.dh))
+	res := C.GoString(C.gpgme_data_get_file_name(d.dh))
+	runtime.KeepAlive(d)
+	return res
 }

--- a/vendor/github.com/mtrmac/gpgme/go.mod
+++ b/vendor/github.com/mtrmac/gpgme/go.mod
@@ -1,0 +1,3 @@
+module github.com/mtrmac/gpgme
+
+go 1.11

--- a/vendor/github.com/mtrmac/gpgme/go_gpgme.c
+++ b/vendor/github.com/mtrmac/gpgme/go_gpgme.c
@@ -8,6 +8,28 @@ void gogpgme_set_passphrase_cb(gpgme_ctx_t ctx, gpgme_passphrase_cb_t cb, uintpt
 	gpgme_set_passphrase_cb(ctx, cb, (void *)handle);
 }
 
+gpgme_off_t gogpgme_data_seek(gpgme_data_t dh, gpgme_off_t offset, int whence) {
+	return gpgme_data_seek(dh, offset, whence);
+}
+
+gpgme_error_t gogpgme_op_assuan_transact_ext(
+		gpgme_ctx_t ctx,
+		char* cmd,
+		uintptr_t data_h,
+		uintptr_t inquiry_h,
+		uintptr_t status_h,
+		gpgme_error_t *operr
+	){
+	return gpgme_op_assuan_transact_ext(
+		ctx,
+		cmd,
+		(gpgme_assuan_data_cb_t)    gogpgme_assuan_data_callback,    (void *)data_h,
+		(gpgme_assuan_inquire_cb_t) gogpgme_assuan_inquiry_callback, (void *)inquiry_h,
+		(gpgme_assuan_status_cb_t)  gogpgme_assuan_status_callback,  (void *)status_h,
+		operr
+	);
+}
+
 unsigned int key_revoked(gpgme_key_t k) {
 	return k->revoked;
 }

--- a/vendor/github.com/mtrmac/gpgme/go_gpgme.h
+++ b/vendor/github.com/mtrmac/gpgme/go_gpgme.h
@@ -6,12 +6,24 @@
 
 #include <gpgme.h>
 
+/* GPGME_VERSION_NUMBER was introduced in 1.4.0 */
+#if !defined(GPGME_VERSION_NUMBER) || GPGME_VERSION_NUMBER < 0x010402
+typedef off_t gpgme_off_t; /* Introduced in 1.4.2 */
+#endif
+
 extern ssize_t gogpgme_readfunc(void *handle, void *buffer, size_t size);
 extern ssize_t gogpgme_writefunc(void *handle, void *buffer, size_t size);
 extern off_t gogpgme_seekfunc(void *handle, off_t offset, int whence);
 extern gpgme_error_t gogpgme_passfunc(void *hook, char *uid_hint, char *passphrase_info, int prev_was_bad, int fd);
 extern gpgme_error_t gogpgme_data_new_from_cbs(gpgme_data_t *dh, gpgme_data_cbs_t cbs, uintptr_t handle);
 extern void gogpgme_set_passphrase_cb(gpgme_ctx_t ctx, gpgme_passphrase_cb_t cb, uintptr_t handle);
+extern gpgme_off_t gogpgme_data_seek(gpgme_data_t dh, gpgme_off_t offset, int whence);
+
+extern gpgme_error_t gogpgme_op_assuan_transact_ext(gpgme_ctx_t ctx, char *cmd, uintptr_t data_h, uintptr_t inquiry_h , uintptr_t status_h, gpgme_error_t *operr);
+
+extern gpgme_error_t gogpgme_assuan_data_callback(void *opaque, void* data, size_t datalen );
+extern gpgme_error_t gogpgme_assuan_inquiry_callback(void *opaque, char* name, char* args);
+extern gpgme_error_t gogpgme_assuan_status_callback(void *opaque, char* status, char* args);
 
 extern unsigned int key_revoked(gpgme_key_t k);
 extern unsigned int key_expired(gpgme_key_t k);

--- a/vendor/github.com/mtrmac/gpgme/unset_agent_info.go
+++ b/vendor/github.com/mtrmac/gpgme/unset_agent_info.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package gpgme
+
+// #include <stdlib.h>
+import "C"
+import (
+	"unsafe"
+)
+
+// This is somewhat of a horrible hack. We need to unset GPG_AGENT_INFO so that gpgme does not pass --use-agent to GPG.
+// os.Unsetenv should be enough, but that only calls the underlying C library (which gpgme uses) if cgo is involved
+// - and cgo can't be used in tests. So, provide this helper for test initialization.
+func unsetenvGPGAgentInfo() {
+	v := C.CString("GPG_AGENT_INFO")
+	defer C.free(unsafe.Pointer(v))
+	C.unsetenv(v)
+}

--- a/vendor/github.com/mtrmac/gpgme/unset_agent_info_windows.go
+++ b/vendor/github.com/mtrmac/gpgme/unset_agent_info_windows.go
@@ -1,0 +1,14 @@
+package gpgme
+
+// #include <stdlib.h>
+import "C"
+import (
+	"unsafe"
+)
+
+// unsetenv is not available in mingw
+func unsetenvGPGAgentInfo() {
+	v := C.CString("GPG_AGENT_INFO=")
+	defer C.free(unsafe.Pointer(v))
+	C.putenv(v)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -189,7 +189,7 @@ github.com/mattn/go-isatty
 github.com/mattn/go-shellwords
 # github.com/mistifyio/go-zfs v2.1.1+incompatible
 github.com/mistifyio/go-zfs
-# github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c
+# github.com/mtrmac/gpgme v0.1.2
 github.com/mtrmac/gpgme
 # github.com/opencontainers/go-digest v1.0.0-rc1
 github.com/opencontainers/go-digest


### PR DESCRIPTION
This fixes CVE-2020-8945 by incorporating proglottis/gpgme#23 .

Other changes included by the rebase:
- Support for `gpgme_off_t` (~no-op on Linux)
- Wrapping a few more GPGME functions (irrelevant if we don't call them)

Given how invasive the CVE fix is (affecting basically all binding code), it seems safer to just update the package (and be verifiably equivalent with upstream) than to backport and try to back out the few other changes.

Performed by
```console
$ go get github.com/mtrmac/gpgme@v0.1.2
$ make vendor
```