### PR TITLE
Remove an obsolete documentation of (make binary-static)

### DIFF
--- a/install.md
+++ b/install.md
@@ -130,12 +130,6 @@ Building in a container is simpler, but more restrictive:
 $ make binary # Or (make all) to also build documentation, see below.
 ```
 
-To build a pure-Go static binary (disables devicemapper, btrfs, and gpgme):
-
-```bash
-$ make binary-static DISABLE_CGO=1
-```
-
 ### Building documentation
 
 To build the manual you will need go-md2man.


### PR DESCRIPTION
... which no longer works after #932.

This does not add documentation for the current static build approach, nor does it add any other place where `DISABLE_CGO` is documented; both are not tested by CI, and discouraged due to bad integration with the rest of the system.