### PR TITLE
Update to macOS 10.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
       <<: *local-build
       name: local build for osx
       os: osx
+      osx_image: xcode11.3
       install:
         # Ideally, the (brew update) should not be necessary and Travis would have fairly
         # frequently updated OS images; that's not been the case historically.
@@ -64,7 +65,6 @@ jobs:
         # since the last OS image build (as of July 2020), but the Travis OS still
         # contains it, and it prevents updating of Python 3.
       - brew update && brew unlink python@2 && brew install gpgme
-      - sudo rm -rf /Library/Developer/CommandLineTools && sudo xcode-select --install
       script:
       - hack/travis_osx.sh
     - stage: local-build


### PR DESCRIPTION
<s>We are updating it because Homebrew warns about the old version, so updating it only afterwards does not help.</s>

Homebrew:
> Warning: You are using macOS 10.13.
> We (and Apple) do not provide support for this old version.
> You will encounter build failures with some formulae.
    
So, update to the 10.14 major version, fully-updated.
    
Also remove the Xcode update attempt, it was added before Homebrew was warning about the Xcode version, but updating only after running Homebrew does not help, and anyway it does not complain anymore after the update.
