### PR TITLE
Add --registry-token flags to support Bearer token authentication

### DIFF
--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -93,10 +93,10 @@ func dockerImageFlags(global *globalOptions, shared *sharedImageOptions, flagPre
 		f := fs.VarPF(newOptionalStringValue(&flags.credsOption), credsOptionAlias, "", "Use `USERNAME[:PASSWORD]` for accessing the registry")
 		f.Hidden = true
 	}
+	fs.Var(newOptionalStringValue(&flags.registryToken), flagPrefix+"registry-token", "Provide a Bearer token for accessing the registry")
 	fs.StringVar(&flags.dockerCertPath, flagPrefix+"cert-dir", "", "use certificates at `PATH` (*.crt, *.cert, *.key) to connect to the registry or daemon")
 	optionalBoolFlag(&fs, &flags.tlsVerify, flagPrefix+"tls-verify", "require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)")
 	fs.BoolVar(&flags.noCreds, flagPrefix+"no-creds", false, "Access the registry anonymously")
-	fs.Var(newOptionalStringValue(&flags.registryToken), flagPrefix+"registry-token", "Provide a Bearer token for accessing the registry")
 	return fs, &flags
 }
 
@@ -133,9 +133,6 @@ func (opts *imageOptions) newSystemContext() (*types.SystemContext, error) {
 	ctx.AuthFilePath = opts.shared.authFilePath
 	ctx.DockerDaemonHost = opts.dockerDaemonHost
 	ctx.DockerDaemonCertPath = opts.dockerCertPath
-	if opts.registryToken.present {
-		ctx.DockerBearerRegistryToken = opts.registryToken.value
-	}
 	if opts.dockerImageOptions.authFilePath.present {
 		ctx.AuthFilePath = opts.dockerImageOptions.authFilePath.value
 	}
@@ -154,6 +151,9 @@ func (opts *imageOptions) newSystemContext() (*types.SystemContext, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+	if opts.registryToken.present {
+		ctx.DockerBearerRegistryToken = opts.registryToken.value
 	}
 	if opts.noCreds {
 		ctx.DockerAuthConfig = &types.DockerAuthConfig{}

--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -68,11 +68,11 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 		DockerCertPath:                    "/srv/cert-dir",
 		DockerInsecureSkipTLSVerify:       types.OptionalBoolTrue,
 		DockerAuthConfig:                  &types.DockerAuthConfig{Username: "creds-user", Password: "creds-password"},
+		DockerBearerRegistryToken:         "faketoken",
 		DockerDaemonCertPath:              "/srv/cert-dir",
 		DockerDaemonHost:                  "daemon-host.example.com",
 		DockerDaemonInsecureSkipTLSVerify: true,
 		BigFilesTemporaryDir:              "/srv",
-		DockerBearerRegistryToken:         "faketoken",
 	}, res)
 
 	// Global/per-command tlsVerify behavior
@@ -180,12 +180,12 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 		DockerCertPath:                    "/srv/cert-dir",
 		DockerInsecureSkipTLSVerify:       types.OptionalBoolTrue,
 		DockerAuthConfig:                  &types.DockerAuthConfig{Username: "creds-user", Password: "creds-password"},
+		DockerBearerRegistryToken:         "faketoken",
 		DockerDaemonCertPath:              "/srv/cert-dir",
 		DockerDaemonHost:                  "daemon-host.example.com",
 		DockerDaemonInsecureSkipTLSVerify: true,
 		DirForceCompress:                  true,
 		BigFilesTemporaryDir:              "/srv",
-		DockerBearerRegistryToken:         "faketoken",
 	}, res)
 
 	// Invalid option values in imageOptions

--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -54,6 +54,7 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 		"--dest-daemon-host", "daemon-host.example.com",
 		"--dest-tls-verify=false",
 		"--dest-creds", "creds-user:creds-password",
+		"--dest-registry-token", "faketoken",
 	})
 	res, err = opts.newSystemContext()
 	require.NoError(t, err)
@@ -71,6 +72,7 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 		DockerDaemonHost:                  "daemon-host.example.com",
 		DockerDaemonInsecureSkipTLSVerify: true,
 		BigFilesTemporaryDir:              "/srv",
+		DockerBearerRegistryToken:         "faketoken",
 	}, res)
 
 	// Global/per-command tlsVerify behavior
@@ -164,6 +166,7 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 		"--dest-daemon-host", "daemon-host.example.com",
 		"--dest-tls-verify=false",
 		"--dest-creds", "creds-user:creds-password",
+		"--dest-registry-token", "faketoken",
 	})
 	res, err = opts.newSystemContext()
 	require.NoError(t, err)
@@ -182,6 +185,7 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 		DockerDaemonInsecureSkipTLSVerify: true,
 		DirForceCompress:                  true,
 		BigFilesTemporaryDir:              "/srv",
+		DockerBearerRegistryToken:         "faketoken",
 	}, res)
 
 	// Invalid option values in imageOptions

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -49,6 +49,8 @@ _skopeo_copy() {
     --dest-tls-verify
     --src-daemon-host
     --dest-daemon-host
+    --src-registry-token
+    --dest-registry-token
     "
 
     local boolean_options="
@@ -74,6 +76,7 @@ _skopeo_inspect() {
      --creds
      --cert-dir
      --retry-times
+     --registry-token
      "
      local boolean_options="
      --config
@@ -120,6 +123,7 @@ _skopeo_delete() {
      --authfile
      --creds
      --cert-dir
+     --registry-token
      "
      local boolean_options="
      --tls-verify
@@ -150,6 +154,7 @@ _skopeo_list_repository_tags() {
      --authfile
      --creds
      --cert-dir
+     --registry-token
      "
 
      local boolean_options="

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -140,11 +140,14 @@ _skopeo_delete() {
 
 _skopeo_layers() {
      local options_with_args="
+       --authfile
        --creds
        --cert-dir
+       --registry-token
      "
      local boolean_options="
        --tls-verify
+       --no-creds
      "
     _complete_ "$options_with_args" "$boolean_options"
 }

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -54,25 +54,25 @@ Path of the authentication file for the destination registry. Uses path given by
 
 **--decryption-key** _key[:passphrase]_ to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.
 
-**--src-creds** _username[:password]_ for accessing the source registry
+**--src-creds** _username[:password]_ for accessing the source registry.
 
-**--dest-compress** _bool-value_ Compress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source)
+**--dest-compress** _bool-value_ Compress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source).
 
-**--dest-oci-accept-uncompressed-layers** _bool-value_ Allow uncompressed image layers when saving to an OCI image using the 'oci' transport. (default is to compress things that aren't compressed)
+**--dest-oci-accept-uncompressed-layers** _bool-value_ Allow uncompressed image layers when saving to an OCI image using the 'oci' transport. (default is to compress things that aren't compressed).
 
-**--dest-creds** _username[:password]_ for accessing the destination registry
+**--dest-creds** _username[:password]_ for accessing the destination registry.
 
-**--src-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the source registry or daemon
+**--src-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the source registry or daemon.
 
 **--src-no-creds** _bool-value_ Access the registry anonymously.
 
-**--src-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container source registry or daemon (defaults to true)
+**--src-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container source registry or daemon (defaults to true).
 
-**--dest-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the destination registry or daemon
+**--dest-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the destination registry or daemon.
 
 **--dest-no-creds** _bool-value_  Access the registry anonymously.
 
-**--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container destination registry or daemon (defaults to true)
+**--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container destination registry or daemon (defaults to true).
 
 **--src-daemon-host** _host_ Copy from docker daemon at _host_. If _host_ starts with `tcp://`, HTTPS is enabled by default. To use plain HTTP, use the form `http://` (default is `unix:///var/run/docker.sock`).
 
@@ -84,9 +84,9 @@ Existing signatures, if any, are preserved as well.
 
 **--dest-compress-level** _format_ Specifies the compression level to use.  The value is specific to the compression algorithm used, e.g. for zstd the accepted values are in the range 1-20 (inclusive), while for gzip it is 1-9 (inclusive).
 
-**--src-registry-token** _Bearer token_ for accessing the source registry
+**--src-registry-token** _Bearer token_ for accessing the source registry.
 
-**--dest-registry-token** _Bearer token_ for accessing the destination registry
+**--dest-registry-token** _Bearer token_ for accessing the destination registry.
 
 ## EXAMPLES
 

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -84,6 +84,10 @@ Existing signatures, if any, are preserved as well.
 
 **--dest-compress-level** _format_ Specifies the compression level to use.  The value is specific to the compression algorithm used, e.g. for zstd the accepted values are in the range 1-20 (inclusive), while for gzip it is 1-9 (inclusive).
 
+**--src-registry-token** _Bearer token_ for accessing the source registry
+
+**--dest-registry-token** _Bearer token_ for accessing the destination registry
+
 ## EXAMPLES
 
 To just copy an image from one registry to another:

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -24,17 +24,17 @@ $ docker exec -it registry /usr/bin/registry garbage-collect /etc/docker-distrib
   Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `skopeo login`.
   If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
-**--creds** _username[:password]_ for accessing the registry
+**--creds** _username[:password]_ for accessing the registry.
 
-**--cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the registry
+**--cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the registry.
 
-**--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true)
+**--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 **--no-creds** _bool-value_ Access the registry anonymously.
 
 Additionally, the registry must allow deletions by setting `REGISTRY_STORAGE_DELETE_ENABLED=true` for the registry daemon.
 
-**--registry-token** _Bearer token_ for accessing the registry
+**--registry-token** _Bearer token_ for accessing the registry.
 
 ## EXAMPLES
 

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -34,6 +34,8 @@ $ docker exec -it registry /usr/bin/registry garbage-collect /etc/docker-distrib
 
 Additionally, the registry must allow deletions by setting `REGISTRY_STORAGE_DELETE_ENABLED=true` for the registry daemon.
 
+**--registry-token** _Bearer token_ for accessing the registry
+
 ## EXAMPLES
 
 Mark image example/pause for deletion from the registry.example.com registry:

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -25,17 +25,17 @@ Return low-level information about _image-name_ in a registry
   Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `skopeo login`.
   If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
-  **--creds** _username[:password]_ for accessing the registry
+  **--creds** _username[:password]_ for accessing the registry.
 
-  **--cert-dir** _path_ Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry
+  **--cert-dir** _path_ Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry.
 
-  **--retry-times**  the number of times to retry, retry wait time will be exponentially increased based on the number of failed attempts
+  **--retry-times**  the number of times to retry, retry wait time will be exponentially increased based on the number of failed attempts.
 
-  **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true)
+  **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
   **--no-creds** _bool-value_ Access the registry anonymously.
 
-  **--registry-token** _Bearer token_ for accessing the registry
+  **--registry-token** _Bearer token_ for accessing the registry.
 
 ## EXAMPLES
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -35,6 +35,8 @@ Return low-level information about _image-name_ in a registry
 
   **--no-creds** _bool-value_ Access the registry anonymously.
 
+  **--registry-token** _Bearer token_ for accessing the registry
+
 ## EXAMPLES
 
 To review information for the image fedora from the docker.io registry:

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -15,15 +15,15 @@ Return a list of tags from _repository-name_ in a registry.
   Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `skopeo login`.
   If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
-  **--creds** _username[:password]_ for accessing the registry
+  **--creds** _username[:password]_ for accessing the registry.
 
-  **--cert-dir** _path_ Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry
+  **--cert-dir** _path_ Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry.
 
-  **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true)
+  **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
   **--no-creds** _bool-value_ Access the registry anonymously.
 
-  **--registry-token** _Bearer token_ for accessing the registry
+  **--registry-token** _Bearer token_ for accessing the registry.
 
 ## REPOSITORY NAMES
 

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -23,6 +23,8 @@ Return a list of tags from _repository-name_ in a registry.
 
   **--no-creds** _bool-value_ Access the registry anonymously.
 
+  **--registry-token** _Bearer token_ for accessing the registry
+
 ## REPOSITORY NAMES
 
 Repository names are transport-specific references as each transport may have its own concept of a "repository" and "tags". Currently, only the Docker transport is supported.

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -71,9 +71,9 @@ Path of the authentication file for the destination registry. Uses path given by
 
 **--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to a container destination registry or daemon (defaults to true).
 
-**--src-registry-token** _Bearer token_ for accessing the source registry
+**--src-registry-token** _Bearer token_ for accessing the source registry.
 
-**--dest-registry-token** _Bearer token_ for accessing the destination registry
+**--dest-registry-token** _Bearer token_ for accessing the destination registry.
 
 ## EXAMPLES
 

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -71,6 +71,10 @@ Path of the authentication file for the destination registry. Uses path given by
 
 **--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to a container destination registry or daemon (defaults to true).
 
+**--src-registry-token** _Bearer token_ for accessing the source registry
+
+**--dest-registry-token** _Bearer token_ for accessing the destination registry
+
 ## EXAMPLES
 
 ### Synchronizing to a local directory


### PR DESCRIPTION
This feature https://github.com/containers/image/pull/842 was merged in containers/image to support authentication using a provided Bearer token (example use case: integration with Harbor webhooks).

This PR adds a flag to the skopeo CLI to provide support for the registry Bearer token.

Signed-off-by: Alvaro Iradier <airadier@gmail.com>