### PR TITLE
Skip updating Homebrew on macOS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,12 +59,7 @@ jobs:
       os: osx
       osx_image: xcode11.3
       install:
-        # Ideally, the (brew update) should not be necessary and Travis would have fairly
-        # frequently updated OS images; that's not been the case historically.
-        # In particular, explicitly unlink python@2, which has been removed from Homebrew
-        # since the last OS image build (as of July 2020), but the Travis OS still
-        # contains it, and it prevents updating of Python 3.
-      - brew update && brew unlink python@2 && brew install gpgme
+      - brew install gpgme
       script:
       - hack/travis_osx.sh
     - stage: local-build


### PR DESCRIPTION
Currently, the Homebrew commands take about 15 out of 17-18 minutes of the macOS test run.

So, drop updating to latest versions of everything, and let's see what happens.
