### PR TITLE
Set User-Agent to skopeo/$VERSION

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -17,6 +17,8 @@ import (
 // and will be populated by the Makefile
 var gitCommit = ""
 
+var defaultUserAgent = "skopeo/" + version.Version
+
 type globalOptions struct {
 	debug              bool          // Enable debug output
 	tlsVerify          optionalBool  // Require HTTPS and verify certificates (for docker: and docker-daemon:)
@@ -143,6 +145,7 @@ func (opts *globalOptions) newSystemContext() *types.SystemContext {
 		VariantChoice:            opts.overrideVariant,
 		SystemRegistriesConfPath: opts.registriesConfPath,
 		BigFilesTemporaryDir:     opts.tmpDir,
+		DockerRegistryUserAgent:  defaultUserAgent,
 	}
 	// DEPRECATED: We support this for backward compatibility, but override it if a per-image flag is provided.
 	if opts.tlsVerify.present {

--- a/cmd/skopeo/main_test.go
+++ b/cmd/skopeo/main_test.go
@@ -23,7 +23,10 @@ func TestGlobalOptionsNewSystemContext(t *testing.T) {
 	// Default state
 	opts, _ := fakeGlobalOptions(t, []string{})
 	res := opts.newSystemContext()
-	assert.Equal(t, &types.SystemContext{}, res)
+	assert.Equal(t, &types.SystemContext{
+		// User-Agent is set by default.
+		DockerRegistryUserAgent: defaultUserAgent,
+	}, res)
 	// Set everything to non-default values.
 	opts, _ = fakeGlobalOptions(t, []string{
 		"--registries.d", "/srv/registries.d",
@@ -43,5 +46,6 @@ func TestGlobalOptionsNewSystemContext(t *testing.T) {
 		BigFilesTemporaryDir:        "/srv",
 		SystemRegistriesConfPath:    "/srv/registries.conf",
 		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+		DockerRegistryUserAgent:     defaultUserAgent,
 	}, res)
 }

--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -37,7 +37,9 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 	opts := fakeImageOptions(t, "dest-", []string{}, []string{})
 	res, err := opts.newSystemContext()
 	require.NoError(t, err)
-	assert.Equal(t, &types.SystemContext{}, res)
+	assert.Equal(t, &types.SystemContext{
+		DockerRegistryUserAgent: defaultUserAgent,
+	}, res)
 
 	// Set everything to non-default values.
 	opts = fakeImageOptions(t, "dest-", []string{
@@ -72,6 +74,7 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 		DockerDaemonCertPath:              "/srv/cert-dir",
 		DockerDaemonHost:                  "daemon-host.example.com",
 		DockerDaemonInsecureSkipTLSVerify: true,
+		DockerRegistryUserAgent:           defaultUserAgent,
 		BigFilesTemporaryDir:              "/srv",
 	}, res)
 
@@ -129,7 +132,9 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 	opts := fakeImageDestOptions(t, "dest-", []string{}, []string{})
 	res, err := opts.newSystemContext()
 	require.NoError(t, err)
-	assert.Equal(t, &types.SystemContext{}, res)
+	assert.Equal(t, &types.SystemContext{
+		DockerRegistryUserAgent: defaultUserAgent,
+	}, res)
 
 	oldXRD, hasXRD := os.LookupEnv("REGISTRY_AUTH_FILE")
 	defer func() {
@@ -149,7 +154,10 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 	})
 	res, err = opts.newSystemContext()
 	require.NoError(t, err)
-	assert.Equal(t, &types.SystemContext{AuthFilePath: authFile}, res)
+	assert.Equal(t, &types.SystemContext{
+		AuthFilePath:            authFile,
+		DockerRegistryUserAgent: defaultUserAgent,
+	}, res)
 
 	// Set everything to non-default values.
 	opts = fakeImageDestOptions(t, "dest-", []string{
@@ -184,6 +192,7 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 		DockerDaemonCertPath:              "/srv/cert-dir",
 		DockerDaemonHost:                  "daemon-host.example.com",
 		DockerDaemonInsecureSkipTLSVerify: true,
+		DockerRegistryUserAgent:           defaultUserAgent,
 		DirForceCompress:                  true,
 		BigFilesTemporaryDir:              "/srv",
 	}, res)
@@ -233,7 +242,8 @@ func TestImageOptionsAuthfileOverride(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, &types.SystemContext{
-			AuthFilePath: testCase.expectedAuthfilePath,
+			AuthFilePath:            testCase.expectedAuthfilePath,
+			DockerRegistryUserAgent: defaultUserAgent,
 		}, res)
 	}
 }


### PR DESCRIPTION
Prior to this, the User-Agent used by containers/image would default to
the default User-Agent for golang, which makes it difficult to
distinguish skopeo from any other golang binaries in registry logs.

Fixes https://github.com/containers/skopeo/issues/1109

If you think this requires a test, I'm happy to add something, but `go test` fails to build for me because I'm missing certain header files, and I figured I'd give this a shot before diving into that 😉 

Signed-off-by: Jon Johnson <jonjohnson@google.com>