### PR TITLE
Correct a typo in docs/skopeo-sync.1.md

### DIFF
--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -168,7 +168,7 @@ This will copy the following images:
 
 For the registry `registry.example.com`, the "john"/"this is a secret" credentials are used, with server TLS certificates located at `/home/john/certs`.
 
-TLS verification is normally enabled, and it can be disabled setting `tls-verify` to `true`.
+TLS verification is normally enabled, and it can be disabled setting `tls-verify` to `false`.
 In the above example, TLS verification is enabled for `reigstry.example.com`, while is
 disabled for `quay.io`.
 


### PR DESCRIPTION
To disable TLS verification need to set "tls-verify" to "false"