### PR TITLE
Use an inter-registry copy as the example for (skopeo copy)

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -55,7 +55,7 @@ Supported transports:
 See skopeo(1) section "IMAGE NAMES" for the expected format
 `, strings.Join(transports.ListNames(), ", ")),
 		RunE:    commandAction(opts.run),
-		Example: `skopeo copy --sign-by dev@example.com container-storage:example/busybox:streaming docker://example/busybox:gold`,
+		Example: `skopeo copy docker://quay.io/skopeo/stable:latest docker://registry.example.com/skopeo:latest`,
 	}
 	adjustUsage(cmd)
 	flags := cmd.Flags()

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -83,6 +83,11 @@ Existing signatures, if any, are preserved as well.
 
 ## EXAMPLES
 
+To just copy an image from one registry to another:
+```sh
+$ skopeo copy docker://quay.io/skopeo/stable:latest docker://registry.example.com/skopeo:latest
+```
+
 To copy the layers of the docker.io busybox image to a local directory:
 ```sh
 $ mkdir -p /var/lib/images/busybox


### PR DESCRIPTION
because that's what users are looking for, and instead of using a `containers-storage:` source, which might not even work all that well with all the automatic defaults Podman sets up.

Fixes #924 .