### PR TITLE
Update nix pin with `make nixpkgs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ binary: cmd/skopeo
 # Update nix/nixpkgs.json its latest stable commit
 .PHONY: nixpkgs
 nixpkgs:
-	@nix run -f channel:nixos-20.03 nix-prefetch-git -c nix-prefetch-git \
+	@nix run -f channel:nixos-20.09 nix-prefetch-git -c nix-prefetch-git \
 		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
 
 # Build statically linked binary

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -38,10 +38,10 @@ let
     doCheck = false;
     enableParallelBuilding = true;
     outputs = [ "out" ];
-    nativeBuildInputs = [ bash git go-md2man installShellFiles makeWrapper pkg-config which ];
+    nativeBuildInputs = [ bash gitMinimal go-md2man installShellFiles makeWrapper pkg-config which ];
     buildInputs = [ glibc glibc.static gpgme libassuan libgpgerror libseccomp ];
     prePatch = ''
-      export CFLAGS='-static'
+      export CFLAGS='-static -pthread'
       export LDFLAGS='-s -w -static-libgcc -static'
       export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
       export BUILDTAGS='static netgo osusergo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper'

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,10 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "6e089d30148953df7abb3a1167169afc7848499c",
-  "date": "2020-11-05T09:56:30+01:00",
-  "sha256": "0ydqjkz7payl16psx445jwh6dc6lgbvj2w11xin1dqvbpcp03jcy",
-  "fetchSubmodules": false
+  "rev": "6ea2fd15d881006b41ea5bbed0f76bffcd85f9f9",
+  "date": "2020-12-20T13:26:58+10:00",
+  "path": "/nix/store/kyw1ackbp9qh1jzlzwmjvi5i3541ym5z-nixpkgs",
+  "sha256": "0kgqmw4ki10b37530jh912sn49x3gay5cnmfr8yz2yp8nvkrk236",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
 }


### PR DESCRIPTION
Regular monthly update; BTW, it is now failing as below:

```
$ nix build -f nix/
waiting for locks or build slots...
builder for '/nix/store/xv4pk3h76fzc7hzan3kkh3wizqv7mah6-gts-0.7.6.drv' failed with exit code 2; last 10 log lines:
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../src/.libs/libgts.so: undefined reference to `pthread_create'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../src/.libs/libgts.so: undefined reference to `pthread_mutexattr_init'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../src/.libs/libgts.so: undefined reference to `pthread_mutexattr_destroy'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../src/.libs/libgts.so: undefined reference to `pthread_rwlock_tryrdlock'
  collect2: error: ld returned 1 exit status
  make[2]: *** [Makefile:467: gts2oogl] Error 1
  make[2]: Leaving directory '/tmp/nix-build-gts-0.7.6.drv-0/gts-0.7.6/tools'
  make[1]: *** [Makefile:475: all-recursive] Error 1
  make[1]: Leaving directory '/tmp/nix-build-gts-0.7.6.drv-0/gts-0.7.6'
  make: *** [Makefile:382: all] Error 2
cannot build derivation '/nix/store/qm7anx3kv6hywx6f1xqk3j5pf8sqf863-graphviz-2.42.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/alwwif59i7f0kbmvkvwdlmx7w7qn5wxz-wayland-1.18.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/9iccccxy564fbsn53p6srv3063pq26a7-mesa-20.2.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/ydi019q8g69fwwn8v7wvg86qwpla8rgc-libGL-1.3.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/d5nmji8lw80skxz3szd7mrab8aqwpgi6-cairo-1.16.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/d6mvckwy2i2gsry6kxnlbxf7qmw21wqm-ruby2.6.6-mathematical-1.6.12.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/4gvrvagafg0y92frjhyrnyh2q6cs24d1-asciidoctor-2.0.10.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/2wj33m7l7gxam92z4prv72q6n9zvr860-asciidoctor-2.0.10.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/z6jc188ckfrfqpqwr8zzg0rpjfhwn2li-git-2.29.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/jg1jcbxwynpj13g62biky003kv9v4vzl-skopeo.drv': 1 dependencies couldn't be built
[0 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/jg1jcbxwynpj13g62biky003kv9v4vzl-skopeo.drv' failed
```