### PR TITLE
Fix macOS builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,12 @@ notifications:
   email: false
 
 install:
-  # NOTE: The (brew update) should not be necessary, and slows things down;
-  # we include it as a workaround for https://github.com/Homebrew/brew/issues/3299
-  # ideally Travis should bake the (brew update) into its images
-  # (https://github.com/travis-ci/travis-ci/issues/8552 ), but that’s only going
-  # to happen around November 2017 per https://blog.travis-ci.com/2017-10-16-a-new-default-os-x-image-is-coming .
-  # Remove the (brew update) at that time.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install gpgme ; fi
+  # Ideally, the (brew update) should not be necessary and Travis would have fairly
+  # frequenstly updated OS images; that’s not been the case historically.
+  # In particular, explicitly unlink python@2, which has been removed from Homebrew
+  # since the last OS image build (as of July 2020), but the Travis OS still
+  # contains it, and it prevents updating of Python 3.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew unlink python@2 && brew install gpgme ; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then hack/travis_osx.sh ; fi


### PR DESCRIPTION
... which are currently failing with
> ```
> Error: The `brew link` step did not complete successfully
> The formula built, but is not symlinked into /usr/local
> Could not symlink Frameworks/Python.framework/Headers
> Target /usr/local/Frameworks/Python.framework/Headers
> is a symlink belonging to python@2. You can unlink it:
>   brew unlink python@2
> ```

because the Travis-installed machine apparently has quite a few Homebrew formulae installed, with an old version of Homebrew, including a now-removed `python@2`, and that prevents updates of `python@3`.

Remove the obsolete motivation for running (brew update), and replace it with a similarly-good motivation that the Travis images are just too old to be relevant to users.
