### PR TITLE
Set PREFIX on FreeBSD and use gpg-config to detect paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,15 @@ PREFIX ?= /usr/local
 
 ifeq ($(shell uname),Darwin)
 DARWIN_BUILD_TAG=
-# On macOS, (brew install gpgme) installs it within /usr/local, but /usr/local/include is not in the default search path.
-# Rather than hard-code this directory, use gpgme-config. Sadly that must be done at the top-level user
-# instead of locally in the gpgme subpackage, because cgo supports only pkg-config, not general shell scripts,
-# and gpgme does not install a pkg-config file.
+endif
+
+# On some plaforms (eg. macOS, FreeBSD) gpgme is installed in /usr/local/ but /usr/local/include/ is
+# not in the default search path. Rather than hard-code this directory, use gpgme-config.
+# Sadly that must be done at the top-level user instead of locally in the gpgme subpackage, because cgo 
+# supports only pkg-config, not general shell scripts, and gpgme does not install a pkg-config file.
 # If gpgme is not installed or gpgme-config can’t be found for other reasons, the error is silently ignored
 # (and the user will probably find out because the cgo compilation will fail).
 GPGME_ENV := CGO_CFLAGS="$(shell gpgme-config --cflags 2>/dev/null)" CGO_LDFLAGS="$(shell gpgme-config --libs 2>/dev/null)"
-endif
 
 CONTAINERSCONFDIR=/etc/containers
 REGISTRIESDDIR=${CONTAINERSCONFDIR}/registries.d


### PR DESCRIPTION
Unconditionally set PREFIX to /usr/local on FreeBSD and Darwin
platforms.
Use gpg-config to detect libraries paths on all platforms.

Fixes error with gpgme not able to locate gpgme.h on FreeBSD.

Ref https://github.com/containers/skopeo/issues/1163