### PR TITLE
Skopeo should support for BigFilesTemporaryDir (SystemContext)

### DIFF
--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -158,6 +158,7 @@ func (opts *imageOptions) newSystemContext() (*types.SystemContext, error) {
 		DockerDaemonHost:         opts.dockerDaemonHost,
 		DockerDaemonCertPath:     opts.dockerCertPath,
 		SystemRegistriesConfPath: opts.global.registriesConfPath,
+		BigFilesTemporaryDir:     opts.global.tmpDir,
 	}
 	if opts.dockerImageOptions.authFilePath.present {
 		ctx.AuthFilePath = opts.dockerImageOptions.authFilePath.value

--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -54,6 +54,7 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 		"--override-arch", "overridden-arch",
 		"--override-os", "overridden-os",
 		"--override-variant", "overridden-variant",
+		"--tmpdir", "/srv",
 	}, []string{
 		"--authfile", "/srv/authfile",
 		"--dest-authfile", "/srv/dest-authfile",
@@ -78,6 +79,7 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 		DockerDaemonCertPath:              "/srv/cert-dir",
 		DockerDaemonHost:                  "daemon-host.example.com",
 		DockerDaemonInsecureSkipTLSVerify: true,
+		BigFilesTemporaryDir:              "/srv",
 	}, res)
 
 	// Global/per-command tlsVerify behavior
@@ -166,6 +168,7 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 		"--override-arch", "overridden-arch",
 		"--override-os", "overridden-os",
 		"--override-variant", "overridden-variant",
+		"--tmpdir", "/srv",
 	}, []string{
 		"--authfile", "/srv/authfile",
 		"--dest-cert-dir", "/srv/cert-dir",
@@ -191,6 +194,7 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 		DockerDaemonHost:                  "daemon-host.example.com",
 		DockerDaemonInsecureSkipTLSVerify: true,
 		DirForceCompress:                  true,
+		BigFilesTemporaryDir:              "/srv",
 	}, res)
 
 	// Invalid option values in imageOptions

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -168,6 +168,7 @@ _skopeo_skopeo() {
        --override-os
        --override-variant
        --command-timeout
+       --tmpdir
      "
      local boolean_options="
        --insecure-policy

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -46,13 +46,13 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
 ## OPTIONS
 
+  **--command-timeout** _duration_ Timeout for the command execution.
+
   **--debug** enable debug output
 
-  **--policy** _path-to-policy_ Path to a policy.json file to use for verifying signatures and deciding whether an image is trusted, overriding the default trust policy file.
+  **--help**|**-h** Show help
 
   **--insecure-policy** Adopt an insecure, permissive policy that allows anything. This obviates the need for a policy file.
-
-  **--registries.d** _dir_ use registry configuration files in _dir_ (e.g. for container signature storage), overriding the default path.
 
   **--override-arch** _arch_ Use _arch_ instead of the architecture of the machine for choosing images.
 
@@ -60,9 +60,11 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
   **--override-variant** _VARIANT_ Use _VARIANT_ instead of the running architecture variant for choosing images.
 
-  **--command-timeout** _duration_ Timeout for the command execution.
+  **--policy** _path-to-policy_ Path to a policy.json file to use for verifying signatures and deciding whether an image is trusted, overriding the default trust policy file.
 
-  **--help**|**-h** Show help
+  **--registries.d** _dir_ use registry configuration files in _dir_ (e.g. for container signature storage), overriding the default path.
+
+  **--tmpdir:**_dir_ _dir_ used to store temporary files. Defaults to /var/tmp.
 
   **--version**|**-v** print the version number
 
@@ -73,11 +75,11 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 | [skopeo-copy(1)](skopeo-copy.1.md)        | Copy an image (manifest, filesystem layers, signatures) from one location to another. |
 | [skopeo-delete(1)](skopeo-delete.1.md)    | Mark image-name for deletion.                                                  |
 | [skopeo-inspect(1)](skopeo-inspect.1.md)  | Return low-level information about image-name in a registry.                   |
+| [skopeo-list-tags(1)](skopeo-list-tags.1.md)  | List the tags for the given transport/repository.                           |
 | [skopeo-manifest-digest(1)](skopeo-manifest-digest.1.md)    | Compute a manifest digest of manifest-file and write it to standard output.|
 | [skopeo-standalone-sign(1)](skopeo-standalone-sign.1.md)    | Sign an image.                                               |
 | [skopeo-standalone-verify(1)](skopeo-standalone-verify.1.md)| Verify an image.                                             |
 | [skopeo-sync(1)](skopeo-sync.1.md)| Copy images from one or more repositories to a user specified destination.             |
-| [skopeo-list-tags(1)](skopeo-list-tags.1.md)  | List the tags for the given transport/repository.                           |
 
 ## FILES
   **/etc/containers/policy.json**

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -64,7 +64,7 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
   **--registries.d** _dir_ use registry configuration files in _dir_ (e.g. for container signature storage), overriding the default path.
 
-  **--tmpdir:**_dir_ _dir_ used to store temporary files. Defaults to /var/tmp.
+  **--tmpdir** _dir_ used to store temporary files. Defaults to /var/tmp.
 
   **--version**|**-v** print the version number
 


### PR DESCRIPTION
Enhancement request: https://github.com/containers/skopeo/issues/805

Also sorted commands and options on skopeo man page and skopeo --help

Originally submitted by  Michel Belleau <michel.belleau@malaiwah.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>