### PR TITLE
Update Skopeo Image Dockerfiles to F33

### DIFF
--- a/contrib/skopeoimage/stable/Dockerfile
+++ b/contrib/skopeoimage/stable/Dockerfile
@@ -6,7 +6,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:33
 
 # Don't include container-selinux and remove
 # directories used by yum that are just taking

--- a/contrib/skopeoimage/testing/Dockerfile
+++ b/contrib/skopeoimage/testing/Dockerfile
@@ -7,7 +7,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:33
 
 # Don't include container-selinux and remove
 # directories used by yum that are just taking

--- a/contrib/skopeoimage/upstream/Dockerfile
+++ b/contrib/skopeoimage/upstream/Dockerfile
@@ -6,7 +6,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:33
 
 # Don't include container-selinux and remove
 # directories used by yum that are just taking


### PR DESCRIPTION
Update the version of Fedora used in the Dockerfiles
that create the Skopeo Container Images on quay.io to
Fedora 33.  This will enable our latest image in stable
and containers to contain v1.0.0 as currently there's not
a v1.0 kit for Fedora 32.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>