### PR TITLE
Use a separate field for the “sync images with tag matching regex” feature

### DIFF
--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -344,8 +344,11 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 
 		tagReg, err := regexp.Compile(tagRegex)
 		if err != nil {
-			repoLogger.Error("Error processing repo, skipping")
+			repoLogger.WithFields(logrus.Fields{
+				"regex": tagRegex,
+			}).Error("Error parsing regex, skipping")
 			logrus.Error(err)
+			continue
 		}
 
 		repoLogger.Info("Querying registry for image tags")

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -152,15 +152,14 @@ func destinationReference(destination string, transport string) (types.ImageRefe
 	case directory.Transport.Name():
 		_, err := os.Stat(destination)
 		if err == nil {
-			return nil, errors.Errorf(fmt.Sprintf("Refusing to overwrite destination directory %q", destination))
+			return nil, errors.Errorf("Refusing to overwrite destination directory %q", destination)
 		}
 		if !os.IsNotExist(err) {
 			return nil, errors.Wrap(err, "Destination directory could not be used")
 		}
 		// the directory holding the image must be created here
 		if err = os.MkdirAll(destination, 0755); err != nil {
-			return nil, errors.Wrapf(err, fmt.Sprintf("Error creating directory for image %s",
-				destination))
+			return nil, errors.Wrapf(err, "Error creating directory for image %s", destination)
 		}
 		imageTransport = directory.Transport
 	default:
@@ -170,7 +169,7 @@ func destinationReference(destination string, transport string) (types.ImageRefe
 
 	destRef, err := imageTransport.ParseReference(destination)
 	if err != nil {
-		return nil, errors.Wrapf(err, fmt.Sprintf("Cannot obtain a valid image reference for transport %q and reference %q", imageTransport.Name(), destination))
+		return nil, errors.Wrapf(err, "Cannot obtain a valid image reference for transport %q and reference %q", imageTransport.Name(), destination)
 	}
 
 	return destRef, nil
@@ -200,7 +199,7 @@ func getImageTags(ctx context.Context, sysCtx *types.SystemContext, repoRef refe
 		logrus.Warnf("Registry disallows tag list retrieval: %s", err)
 		break
 	default:
-		return tags, errors.Wrapf(err, fmt.Sprintf("Error determining repository tags for image %s", name))
+		return tags, errors.Wrapf(err, "Error determining repository tags for image %s", name)
 	}
 
 	return tags, nil
@@ -245,7 +244,7 @@ func imagesToCopyFromDir(dirPath string) ([]types.ImageReference, error) {
 			dirname := filepath.Dir(path)
 			ref, err := directory.Transport.ParseReference(dirname)
 			if err != nil {
-				return errors.Wrapf(err, fmt.Sprintf("Cannot obtain a valid image reference for transport %q and reference %q", directory.Transport.Name(), dirname))
+				return errors.Wrapf(err, "Cannot obtain a valid image reference for transport %q and reference %q", directory.Transport.Name(), dirname)
 			}
 			sourceReferences = append(sourceReferences, ref)
 			return filepath.SkipDir
@@ -255,7 +254,7 @@ func imagesToCopyFromDir(dirPath string) ([]types.ImageReference, error) {
 
 	if err != nil {
 		return sourceReferences,
-			errors.Wrapf(err, fmt.Sprintf("Error walking the path %q", dirPath))
+			errors.Wrapf(err, "Error walking the path %q", dirPath)
 	}
 
 	return sourceReferences, nil
@@ -563,7 +562,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) error {
 
 			_, err = copy.Image(ctx, policyContext, destRef, ref, &options)
 			if err != nil {
-				return errors.Wrapf(err, fmt.Sprintf("Error copying tag %q", transports.ImageName(ref)))
+				return errors.Wrapf(err, "Error copying tag %q", transports.ImageName(ref))
 			}
 			imagesNumber++
 		}

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -364,7 +364,7 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 				repoLogger.Errorf("Internal error, reference %s does not have a tag, skipping", sReference.DockerReference())
 				continue
 			}
-			if tagReg.Match([]byte(tagged.Tag())) {
+			if tagReg.MatchString(tagged.Tag()) {
 				sourceReferences = append(sourceReferences, sReference)
 			}
 		}

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -359,8 +359,12 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 
 		repoLogger.Infof("Start filtering using the regular expression: %v", tagRegex)
 		for _, sReference := range allSourceReferences {
-			// get the tag names to match, [1] default is "latest" by .DockerReference().String()
-			if tagReg.Match([]byte(strings.Split(sReference.DockerReference().String(), ":")[1])) {
+			tagged, isTagged := sReference.DockerReference().(reference.Tagged)
+			if !isTagged {
+				repoLogger.Errorf("Internal error, reference %s does not have a tag, skipping", sReference.DockerReference())
+				continue
+			}
+			if tagReg.Match([]byte(tagged.Tag())) {
 				sourceReferences = append(sourceReferences, sReference)
 			}
 		}

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -273,7 +273,7 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 
 	var repoDescList []repoDescriptor
 	for imageName, tags := range cfg.Images {
-		repoName := fmt.Sprintf("//%s", path.Join(registryName, imageName))
+		repoName := fmt.Sprintf("//%s/%s", registryName, imageName)
 		repoLogger := logrus.WithFields(logrus.Fields{
 			"repo":     imageName,
 			"registry": registryName,
@@ -323,7 +323,7 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 	}
 
 	for imageName, tagRegex := range cfg.ImagesByTagRegex {
-		repoName := fmt.Sprintf("//%s", path.Join(registryName, imageName))
+		repoName := fmt.Sprintf("//%s/%s", registryName, imageName)
 		repoLogger := logrus.WithFields(logrus.Fields{
 			"repo":     imageName,
 			"registry": registryName,

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -263,6 +263,14 @@ func imagesToCopyFromDir(dirPath string) ([]types.ImageReference, error) {
 // found and any error encountered. Each element of the slice is a list of
 // tagged image references, to be used as sync source.
 func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourceCtx types.SystemContext) ([]repoDescriptor, error) {
+	serverCtx := &sourceCtx
+	// override ctx with per-registryName options
+	serverCtx.DockerCertPath = cfg.CertDir
+	serverCtx.DockerDaemonCertPath = cfg.CertDir
+	serverCtx.DockerDaemonInsecureSkipTLSVerify = (cfg.TLSVerify.skip == types.OptionalBoolTrue)
+	serverCtx.DockerInsecureSkipTLSVerify = cfg.TLSVerify.skip
+	serverCtx.DockerAuthConfig = &cfg.Credentials
+
 	var repoDescList []repoDescriptor
 	for imageName, tags := range cfg.Images {
 		repoName := fmt.Sprintf("//%s", path.Join(registryName, imageName))
@@ -271,16 +279,7 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 			"registry": registryName,
 		}).Info("Processing repo")
 
-		serverCtx := &sourceCtx
-		// override ctx with per-registryName options
-		serverCtx.DockerCertPath = cfg.CertDir
-		serverCtx.DockerDaemonCertPath = cfg.CertDir
-		serverCtx.DockerDaemonInsecureSkipTLSVerify = (cfg.TLSVerify.skip == types.OptionalBoolTrue)
-		serverCtx.DockerInsecureSkipTLSVerify = cfg.TLSVerify.skip
-		serverCtx.DockerAuthConfig = &cfg.Credentials
-
 		var sourceReferences []types.ImageReference
-
 		for _, tag := range tags {
 			source := fmt.Sprintf("%s:%s", repoName, tag)
 
@@ -340,14 +339,6 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 			"repo":     imageName,
 			"registry": registryName,
 		}).Info("Processing repo")
-
-		serverCtx := &sourceCtx
-		// override ctx with per-registryName options
-		serverCtx.DockerCertPath = cfg.CertDir
-		serverCtx.DockerDaemonCertPath = cfg.CertDir
-		serverCtx.DockerDaemonInsecureSkipTLSVerify = (cfg.TLSVerify.skip == types.OptionalBoolTrue)
-		serverCtx.DockerInsecureSkipTLSVerify = cfg.TLSVerify.skip
-		serverCtx.DockerAuthConfig = &cfg.Credentials
 
 		var sourceReferences []types.ImageReference
 

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -280,21 +280,21 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 		}).Info("Processing repo")
 
 		var sourceReferences []types.ImageReference
-		for _, tag := range tags {
-			source := fmt.Sprintf("%s:%s", repoName, tag)
+		if len(tags) != 0 {
+			for _, tag := range tags {
+				source := fmt.Sprintf("%s:%s", repoName, tag)
 
-			imageRef, err := docker.ParseReference(source)
-			if err != nil {
-				logrus.WithFields(logrus.Fields{
-					"tag": source,
-				}).Error("Error processing tag, skipping")
-				logrus.Errorf("Error getting image reference: %s", err)
-				continue
+				imageRef, err := docker.ParseReference(source)
+				if err != nil {
+					logrus.WithFields(logrus.Fields{
+						"tag": source,
+					}).Error("Error processing tag, skipping")
+					logrus.Errorf("Error getting image reference: %s", err)
+					continue
+				}
+				sourceReferences = append(sourceReferences, imageRef)
 			}
-			sourceReferences = append(sourceReferences, imageRef)
-		}
-
-		if len(tags) == 0 {
+		} else { // len(tags) == 0
 			logrus.WithFields(logrus.Fields{
 				"repo":     imageName,
 				"registry": registryName,

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -417,17 +417,15 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 		}
 
 		if imageTagged {
-			desc.TaggedImages = append(desc.TaggedImages, srcRef)
-			descriptors = append(descriptors, desc)
-			break
-		}
-
-		desc.TaggedImages, err = imagesToCopyFromRepo(sourceCtx, srcRef.DockerReference())
-		if err != nil {
-			return descriptors, err
-		}
-		if len(desc.TaggedImages) == 0 {
-			return descriptors, errors.Errorf("No images to sync found in %q", source)
+			desc.TaggedImages = []types.ImageReference{srcRef}
+		} else {
+			desc.TaggedImages, err = imagesToCopyFromRepo(sourceCtx, srcRef.DockerReference())
+			if err != nil {
+				return descriptors, err
+			}
+			if len(desc.TaggedImages) == 0 {
+				return descriptors, errors.Errorf("No images to sync found in %q", source)
+			}
 		}
 		descriptors = append(descriptors, desc)
 

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -87,13 +87,13 @@ Images are located at:
 ```
 
 ### Synchronizing to a container registry from local
-The Image's locate info:
+Images are located at:
 ```
-/media/usb/busybox:1-glibc/
+/media/usb/busybox:1-glibc
 ```
 Sync run
 ```
-$ skopeo sync --src dir --dest docker /media/usb/busybox\:1-glibc my-registry.local.lan/test/
+$ skopeo sync --src dir --dest docker /media/usb/busybox:1-glibc my-registry.local.lan/test/
 ```
 Destination registry content:
 ```

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -143,7 +143,8 @@ registry.example.com:
         redis:
             - "1.0"
             - "2.0"
-        nginx: ^1\.13\.[12]-alpine-perl$ # String types are used for regular expressions, it will match `1.13.1-alpine-perl` and `1.13.2-alpine-perl`
+    images-by-tag-regex:
+        nginx: ^1\.13\.[12]-alpine-perl$
     credentials:
         username: john
         password: this is a secret

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -263,7 +263,7 @@ func (s *SyncSuite) TestYamlRegex2Dir(c *check.C) {
 
 	yamlConfig := `
 docker.io:
-  images:
+  images-by-tag-regex:
     nginx: ^1\.13\.[12]-alpine-perl$  # regex string test
 `
 	// the       ↑    regex strings always matches only 2 images


### PR DESCRIPTION
This is a proposal to change #920 before it gets released.

IMHO, fields that magically change their behavior depending on type of the value are too much hassle for no benefit.

The initial commit just copies&pastes the full loop in `imagesToCopyFromRegistry` to create another loop handling the new `ImagesByTagRegex` field; then follows a large set of cleanups and small fixes, some related to the original subject matter, quite a few independent.

Please see individual commit messages for details.

I’ll be happy to move the unrelated changes (or even the partially-related changes?) into a separate PR if desired.