### PR TITLE
build from ubuntu 19.10

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:19.10
 
 RUN apt-get update && apt-get install -y \
     golang \


### PR DESCRIPTION
Just bumping to ubuntu 19.10; ubuntu 18.10 is no longer supported, causing the current binary target to fail with errors

```sh
E: The repository 'http://security.ubuntu.com/ubuntu cosmic-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic-backports Release' does not have a Release file.
```

