### PR TITLE
Use osusergo build tag for static build

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,7 +44,7 @@ let
       export CFLAGS='-static'
       export LDFLAGS='-s -w -static-libgcc -static'
       export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
-      export BUILDTAGS='static netgo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper'
+      export BUILDTAGS='static netgo osusergo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper'
     '';
     buildPhase = ''
       patchShebangs .


### PR DESCRIPTION
We now use the osusergo build tag to not use the glibc functions which
occur in the warnings but them from golang the os/user package.
