### PR TITLE
Run (go mod tidy) before (go mod vendor)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,8 +184,8 @@ test-unit-local:
 	$(GPGME_ENV) $(GO) test $(MOD_VENDOR) -tags "$(BUILDTAGS)" $$($(GO) list $(MOD_VENDOR) -tags "$(BUILDTAGS)" -e ./... | grep -v '^github\.com/containers/skopeo/\(integration\|vendor/.*\)$$')
 
 vendor:
-	$(GO) mod vendor
 	$(GO) mod tidy
+	$(GO) mod vendor
 	$(GO) mod verify
 
 vendor-in-container:


### PR DESCRIPTION
This is conceptually consistent: First change the set of dependencies, then update the vendored copy.
(Due to `go mod verify` afterwards, and CI running this again, this should not make a difference in practice, so this is just a clean-up.)
