### PR TITLE
[nix] Add nix derivation for static builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.1
 /layers-*
 /skopeo
+result
 
 # ignore JetBrains IDEs (GoLand) config folder
 .idea

--- a/contrib/skopeoimage/upstream/Dockerfile
+++ b/contrib/skopeoimage/upstream/Dockerfile
@@ -29,7 +29,7 @@ mkdir /root/skopeo; \
 git clone https://github.com/containers/skopeo /root/skopeo/src/github.com/containers/skopeo; \
 export GOPATH=/root/skopeo; \
 cd /root/skopeo/src/github.com/containers/skopeo; \
-make binary-local;\
+make bin/skopeo;\
 make install;\
 rm -rf /root/skopeo/*; \
 yum -y remove git golang go-md2man make; \

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -8,7 +8,7 @@ bundle_test_integration() {
 
 # subshell so that we can export PATH without breaking other things
 (
-	make binary-local ${BUILDTAGS:+BUILDTAGS="$BUILDTAGS"}
+	make bin/skopeo ${BUILDTAGS:+BUILDTAGS="$BUILDTAGS"}
 	make install
 	bundle_test_integration
 ) 2>&1

--- a/hack/make/test-system
+++ b/hack/make/test-system
@@ -11,7 +11,7 @@ sed -i \
     /etc/containers/storage.conf
 
 # Build skopeo, install into /usr/bin
-make binary-local ${BUILDTAGS:+BUILDTAGS="$BUILDTAGS"}
+make bin/skopeo ${BUILDTAGS:+BUILDTAGS="$BUILDTAGS"}
 make install
 
 # Run tests

--- a/hack/travis_osx.sh
+++ b/hack/travis_osx.sh
@@ -12,6 +12,6 @@ go version
 GO111MODULE=off go get -u github.com/cpuguy83/go-md2man golang.org/x/lint/golint
 
 cd ${_containers}/skopeo
-make validate-local test-unit-local binary-local
+make validate-local test-unit-local bin/skopeo
 sudo make install
 skopeo -v

--- a/install.md
+++ b/install.md
@@ -114,7 +114,7 @@ Make sure to clone this repository in your `GOPATH` - otherwise compilation fail
 
 ```bash
 $ git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo
-$ cd $GOPATH/src/github.com/containers/skopeo && make binary-local
+$ cd $GOPATH/src/github.com/containers/skopeo && make bin/skopeo
 ```
 
 ### Building in a container

--- a/integration/openshift_shell_test.go
+++ b/integration/openshift_shell_test.go
@@ -19,7 +19,7 @@ to start a container, then within the container:
 	SKOPEO_CONTAINER_TESTS=1 PS1='nested> ' go test -tags openshift_shell -timeout=24h ./integration -v -check.v -check.vv -check.f='CopySuite.TestRunShell'
 
 An example of what can be done within the container:
-	cd ..; make binary-local install
+	cd ..; make bin/skopeo install
 	./skopeo --tls-verify=false  copy --sign-by=personal@example.com docker://busybox:latest atomic:localhost:5000/myns/personal:personal
 	oc get istag personal:personal -o json
 	curl -L -v 'http://localhost:5000/v2/'

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,43 @@
+{ system ? builtins.currentSystem }:
+let
+  pkgs = (import ./nixpkgs.nix {
+    config = {
+      packageOverrides = pkg: {
+        gpgme = (static pkg.gpgme);
+        libassuan = (static pkg.libassuan);
+        libgpgerror = (static pkg.libgpgerror);
+      };
+    };
+  });
+
+  static = pkg: pkg.overrideAttrs(x: {
+    configureFlags = (x.configureFlags or []) ++
+      [ "--without-shared" "--disable-shared" ];
+    dontDisableStatic = true;
+    enableSharedExecutables = false;
+    enableStatic = true;
+  });
+
+  self = with pkgs; buildGoPackage rec {
+    name = "skopeo";
+    src = ./..;
+    goPackagePath = "github.com/containers/skopeo";
+    doCheck = false;
+    enableParallelBuilding = true;
+    nativeBuildInputs = [ git go-md2man installShellFiles makeWrapper pkg-config ];
+    buildInputs = [ glibc glibc.static gpgme libassuan libgpgerror ];
+    prePatch = ''
+      export LDFLAGS='-s -w -static-libgcc -static'
+      export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
+      export BUILDTAGS='static netgo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper'
+    '';
+    buildPhase = ''
+      pushd go/src/${goPackagePath}
+      patchShebangs .
+      make bin/skopeo
+    '';
+    installPhase = ''
+      install -Dm755 bin/skopeo $out/bin/skopeo
+    '';
+  };
+in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "78e324d2726127828a15f87a75b4d3199a8955ec",
+  "date": "2020-06-16T18:23:14-07:00",
+  "path": "/nix/store/bwhp0061k3fk00j8fskpfak261jdcjl6-nixpkgs",
+  "sha256": "1j58aa9ngdmvbnds4x4a497nynj390dzqyb5yrvmhjc7k9anq6jm",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable";
+    url = "${json.url}/archive/${json.rev}.tar.gz";
+    inherit (json) sha256;
+  });
+in nixpkgs


### PR DESCRIPTION
#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind feature

#### What this PR does / why we need it:

Similar PR goes for crun/conmon/libpod/cri-o/etc, too.


Also see:
  - ~~https://github.com/containers/crun/pull/372~~
  - ~~https://github.com/containers/conmon/pull/161~~
  - https://github.com/containers/skopeo/pull/932
  - https://github.com/containers/buildah/pull/2380
  - https://github.com/containers/libpod/pull/6402
  - https://github.com/cri-o/cri-o/pull/3804


Static binaries:
  - [crun-0.13-linux-amd64](https://github.com/alvistack/crun/releases/download/0.13/crun-0.13-linux-amd64)
  - [conmon-v2.0.17-linux-amd64](https://github.com/alvistack/conmon/releases/download/v2.0.17/conmon-v2.0.17-linux-amd64)
  - [skopeo-v1.0.0-linux-amd64](https://github.com/alvistack/skopeo/releases/download/v1.0.0/skopeo-v1.0.0-linux-amd64)
  - [buildah-v1.14.9-linux-amd64](https://github.com/alvistack/buildah/releases/download/v1.14.9/buildah-v1.14.9-linux-amd64)
  - [podman-v1.9.3-linux-amd64](https://github.com/alvistack/libpod/releases/download/v1.9.3/podman-v1.9.3-linux-amd64)
  - [cri-o-v1.17.4-linux-amd64.tar.gz](https://github.com/alvistack/cri-o/releases/download/v1.17.4/cri-o-v1.17.4-linux-amd64.tar.gz)
  - [cri-o-v1.18.1-linux-amd64.tar.gz](https://github.com/alvistack/cri-o/releases/download/v1.18.1/cri-o-v1.18.1-linux-amd64.tar.gz)

Ansible Roles:
  - https://github.com/alvistack/ansible-role-crun
  - https://github.com/alvistack/ansible-role-conmon
  - https://github.com/alvistack/ansible-role-skopeo
  - https://github.com/alvistack/ansible-role-buildah 
  - https://github.com/alvistack/ansible-role-podman
  - https://github.com/alvistack/ansible-role-cri_o


#### How to verify it

```
nix build -f nix/
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:


Here I skip the btrfs and lvm2 support for static binary, because:
1. btrfs will not support in CentOS 8
2. With skopeo experience both btrfs and lvm2 are not easy for compile as static binary

Also see:
- https://github.com/containers/libpod/pull/6402#discussion_r431398382

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

