### PR TITLE
add support for REGISTRY_AUTH_FILE

### DIFF
--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/containers/image/v5/pkg/compression"
@@ -44,7 +45,8 @@ func sharedImageFlags() ([]cli.Flag, *sharedImageOptions) {
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:        "authfile",
-			Usage:       "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+			Usage:       "path of the authentication file. Example: ${XDG_RUNTIME_DIR}/containers/auth.json",
+			Value:       os.Getenv("REGISTRY_AUTH_FILE"),
 			Destination: &opts.authFilePath,
 		},
 	}, &opts
@@ -94,7 +96,7 @@ func dockerImageFlags(global *globalOptions, shared *sharedImageOptions, flagPre
 		flags = append(flags,
 			cli.GenericFlag{
 				Name:  flagPrefix + "authfile",
-				Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
+				Usage: "path of the authentication file. Example: ${XDG_RUNTIME_DIR}/containers/auth.json",
 				Value: newOptionalStringValue(&opts.authFilePath),
 			},
 		)

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -28,6 +28,9 @@ the images in the list, and the list itself.
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
+Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
+environment variable. `export REGISTRY_AUTH_FILE=path`
+
 **--src-authfile** _path_
 
 Path of the authentication file for the source registry. Uses path given by `--authfile`, if not provided.


### PR DESCRIPTION
Fix cli to use REGISTRY_AUTH_FILE if set and to display the
default location to use for authfiles in the `skopeo copy --help`

Modify tests to verify the different settings.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>