### PR TITLE
Make Makefile a little easier to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,12 @@ endif
 #     Note: Uses the -N -l go compiler options to disable compiler optimizations
 #           and inlining. Using these build options allows you to subsequently
 #           use source debugging tools like delve.
-all: binary docs-in-container
+all: bin/skopeo docs
 
 help:
 	@echo "Usage: make <target>"
+	@echo
+	@echo "Defaults to building bin/skopeo and docs"
 	@echo
 	@echo " * 'install' - Install binaries and documents to system locations"
 	@echo " * 'binary' - Build skopeo with a container"
@@ -134,7 +136,7 @@ build-container:
 	${CONTAINER_RUNTIME} build ${BUILD_ARGS} -t "$(IMAGE)" .
 
 $(MANPAGES): %: %.md
-	@sed -e 's/\((skopeo.*\.md)\)//' -e 's/\[\(skopeo.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $@
+	sed -e 's/\((skopeo.*\.md)\)//' -e 's/\[\(skopeo.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $@
 
 docs: $(MANPAGES)
 

--- a/install.md
+++ b/install.md
@@ -183,7 +183,7 @@ $ make docs
 
 Building in a container is simpler, but more restrictive:
 
-- It requires the `podman` command and the ability to run Linux containers
+- It requires the `podman` command and the ability to run Linux containers.
 - The created executable is a Linux executable, and depends on dynamic libraries
   which may only be available only in a container of a similar Linux
   distribution.

--- a/install.md
+++ b/install.md
@@ -157,18 +157,7 @@ $ git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containe
 $ cd $GOPATH/src/github.com/containers/skopeo && make bin/skopeo
 ```
 
-### Building in a container
-
-Building in a container is simpler, but more restrictive:
-
-- It requires the `podman` command and the ability to run Linux containers
-- The created executable is a Linux executable, and depends on dynamic libraries
-  which may only be available only in a container of a similar Linux
-  distribution.
-
-```bash
-$ make binary # Or (make all) to also build documentation, see below.
-```
+By default the `make` comman (make all) will build bin/skopeo and the documation locally.
 
 ### Building documentation
 
@@ -188,6 +177,19 @@ Then
 
 ```bash
 $ make docs
+```
+
+### Building in a container
+
+Building in a container is simpler, but more restrictive:
+
+- It requires the `podman` command and the ability to run Linux containers
+- The created executable is a Linux executable, and depends on dynamic libraries
+  which may only be available only in a container of a similar Linux
+  distribution.
+
+```bash
+$ make binary
 ```
 
 ### Installation

--- a/install.md
+++ b/install.md
@@ -157,7 +157,7 @@ $ git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containe
 $ cd $GOPATH/src/github.com/containers/skopeo && make bin/skopeo
 ```
 
-By default the `make` comman (make all) will build bin/skopeo and the documation locally.
+By default the `make` command (make all) will build bin/skopeo and the documentation locally.
 
 ### Building documentation
 


### PR DESCRIPTION
By default we should build bin/skopeo locally
and build docs locally.

Show output when doing make docs.

Add description in `make help` to explain default
behaviour.

Fixes: https://github.com/containers/skopeo/issues/580

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>