### PR TITLE
fix creds sync from yaml

### DIFF
--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -280,8 +280,9 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 	serverCtx.DockerDaemonCertPath = cfg.CertDir
 	serverCtx.DockerDaemonInsecureSkipTLSVerify = (cfg.TLSVerify.skip == types.OptionalBoolTrue)
 	serverCtx.DockerInsecureSkipTLSVerify = cfg.TLSVerify.skip
-	serverCtx.DockerAuthConfig = &cfg.Credentials
-
+	if cfg.Credentials != (types.DockerAuthConfig{}) {
+		serverCtx.DockerAuthConfig = &cfg.Credentials
+	}
 	var repoDescList []repoDescriptor
 	for imageName, refs := range cfg.Images {
 		repoLogger := logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
   Pass down the creds from yaml file only if the values are not empty.
   Enables to use credentials from other authfiles alternatively.
close: #1122 
Signed-off-by: Qi Wang <qiwan@redhat.com>