### PR TITLE
(WIP) add goreleaser basic config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ result
 
 # ignore JetBrains IDEs (GoLand) config folder
 .idea
+
+# goreleaser dist dir
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,58 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+# before:
+#   hooks:
+#     # You may remove this if you don't use go modules.
+#     - go mod download
+#     # you may remove this if you don't need go generate
+#     - go generate ./...
+builds:
+  - id: "linux"
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    dir: cmd/skopeo
+    binary: skopeo
+    goarch:
+      - amd64
+
+archives:
+  - replacements:
+      linux: Linux
+      amd64: x86_64
+
+nfpms:
+  - id: linux
+    formats:
+      - deb
+      - rpm
+    overrides:
+      deb:
+        dependencies:
+          - libgpgme11
+          - libdevmapper1.02.1
+          - ca-certificates
+      rpm:
+        dependencies:
+          - device-mapper-devel
+source:
+  enabled: true
+dockers:
+  - builds:
+    - linux
+    image_templates:
+    - "containers/{{.ProjectName}}:{{ .Tag }}"
+    - "containers/{{.ProjectName}}:v{{ .Major }}"
+    - "containers/{{.ProjectName}}:v{{ .Major }}.{{ .Minor }}"
+    - "containers/{{.ProjectName}}:latest"
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
This PR adds the basic config for GoReleaser build, compact, package rpm and deb, and a docker image.

Due to the CGO dependencies the build is only made on Linux 64 bits. I can work on alternatives for i386 if that is something needed. But for OSX I need to check that problem on another PR. 

About the docker image, I think that the ideal is that we use a distro less based image WDYT?

Should I add the changes for the Travis CI too?

related with #715 