### PR TITLE
Build static binary with `buildGoModule`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ help:
 	@echo
 	@echo " * 'install' - Install binaries and documents to system locations"
 	@echo " * 'binary' - Build skopeo with a container"
+	@echo " * 'static' - Build statically linked binary"
 	@echo " * 'bin/skopeo' - Build skopeo locally"
 	@echo " * 'test-unit' - Execute unit tests"
 	@echo " * 'test-integration' - Execute integration tests"
@@ -103,11 +104,18 @@ binary: cmd/skopeo
 	${CONTAINER_RUNTIME} run --rm --security-opt label=disable -v $$(pwd):/src/github.com/containers/skopeo \
 		skopeobuildimage make bin/skopeo $(if $(DEBUG),DEBUG=$(DEBUG)) BUILDTAGS='$(BUILDTAGS)'
 
-# Update nix/nixpkgs.json its latest master commit
+# Update nix/nixpkgs.json its latest stable commit
 .PHONY: nixpkgs
 nixpkgs:
 	@nix run -f channel:nixos-20.03 nix-prefetch-git -c nix-prefetch-git \
 		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
+
+# Build statically linked binary
+.PHONY: static
+static:
+	@nix build -f nix/
+	mkdir -p ./bin
+	cp -rfp ./result/bin/* ./bin/
 
 # Build w/o using containers
 .PHONY: bin/skopeo

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "87c5724af9f61be5e77034229078960690c1abe2",
-  "date": "2020-06-28T22:14:24+01:00",
-  "sha256": "1vg6iajb945b33nx674nnask6wai8zkjd4m0i9fcpdkwhwr0s46s",
+  "rev": "d6a445fe821052861b379d9b6c02d21623c25464",
+  "date": "2020-08-11T04:28:16+01:00",
+  "sha256": "064scwaxg8qg4xbmq07hag57saa4bhsb4pgg5h5vfs4nhhwvchg9",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Also synchronize nix build implementation between skopeo/buildah/podman/cri-o.

Also see:
- https://github.com/containers/crun/pull/428
- https://github.com/containers/conmon/pull/189
- https://github.com/containers/skopeo/pull/973
- https://github.com/containers/buildah/pull/2428
- https://github.com/containers/podman/pull/7076
- https://github.com/cri-o/cri-o/pull/4012

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>

```release-note
Build static binary with `buildGoModule`
```