### PR TITLE
Fix reading the after-sync list of tags in SyncSuite.TestYamlUntagged

### DIFF
--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -262,7 +262,9 @@ docker.io:
 	sysCtx = types.SystemContext{
 		DockerInsecureSkipTLSVerify: types.NewOptionalBool(true),
 	}
-	localTags, err := docker.GetRepositoryTags(context.Background(), &sysCtx, imageRef)
+	localImageRef, err := docker.ParseReference(fmt.Sprintf("//%s/%s", v2DockerRegistryURL, imagePath))
+	c.Assert(err, check.IsNil)
+	localTags, err := docker.GetRepositoryTags(context.Background(), &sysCtx, localImageRef)
 	c.Assert(err, check.IsNil)
 	c.Check(len(localTags), check.Not(check.Equals), 0)
 	c.Assert(len(localTags), check.Equals, len(tags))


### PR DESCRIPTION
From https://github.com/containers/skopeo/pull/1146#discussion_r552718986 .

Filed somewhat as a reminder, this may need updating after #1146.