### PR TITLE
Add Subject Alternative Name to local openssl cert

### DIFF
--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -331,7 +331,8 @@ start_registry() {
             log_and_run openssl req -newkey rsa:4096 -nodes -sha256 \
                     -keyout $AUTHDIR/domain.key -x509 -days 2 \
                     -out $CERT \
-                    -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=localhost"
+                    -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=registry host certificate" \
+                    -addext subjectAltName=DNS:localhost
         fi
 
         reg_args+=(


### PR DESCRIPTION
Go 1.15 deprecates checking CN; this broke gating tests:

   Get "https://localhost:5000/v2/": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0

Easy two-line solution in the 'openssl' invocation. Huge
thanks to Nalin for tracking down and fixing while I was
still getting started:

   https://github.com/containers/buildah/pull/2595

Copied from 0f2892a5b021de3b1cf273f5679fda8298b57c02 in buildah

Signed-off-by: Ed Santiago <santiago@redhat.com>