### PR TITLE
CI: force Podman to use runc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-md2ma
 	gnupg \
 	# OpenShift deps
 	which tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute \
-        bats jq podman \
+        bats jq podman runc \
 	golint \
 	&& dnf clean all
 

--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -290,7 +290,7 @@ start_registry() {
 
     # cgroup option necessary under podman-in-podman (CI tests),
     # and doesn't seem to do any harm otherwise.
-    PODMAN="podman --cgroup-manager=cgroupfs"
+    PODMAN="podman --runtime runc --cgroup-manager=cgroupfs"
 
     # Called with --testuser? Create an htpasswd file
     if [[ -n $testuser ]]; then


### PR DESCRIPTION
crun had a regression running on cgroupsv1 in containers.  It has been
fixed upstream but did not yet bubble up into the packages.  Force using
runc to unblock Skopeo's CI.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>