### PR TITLE
Fix (make vendor)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,9 @@ test-unit-local:
 	$(GPGME_ENV) $(GO) test $(MOD_VENDOR) -tags "$(BUILDTAGS)" $$($(GO) list $(MOD_VENDOR) -tags "$(BUILDTAGS)" -e ./... | grep -v '^github\.com/containers/skopeo/\(integration\|vendor/.*\)$$')
 
 vendor:
-	export GO111MODULE=on \
-		$(GO) mod vendor && \
-		$(GO) mod tidy && \
-		$(GO) mod verify
+	$(GO) mod vendor
+	$(GO) mod tidy
+	$(GO) mod verify
 
 vendor-in-container:
 	podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.13 make vendor


### PR DESCRIPTION
`(export a=b command args)` does not run `(command args)` with `a=b`, it sets `$a` to `b`, and marks variables `$a` `$command` `$args` as exported, i.e. `(command args)` is not run.

So, before https://github.com/containers/skopeo/pull/888 we were not actually running `(go mod tidy)`, and now we are not running `(go mod vendor)`.

Just use `$(GO)`, which already sets `GO111MODULE=on`, without the extra export.
