### PR TITLE
Bump to v0.2.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.2.0"
+const Version = "0.2.0-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.42-dev"
+const Version = "0.2.0"


### PR DESCRIPTION
    Update on #834: force runc only when cgroupsv1
    Update docs/skopeo.1.md
    Add example with repository
    Skopeo should support for BigFilesTemporaryDir (SystemContext)
    Use fully-qualified image names
    Mention CentOS/RHEL in installation instructions
    bump to a supported ubuntu release
    add support for REGISTRY_AUTH_FILE
    Partial image encryption support
    Fix wrong import of docker reference
    Fix inconsistency in manpage example for list-tags
    Fix formatting on test
    Adds "list-tags" command to list tags with no known tag required. Fixes #276
