### PR TITLE
Run htpasswd from our build-container instead of registry:2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-md2ma
 	# gpgme bindings deps
 	libassuan-devel gpgme-devel \
 	gnupg \
+	# htpasswd for system tests
+	httpd-tools \
 	# OpenShift deps
 	which tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute \
         bats jq podman runc \

--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -314,8 +314,7 @@ start_registry() {
         fi
 
         if ! egrep -q "^$testuser:" $AUTHDIR/htpasswd; then
-            log_and_run $PODMAN run --rm --entrypoint htpasswd $REGISTRY_FQIN \
-                   -Bbn $testuser $testpassword >> $AUTHDIR/htpasswd
+            htpasswd -Bbn $testuser $testpassword >> $AUTHDIR/htpasswd
         fi
 
         reg_args+=(


### PR DESCRIPTION
registry:2 no longer contains htpasswd.