### PR TITLE
Add upstream and testing container images

### DIFF
--- a/contrib/skopeoimage/README.md
+++ b/contrib/skopeoimage/README.md
@@ -1,0 +1,36 @@
+<img src="https://cdn.rawgit.com/containers/skopeo/master/docs/skopeo.svg" width="250">
+
+----
+
+# skopeoimage
+
+## Overview
+
+This directory contains the Dockerfiles necessary to create the three skopeoimage container
+images that are housed on quay.io under the skopeo account.  All three repositories where
+the images live are public and can be pulled without credentials.  These container images
+are secured and the resulting containers can run safely.  The container images are built
+using the latest Fedora and then Skopeo is installed into them:
+
+  * quay.io/skopeo/stable - This image is built using the latest stable version of Skopeo in a Fedora based container.  Built with skopeoimage/stable/Dockerfile.
+  * quay.io/skopeo/upstream - This image is built using the latest code found in this GitHub repository.  When someone creates a commit and pushes it, the image is created.  Due to that the image changes frequently and is not guaranteed to be stable.  Built with skopeoimage/upstream/Dockerfile.
+  * quay.io/skopeo/testing - This image is built using the latest version of Skopeo that is or was in updates testing for Fedora.  At times this may be the same as the stable image.  This container image will primarily be used by the development teams for verification testing when a new package is created.  Built with skopeoimage/testing/Dockerfile.
+
+## Sample Usage
+
+Although not required, it is suggested that [Podman](https://github.com/containers/libpod) be used with these container images.
+
+```
+# Get Help on Skopeo
+podman run docker://quay.io/skopeo/stable:latest --help
+
+# Get help on the Skopeo Copy command
+podman run docker://quay.io/skopeo/stable:latest copy --help
+
+# Copy the Skopeo container image from quay.io to
+# a private registry
+podman run docker://quay.io/skopeo/stable:latest copy docker://quay.io/skopeo/stable docker://registry.internal.company.com/skopeo
+
+# Inspect the fedora:latest image
+podman run docker://quay.io/skopeo/stable:latest inspect --config docker://registry.fedoraproject.org/fedora:latest  | jq
+```

--- a/contrib/skopeoimage/testing/Dockerfile
+++ b/contrib/skopeoimage/testing/Dockerfile
@@ -1,0 +1,34 @@
+# testing/Dockerfile
+#
+# Build a Skopeo container image from the latest
+# version of Skopeo that is in updates-testing
+# on the Fedoras Updates System.
+# https://bodhi.fedoraproject.org/updates/?search=skopeo
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+#
+FROM registry.fedoraproject.org/fedora:32
+
+# Don't include container-selinux and remove
+# directories used by yum that are just taking
+# up space.  Also reinstall shadow-utils as without
+# doing so, the setuid/setgid bits on newuidmap
+# and newgidmap are lost in the Fedora images. 
+RUN useradd skopeo; yum -y update; yum -y reinstall shadow-utils; yum -y install skopeo fuse-overlayfs --enablerepo updates-testing --exclude container-selinux; yum clean all; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+
+# Setup the ability to use additional stores
+# with this container image.
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Setup skopeo's uid/guid entries
+RUN echo skopeo:100000:65536 > /etc/subuid
+RUN echo skopeo:100000:65536 > /etc/subgid
+
+# Point to the Authorization file
+ENV REGISTRY_AUTH_FILE=/auth.json
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/bin/skopeo"]

--- a/contrib/skopeoimage/upstream/Dockerfile
+++ b/contrib/skopeoimage/upstream/Dockerfile
@@ -1,0 +1,53 @@
+# upstream/Dockerfile
+#
+# Build a Skopeo container image from the latest
+# upstream version of Skopeo on GitHub.
+# https://github.com/containers/skopeo
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+#
+FROM registry.fedoraproject.org/fedora:32
+
+# Don't include container-selinux and remove
+# directories used by yum that are just taking
+# up space.  Also reinstall shadow-utils as without
+# doing so, the setuid/setgid bits on newuidmap
+# and newgidmap are lost in the Fedora images. 
+RUN useradd skopeo; yum -y update; yum -y reinstall shadow-utils; \
+yum -y install make \
+golang \
+git \
+go-md2man \
+fuse-overlayfs \
+fuse3 \
+containers-common \
+gpgme-devel \
+libassuan-devel \
+btrfs-progs-devel \
+device-mapper-devel --enablerepo updates-testing --exclude container-selinux; \
+mkdir /root/skopeo; \
+git clone https://github.com/containers/skopeo /root/skopeo/src/github.com/containers/skopeo; \
+export GOPATH=/root/skopeo; \
+cd /root/skopeo/src/github.com/containers/skopeo; \
+make binary-local;\
+make install;\
+rm -rf /root/skopeo/*; \
+yum -y remove git golang go-md2man make; \
+yum clean all; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+
+# Setup the ability to use additional stores
+# with this container image.
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Setup skopeo's uid/guid entries
+RUN echo skopeo:100000:65536 > /etc/subuid
+RUN echo skopeo:100000:65536 > /etc/subgid
+
+# Point to the Authorization file
+ENV REGISTRY_AUTH_FILE=/auth.json
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/bin/skopeo"]


### PR DESCRIPTION
This PR adds the Dockerfiles necessary to create the upstream
and testing variants of the Skopeo container images that will
reside in quay.io/skopeo/upstream and quay.io/skopeo/testing
repositories.  The only difference in the Dockerfile between
the stable and testing image is the option `--enablerepo updates-testing`
was added.  The testing variant is relatively the same, but
I'd to clone and install Skopeo in the container.

I've also added a README.md which explains all of the varities
of images and includes some sample usage.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>