### PR TITLE
Support namespaced logins for quay.io

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -4,6 +4,15 @@
 export DOCKER_CLI_EXPERIMENTAL=enabled
 GOARCH ?= $(shell go env GOARCH)
 
+# Dereference variable $(1), return value if non-empty, otherwise raise an error.
+err_if_empty = $(if $(strip $($(1))),$(strip $($(1))),$(error Required $(1) variable is undefined or empty))
+
+# Requires two arguments: Names of the username and the password env. vars.
+define quay_login
+	@echo "$(call err_if_empty,$(2))" | \
+		docker login quay.io -u "$(call err_if_empty,$(1))" --password-stdin
+endef
+
 # Build container image of skopeo upstream based on host architecture
 build-image/upstream:
 	docker build -t "${UPSTREAM_IMAGE}-${GOARCH}" contrib/skopeoimage/upstream
@@ -14,27 +23,29 @@ build-image/stable:
 
 # Push container image of skopeo upstream (based on host architecture) to image repository
 push-image/upstream:
-	echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
+	$(call quay_login,SKOPEO_QUAY_USERNAME,SKOPEO_QUAY_PASSWORD)
 	docker push "${UPSTREAM_IMAGE}-${GOARCH}"
 
 # Push container image of skopeo stable (based on host architecture) to image default and extra repositories
 push-image/stable:
-	echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
+	$(call quay_login,SKOPEO_QUAY_USERNAME,SKOPEO_QUAY_PASSWORD)
 	docker push "${STABLE_IMAGE}-${GOARCH}"
 	docker tag "${STABLE_IMAGE}-${GOARCH}" "${EXTRA_STABLE_IMAGE}-${GOARCH}"
+	$(call quay_login,CONTAINERS_QUAY_USERNAME,CONTAINERS_QUAY_PASSWORD)
 	docker push "${EXTRA_STABLE_IMAGE}-${GOARCH}"
 
 # Create and push multiarch image manifest of skopeo upstream
 push-manifest-multiarch/upstream:
-	echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
 	docker manifest create "${UPSTREAM_IMAGE}" $(foreach arch,${MULTIARCH_MANIFEST_ARCHITECTURES}, ${UPSTREAM_IMAGE}-${arch})
+	$(call quay_login,SKOPEO_QUAY_USERNAME,SKOPEO_QUAY_PASSWORD)
 	docker manifest push --purge "${UPSTREAM_IMAGE}"
 
 # Create and push multiarch image manifest of skopeo stable
 push-manifest-multiarch/stable:
-	echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
 	docker manifest create "${STABLE_IMAGE}" $(foreach arch,${MULTIARCH_MANIFEST_ARCHITECTURES}, ${STABLE_IMAGE}-${arch})
+	$(call quay_login,SKOPEO_QUAY_USERNAME,SKOPEO_QUAY_PASSWORD)
 	docker manifest push --purge "${STABLE_IMAGE}"
 	# Push to extra repository
 	docker manifest create "${EXTRA_STABLE_IMAGE}" $(foreach arch,${MULTIARCH_MANIFEST_ARCHITECTURES}, ${EXTRA_STABLE_IMAGE}-${arch})
+	$(call quay_login,CONTAINERS_QUAY_USERNAME,CONTAINERS_QUAY_PASSWORD)
 	docker manifest push --purge "${EXTRA_STABLE_IMAGE}"


### PR DESCRIPTION
Service accounts (a.k.a. robots) in `quay.io` are forcably namespaced
to the user or orginization under which they are created.  Therefore,
it is impossible to use a common login/password to push images for
both `skopeo` and `containers` namespaces.  Worse, because the
authentication is recorded against `quay.io`, multiple login sessions
are required.

Fix this by adding a function definition which verifies non-empty
username/password arguments, before logging in.  Call this function
as needed from relevant targets, prior to pushing images.

Signed-off-by: Chris Evich <cevich@redhat.com>