### PR TITLE
feat: show signers info in skopeo inspect

### DIFF
--- a/cmd/skopeo/inspect/output.go
+++ b/cmd/skopeo/inspect/output.go
@@ -12,6 +12,7 @@ type Output struct {
 	Name          string `json:",omitempty"`
 	Tag           string `json:",omitempty"`
 	Digest        digest.Digest
+	Signers       []string `json:",omitempty"`
 	RepoTags      []string
 	Created       *time.Time
 	DockerVersion string


### PR DESCRIPTION
If a remote image being inspected has signatures available, show them in
the inspect output under "Signers". Attempt to display the verified key
fingerprints (if a matching public key is available locally), otherwise
fallback to showing the unverified key IDs.