### PR TITLE
Mention CentOS/RHEL in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,13 @@ you'll get an error. You can fix this by either logging in (via `docker login`) 
 
 Obtaining skopeo
 -
-`skopeo` may already be packaged in your distribution, for example on Fedora 23 and later you can install it using
+`skopeo` may already be packaged in your distribution, for example on RHEL/CentOS ≥ 8 or Fedora you can install it using
 ```sh
 $ sudo dnf install skopeo
+```
+on RHEL/CentOS ≤ 7.x:
+```sh
+$ sudo yum install skopeo
 ```
 for openSUSE:
 ```sh


### PR DESCRIPTION
apparently the Fedora reference is not obviously relevant.

(I didn’t add the same update for the local build instructions, because that requires more information about enabling non-default repositories, and especially RHEL users should get a chance to think for a bit before overriding a system package. This is not at all clear to be the right decision — anyway, filing a PR for the easy decision for now.)