### PR TITLE
Use fully-qualified image names

### DIFF
--- a/systemtest/010-inspect.bats
+++ b/systemtest/010-inspect.bats
@@ -73,7 +73,7 @@ END_EXPECT
     #    1) Get remote image values of environment variables (the value of 'Env')
     #    2) Confirm substring in check_array and the value of 'Env' match.
     check_array=(PATH=.* )
-    remote=$(echo "$inspect_remote" | jq '.Env[]')
+    remote=$(jq '.Env[]' <<<"$inspect_remote")
     for substr in ${check_array[@]}; do
         expect_output --from="$remote" --substring "$substr"
     done
@@ -106,10 +106,8 @@ END_EXPECT
     for arch in $diff_arch_list; do
         remote_image=docker://docker.io/$arch/golang
         run_skopeo inspect --tls-verify=false --raw $remote_image
-        remote=$(echo "$output" | jq -r '.manifests[0]["platform"]')
-        expect=$(echo "{\"architecture\":\"$arch\",\"os\":\"linux\"}" | jq)
-        expect_output --from="$remote" --substring "$expect" \
-                  "platform arch is not expected"
+        remote_arch=$(jq -r '.manifests[0]["platform"]["architecture"]' <<< "$output")
+        expect_output --from="$remote_arch" "$arch" "platform arch of $remote_image"
     done
 }
 

--- a/systemtest/020-copy.bats
+++ b/systemtest/020-copy.bats
@@ -14,7 +14,7 @@ function setup() {
 # From remote, to dir1, to local, to dir2;
 # compare dir1 and dir2, expect no changes
 @test "copy: dir, round trip" {
-    local remote_image=docker://busybox:latest
+    local remote_image=docker://docker.io/library/busybox:latest
     local localimg=docker://localhost:5000/busybox:unsigned
 
     local dir1=$TESTDIR/dir1
@@ -30,7 +30,7 @@ function setup() {
 
 # Same as above, but using 'oci:' instead of 'dir:' and with a :latest tag
 @test "copy: oci, round trip" {
-    local remote_image=docker://busybox:latest
+    local remote_image=docker://docker.io/library/busybox:latest
     local localimg=docker://localhost:5000/busybox:unsigned
 
     local dir1=$TESTDIR/oci1
@@ -46,7 +46,7 @@ function setup() {
 
 # Compression zstd
 @test "copy: oci, round trip, zstd" {
-    local remote_image=docker://busybox:latest
+    local remote_image=docker://docker.io/library/busybox:latest
 
     local dir=$TESTDIR/dir
 
@@ -61,7 +61,7 @@ function setup() {
 
 # Same image, extracted once with :tag and once without
 @test "copy: oci w/ and w/o tags" {
-    local remote_image=docker://busybox:latest
+    local remote_image=docker://docker.io/library/busybox:latest
 
     local dir1=$TESTDIR/dir1
     local dir2=$TESTDIR/dir2

--- a/systemtest/030-local-registry-tls.bats
+++ b/systemtest/030-local-registry-tls.bats
@@ -14,7 +14,7 @@ function setup() {
 @test "local registry, with cert" {
     # Push to local registry...
     run_skopeo copy --dest-cert-dir=$TESTDIR/client-auth \
-               docker://busybox:latest \
+               docker://docker.io/library/busybox:latest \
                docker://localhost:5000/busybox:unsigned
 
     # ...and pull it back out

--- a/systemtest/040-local-registry-auth.bats
+++ b/systemtest/040-local-registry-auth.bats
@@ -43,7 +43,8 @@ function setup() {
 
     # These should pass
     run_skopeo copy --dest-tls-verify=false --dcreds=$testuser:$testpassword \
-               docker://busybox:latest docker://localhost:5000/busybox:mine
+               docker://docker.io/library/busybox:latest \
+               docker://localhost:5000/busybox:mine
     run_skopeo inspect --tls-verify=false --creds=$testuser:$testpassword \
                docker://localhost:5000/busybox:mine
     expect_output --substring "localhost:5000/busybox"
@@ -54,7 +55,8 @@ function setup() {
     podman login --tls-verify=false -u $testuser -p $testpassword localhost:5000
 
     run_skopeo copy --dest-tls-verify=false \
-               docker://busybox:latest docker://localhost:5000/busybox:mine
+               docker://docker.io/library/busybox:latest \
+               docker://localhost:5000/busybox:mine
     run_skopeo inspect --tls-verify=false docker://localhost:5000/busybox:mine
     expect_output --substring "localhost:5000/busybox"
 

--- a/systemtest/050-signing.bats
+++ b/systemtest/050-signing.bats
@@ -92,7 +92,8 @@ END_POLICY_JSON
     fi
 
     # Cache local copy
-    run_skopeo copy docker://busybox:latest dir:$TESTDIR/busybox
+    run_skopeo copy docker://docker.io/library/busybox:latest \
+               dir:$TESTDIR/busybox
 
     # Push a bunch of images. Do so *without* --policy flag; this lets us
     # sign or not, creating images that will or won't conform to policy.

--- a/systemtest/060-delete.bats
+++ b/systemtest/060-delete.bats
@@ -13,7 +13,7 @@ function setup() {
 
 # delete image from registry
 @test "delete: remove image from registry" {
-    local remote_image=docker://busybox:latest
+    local remote_image=docker://docker.io/library/busybox:latest
     local localimg=docker://localhost:5000/busybox:unsigned
     local output=
 

--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -5,6 +5,9 @@ SKOPEO_BINARY=${SKOPEO_BINARY:-$(dirname ${BASH_SOURCE})/../skopeo}
 # Default timeout for a skopeo command.
 SKOPEO_TIMEOUT=${SKOPEO_TIMEOUT:-300}
 
+# Default image to run as a local registry
+REGISTRY_FQIN=${SKOPEO_TEST_REGISTRY_FQIN:-docker.io/library/registry:2}
+
 ###############################################################################
 # BEGIN setup/teardown
 
@@ -299,7 +302,7 @@ start_registry() {
         fi
 
         if ! egrep -q "^$testuser:" $AUTHDIR/htpasswd; then
-            log_and_run $PODMAN run --rm --entrypoint htpasswd registry:2 \
+            log_and_run $PODMAN run --rm --entrypoint htpasswd $REGISTRY_FQIN \
                    -Bbn $testuser $testpassword >> $AUTHDIR/htpasswd
         fi
 
@@ -332,7 +335,7 @@ start_registry() {
         log_and_run cp $CERT $TESTDIR/client-auth/
     fi
 
-    log_and_run $PODMAN run -d --name $name "${reg_args[@]}" registry:2
+    log_and_run $PODMAN run -d --name $name "${reg_args[@]}" $REGISTRY_FQIN
 
     # Wait for registry to actually come up
     timeout=10


### PR DESCRIPTION
Replace shortnames with FQINs; this should allow tests to
run regardless of the state of registries.conf.

And, fix one broken new test that invoked 'jq' (without dot).
This usage works in Fedora, but not in RHEL.

Signed-off-by: Ed Santiago <santiago@redhat.com>