### PR TITLE
Add Skopeo Stable Image Dockerfile for Quay

### DIFF
--- a/contrib/skopeoimage/stable/Dockerfile
+++ b/contrib/skopeoimage/stable/Dockerfile
@@ -1,0 +1,33 @@
+# stable/Dockerfile
+#
+# Build a Skopeo container image from the latest
+# stable version of Skopeo on the Fedoras Updates System.
+# https://bodhi.fedoraproject.org/updates/?search=skopeo
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+#
+FROM registry.fedoraproject.org/fedora:32
+
+# Don't include container-selinux and remove
+# directories used by yum that are just taking
+# up space.  Also reinstall shadow-utils as without
+# doing so, the setuid/setgid bits on newuidmap
+# and newgidmap are lost in the Fedora images. 
+RUN useradd skopeo; yum -y update; yum -y reinstall shadow-utils; yum -y install skopeo fuse-overlayfs --exclude container-selinux; yum clean all; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+
+# Setup the ability to use additional stores
+# with this container image.
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Setup skopeo's uid/guid entries
+RUN echo skopeo:100000:65536 > /etc/subuid
+RUN echo skopeo:100000:65536 > /etc/subgid
+
+# Point to the Authorization file
+ENV REGISTRY_AUTH_FILE=/auth.json
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/bin/skopeo"]


### PR DESCRIPTION
Adds the Dockerfile for building the Skopeo container
image on quay.io.  Once merged, this image will be
built automatically upon any merge into the master
branch.  The images will live at:
quay.io/containers/skopeo:latest
quay.io/skopeo/stable:latest

I've built an image using this Dockerfile and have pushed
it to both repositories if you want to play with that.

Once merged, I'll create similar Dockerfiles for
quay.io/skopeo/testing and quay.io/skopeo/upstream.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>