### PR TITLE
Avoid overriding LDFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ CONTAINER_RUN := $(CONTAINER_CMD) "$(IMAGE)"
 GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || true)
 
 EXTRA_LDFLAGS ?=
-LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} $(EXTRA_LDFLAGS)'
+SKOPEO_LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} $(EXTRA_LDFLAGS)'
 
 MANPAGES_MD = $(wildcard docs/*.md)
 MANPAGES ?= $(MANPAGES_MD:%.md=%)
@@ -127,9 +127,9 @@ static:
 # Build w/o using containers
 .PHONY: bin/skopeo
 bin/skopeo:
-	$(GPGME_ENV) $(GO) build $(MOD_VENDOR) ${GO_DYN_FLAGS} ${LDFLAGS} -gcflags "$(GOGCFLAGS)" -tags "$(BUILDTAGS)" -o $@ ./cmd/skopeo
+	$(GPGME_ENV) $(GO) build $(MOD_VENDOR) ${GO_DYN_FLAGS} ${SKOPEO_LDFLAGS} -gcflags "$(GOGCFLAGS)" -tags "$(BUILDTAGS)" -o $@ ./cmd/skopeo
 bin/skopeo.%:
-	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) $(GO) build $(MOD_VENDOR) ${LDFLAGS} -tags "containers_image_openpgp $(BUILDTAGS)" -o $@ ./cmd/skopeo
+	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) $(GO) build $(MOD_VENDOR) ${SKOPEO_LDFLAGS} -tags "containers_image_openpgp $(BUILDTAGS)" -o $@ ./cmd/skopeo
 local-cross: bin/skopeo.darwin.amd64 bin/skopeo.linux.arm bin/skopeo.linux.arm64 bin/skopeo.windows.386.exe bin/skopeo.windows.amd64.exe
 
 build-container:


### PR DESCRIPTION
Similar to https://github.com/containers/buildah/pull/2752:

#### What this PR does / why we need it:

`LDFLAGS` is a common/standard variable to hold linker flags for C/C++ compilers.
This PR uses a different name (`SKOPEO_LDFLAGS`) for the `-ldflags` passed on to Go so that we avoid overriding `LDFLAGS` set in the environment.

@mtrmac in https://github.com/containers/skopeo/pull/1099#pullrequestreview-525574335 :
> For the record, a missing part of the motivation is that CGo uses LDFLAGS when referring to C libraries, so this breaks overriding e.g. paths with `-L`.