### PR TITLE
Fix for yet another breaking podman change

### DIFF
--- a/systemtest/010-inspect.bats
+++ b/systemtest/010-inspect.bats
@@ -87,7 +87,16 @@ END_EXPECT
     #    1) Get current platform arch
     #    2) Inspect container image is different from current platform arch
     #    3) Compare output w/ expected result
-    arch=$(podman info --format '{{.host.arch}}')
+
+    # Here we see a revolting workaround for a podman incompatibility
+    # change: in April 2020, podman info completely changed format
+    # of the keys. What worked until then now throws an error. We
+    # need to work with both old and new podman.
+    arch=$(podman info --format '{{.host.arch}}' || true)
+    if [[ -z "$arch" ]]; then
+        arch=$(podman info --format '{{.Host.Arch}}')
+    fi
+
     case $arch in
         "amd64")
             diff_arch_list="s390x ppc64le"


### PR DESCRIPTION
'podman info' changed format, again, without preserving backward
compatibility. Basically, some keys that used to be lower-case
are now upper-case-first-letter.

These tests need to work with new podman on rawhide, and
old podman on f31/f32 and possibly RHEL. We must therefore
add a revolting workaround for the change.

Signed-off-by: Ed Santiago <santiago@redhat.com>