### PR TITLE
add multi-arch build of upstream skopeo image via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,100 @@
 language: go
 
-matrix:
-  include:
-  -  os: linux
-     sudo: required
-     services:
-       - docker
-  -  os: osx
-
 go:
   - 1.15.x
 
 notifications:
   email: false
 
-install:
-  # Ideally, the (brew update) should not be necessary and Travis would have fairly
-  # frequenstly updated OS images; that’s not been the case historically.
-  # In particular, explicitly unlink python@2, which has been removed from Homebrew
-  # since the last OS image build (as of July 2020), but the Travis OS still
-  # contains it, and it prevents updating of Python 3.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew unlink python@2 && brew install gpgme ; fi
+env:
+  global:
+    # Multiarch manifest will support architectures from this list. It should be the same architectures, as ones in image-build-push step in this Travis config
+    - MULTIARCH_MANIFEST_ARCHITECTURES="amd64 s390x ppc64le"
+    # env variables for stable image build
+    - STABLE_IMAGE=quay.io/skopeo/stable:v1.2.0
+    - EXTRA_STABLE_IMAGE=quay.io/containers/skopeo:v1.2.0
+    # env variable for upstream image build
+    - UPSTREAM_IMAGE=quay.io/skopeo/upstream:master
 
-script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then hack/travis_osx.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make vendor && ./hack/tree_status.sh && make local-cross && make check ; fi
+# Just declaration of the image-build-push step with script actions to execute
+x_base_steps:
+  - &image-build-push
+    services:
+      - docker
+    os: linux
+    dist: focal
+    script:
+      # skopeo upstream image build
+      - make -f release/Makefile build-image/upstream
+      # Push image in case if build is started via cron job or code is pushed to master
+      - if [ "$TRAVIS_EVENT_TYPE" == "push" ] || [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+           make -f release/Makefile push-image/upstream ;
+        fi
+
+      # skopeo stable image build
+      - make -f release/Makefile build-image/stable
+      # Push image in case if build is started via cron job or code is pushed to master
+      - if [ "$TRAVIS_EVENT_TYPE" == "push" ] || [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+           make -f release/Makefile push-image/stable ;
+        fi
+
+# Just declaration of stage order to run
+stages:
+  # Test for local build
+  - local-build
+  # Build and push image for 1 architecture
+  - name: image-build-push
+    if: branch = master
+  # Create and push image manifest to have multiarch image on top of architecture specific images
+  - name: manifest-multiarch-push
+    if: (type IN (push, cron)) AND branch = master
+
+# Actual execution of steps
+jobs:
+  include:
+    # Run 2 local-build steps in parallel for osx and linux/amd64 platforms
+    - stage: local-build
+      <<: *local-build
+      name: local build for osx
+      os: osx
+      install:
+        # Ideally, the (brew update) should not be necessary and Travis would have fairly
+        # frequently updated OS images; that's not been the case historically.
+        # In particular, explicitly unlink python@2, which has been removed from Homebrew
+        # since the last OS image build (as of July 2020), but the Travis OS still
+        # contains it, and it prevents updating of Python 3.
+      - brew update && brew unlink python@2 && brew install gpgme
+      script:
+      - hack/travis_osx.sh
+    - stage: local-build
+      <<: *local-build
+      name: local build for linux
+      os: linux
+      services:
+      - docker
+      script: 
+      - make vendor && ./hack/tree_status.sh && make local-cross && make check
+
+    # Run 3 image-build-push tasks in parallel for linux/amd64, linux/s390x and linux/ppc64le platforms (for upstream and stable)
+    - stage: image-build-push
+      <<: *image-build-push
+      name: images for amd64
+      arch: amd64
+
+    - stage: image-build-push
+      <<: *image-build-push
+      name: images for s390x
+      arch: s390x
+
+    - stage: image-build-push
+      <<: *image-build-push
+      name: images for ppc64le
+      arch: ppc64le
+
+    # Run final task to generate multi-arch image manifests (for upstream and stable)
+    - stage: manifest-multiarch-push
+      os: linux
+      dist: focal
+      script:
+      - make -f release/Makefile push-manifest-multiarch/upstream
+      - make -f release/Makefile push-manifest-multiarch/stable

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,0 +1,40 @@
+## This Makefile is used to publish skopeo container images with Travis CI ##
+## Environment variables, used in this Makefile are specified in .travis.yml
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+GOARCH ?= $(shell go env GOARCH)
+
+# Build container image of skopeo upstream based on host architecture
+build-image/upstream:
+	docker build -t "${UPSTREAM_IMAGE}-${GOARCH}" contrib/skopeoimage/upstream
+
+# Build container image of skopeo stable based on host architecture
+build-image/stable:
+	docker build -t "${STABLE_IMAGE}-${GOARCH}" contrib/skopeoimage/stable
+
+# Push container image of skopeo upstream (based on host architecture) to image repository
+push-image/upstream:
+	echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
+	docker push "${UPSTREAM_IMAGE}-${GOARCH}"
+
+# Push container image of skopeo stable (based on host architecture) to image default and extra repositories
+push-image/stable:
+	echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
+	docker push "${STABLE_IMAGE}-${GOARCH}"
+	docker tag "${STABLE_IMAGE}-${GOARCH}" "${EXTRA_STABLE_IMAGE}-${GOARCH}"
+	docker push "${EXTRA_STABLE_IMAGE}-${GOARCH}"
+
+# Create and push multiarch image manifest of skopeo upstream
+push-manifest-multiarch/upstream:
+	echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
+	docker manifest create "${UPSTREAM_IMAGE}" $(foreach arch,${MULTIARCH_MANIFEST_ARCHITECTURES}, ${UPSTREAM_IMAGE}-${arch})
+	docker manifest push --purge "${UPSTREAM_IMAGE}"
+
+# Create and push multiarch image manifest of skopeo stable
+push-manifest-multiarch/stable:
+	echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
+	docker manifest create "${STABLE_IMAGE}" $(foreach arch,${MULTIARCH_MANIFEST_ARCHITECTURES}, ${STABLE_IMAGE}-${arch})
+	docker manifest push --purge "${STABLE_IMAGE}"
+	# Push to extra repository
+	docker manifest create "${EXTRA_STABLE_IMAGE}" $(foreach arch,${MULTIARCH_MANIFEST_ARCHITECTURES}, ${EXTRA_STABLE_IMAGE}-${arch})
+	docker manifest push --purge "${EXTRA_STABLE_IMAGE}"

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,39 @@
+# skopeo container image build with Travis
+
+This document describes the details and requirements to build and publish skopeo container images. The images are published as several architecture specific images and multiarch images on top for upstream and stable versions.
+
+The Travis configuration is available at `.travis.yml`.
+
+The code to build and publish images is available at `release/Makefile` and should be used only via Travis.
+
+Travis workflow has 3 major pieces:
+- `local-build` - build and test source code locally on osx and linux/amd64 environments, 2 jobs are running in parallel
+- `image-build-push` - build and push container images with several Travis jobs running in parallel to build images for several architectures (linux/amd64, linux/s390x, linux/ppc64le). Build part is done for each PR, push part is executed only in case of cron job or master branch update.
+- `manifest-multiarch-push` - create and push image manifests, which consists of architecture specific images from previous step. Executed only in case of cron job or master branch update.
+
+## Ways to have full worklow run
+- [cron job](https://docs.travis-ci.com/user/cron-jobs/#adding-cron-jobs)
+- Trigger build from Travis CI
+- Update code in master branch
+
+## Environment variables
+
+Several environment variables are used to customize image names and keep private credentials to push to quay.io repositories.
+
+**Image tags** are specified in environment variable and should be manually updated in case of new release.
+
+- `QUAY_USERNAME` and `QUAY_PASSWORD` are credentials to push image to corresponding quay.io repositories, should have write permissions. These variables should be specified in [Travis](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings).
+
+Variables in .travis.yml
+- `MULTIARCH_MANIFEST_ARCHITECTURES` is a list with architecture shortnames, to apprear in final multiarch manifest. The values should fit to architectures used in the `image-build-push` Travis step.
+- `STABLE_IMAGE`, `EXTRA_STABLE_IMAGE` are image names to publish stable skopeo
+- `UPSTREAM_IMAGE` is image name to publish upstream skopeo
+
+### Values for environment variables
+
+| Env variable                     | Value                            |
+| -------------------------------- |----------------------------------|
+| MULTIARCH_MANIFEST_ARCHITECTURES | "amd64 s390x ppc64le"            |
+| STABLE_IMAGE                     | quay.io/skopeo/stable:v1.2.0     |
+| EXTRA_STABLE_IMAGE               | quay.io/containers/skopeo:v1.2.0 |
+| UPSTREAM_IMAGE                   | quay.io/skopeo/upstream:master |


### PR DESCRIPTION
This PR is connected to https://github.com/containers/skopeo/issues/1010 to get skopeo multi-arch container images.
 
To build multi-arch upstream container image Travis is used, as it has native hardware to run the build for many architectures (amd64, s390x, ppc64le). Docker is used as build and manifest tool. `quay.io/skopeo/upstream:master`, `quay.io/skopeo/stable:v1.2.0` and `quay.io/containers/skopeo:v1.2.0` are specified as target multi-arch images.
Travis config file has 3 stages:
- `local-build` to do the local binary build and test for linux/amd64 and osx, as it was in
the initial code
- `image-build-push` to build and push images for specific architectures (amd64, s390x, ppc64le)
- `multi-arch-manifest-push` to create and push manifest for multi-arch image - `quay.io/skopeo/upstream:master`, `quay.io/skopeo/stable:v1.2.0` and `quay.io/containers/skopeo:v1.2.0`

2 last stages are not done for pull request event or for non-master branch.

2 env variables in Travis are expected - QUAY_USERNAME and QUAY_PASSWORD to push the images to quay.io. 
As a result multi-arch image for 3 architectures is published.

The code is tested using another quay registry to push https://travis-ci.com/github/barthy1/skopeo/builds/194396214

Signed-off-by: Yulia Gaponenko <yulia.gaponenko1@de.ibm.com>