### PR TITLE
Migrate tests from docker.io

### DIFF
--- a/systemtest/020-copy.bats
+++ b/systemtest/020-copy.bats
@@ -14,7 +14,7 @@ function setup() {
 # From remote, to dir1, to local, to dir2;
 # compare dir1 and dir2, expect no changes
 @test "copy: dir, round trip" {
-    local remote_image=docker://docker.io/library/busybox:latest
+    local remote_image=docker://quay.io/libpod/busybox:latest
     local localimg=docker://localhost:5000/busybox:unsigned
 
     local dir1=$TESTDIR/dir1
@@ -30,7 +30,7 @@ function setup() {
 
 # Same as above, but using 'oci:' instead of 'dir:' and with a :latest tag
 @test "copy: oci, round trip" {
-    local remote_image=docker://docker.io/library/busybox:latest
+    local remote_image=docker://quay.io/libpod/busybox:latest
     local localimg=docker://localhost:5000/busybox:unsigned
 
     local dir1=$TESTDIR/oci1
@@ -46,7 +46,7 @@ function setup() {
 
 # Compression zstd
 @test "copy: oci, round trip, zstd" {
-    local remote_image=docker://docker.io/library/busybox:latest
+    local remote_image=docker://quay.io/libpod/busybox:latest
 
     local dir=$TESTDIR/dir
 
@@ -61,7 +61,7 @@ function setup() {
 
 # Same image, extracted once with :tag and once without
 @test "copy: oci w/ and w/o tags" {
-    local remote_image=docker://docker.io/library/busybox:latest
+    local remote_image=docker://quay.io/libpod/busybox:latest
 
     local dir1=$TESTDIR/dir1
     local dir2=$TESTDIR/dir2
@@ -78,7 +78,7 @@ function setup() {
 
 # Registry -> storage -> oci-archive
 @test "copy: registry -> storage -> oci-archive" {
-    local alpine=docker.io/library/alpine:latest
+    local alpine=quay.io/libpod/alpine:latest
     local tmp=$TESTDIR/oci
 
     run_skopeo copy docker://$alpine containers-storage:$alpine

--- a/systemtest/030-local-registry-tls.bats
+++ b/systemtest/030-local-registry-tls.bats
@@ -14,7 +14,7 @@ function setup() {
 @test "local registry, with cert" {
     # Push to local registry...
     run_skopeo copy --dest-cert-dir=$TESTDIR/client-auth \
-               docker://docker.io/library/busybox:latest \
+               docker://quay.io/libpod/busybox:latest \
                docker://localhost:5000/busybox:unsigned
 
     # ...and pull it back out

--- a/systemtest/040-local-registry-auth.bats
+++ b/systemtest/040-local-registry-auth.bats
@@ -43,7 +43,7 @@ function setup() {
 
     # These should pass
     run_skopeo copy --dest-tls-verify=false --dcreds=$testuser:$testpassword \
-               docker://docker.io/library/busybox:latest \
+               docker://quay.io/libpod/busybox:latest \
                docker://localhost:5000/busybox:mine
     run_skopeo inspect --tls-verify=false --creds=$testuser:$testpassword \
                docker://localhost:5000/busybox:mine
@@ -55,7 +55,7 @@ function setup() {
     podman login --tls-verify=false -u $testuser -p $testpassword localhost:5000
 
     run_skopeo copy --dest-tls-verify=false \
-               docker://docker.io/library/busybox:latest \
+               docker://quay.io/libpod/busybox:latest \
                docker://localhost:5000/busybox:mine
     run_skopeo inspect --tls-verify=false docker://localhost:5000/busybox:mine
     expect_output --substring "localhost:5000/busybox"

--- a/systemtest/050-signing.bats
+++ b/systemtest/050-signing.bats
@@ -92,7 +92,7 @@ END_POLICY_JSON
     fi
 
     # Cache local copy
-    run_skopeo copy docker://docker.io/library/busybox:latest \
+    run_skopeo copy docker://quay.io/libpod/busybox:latest \
                dir:$TESTDIR/busybox
 
     # Push a bunch of images. Do so *without* --policy flag; this lets us

--- a/systemtest/060-delete.bats
+++ b/systemtest/060-delete.bats
@@ -13,7 +13,7 @@ function setup() {
 
 # delete image from registry
 @test "delete: remove image from registry" {
-    local remote_image=docker://docker.io/library/busybox:latest
+    local remote_image=docker://quay.io/libpod/busybox:latest
     local localimg=docker://localhost:5000/busybox:unsigned
     local output=
 

--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -6,7 +6,7 @@ SKOPEO_BINARY=${SKOPEO_BINARY:-$(dirname ${BASH_SOURCE})/../skopeo}
 SKOPEO_TIMEOUT=${SKOPEO_TIMEOUT:-300}
 
 # Default image to run as a local registry
-REGISTRY_FQIN=${SKOPEO_TEST_REGISTRY_FQIN:-docker.io/library/registry:2}
+REGISTRY_FQIN=${SKOPEO_TEST_REGISTRY_FQIN:-quay.io/libpod/registry:2}
 
 ###############################################################################
 # BEGIN setup/teardown

--- a/systemtest/make-noarch-manifest
+++ b/systemtest/make-noarch-manifest
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+# Tool for creating an image whose OS and arch will (probably) never
+# match a system on which skopeo will run. This image will be used
+# in the 'inspect' test.
+#
+set -ex
+
+# Name and tag of the image we create
+imgname=notmyarch
+imgtag=$(date +%Y%m%d)
+
+# (In case older image exists from a prior run)
+buildah rmi $imgname:$imgtag &>/dev/null || true
+
+#
+# Step 1: create an image containing only a README and a copy of this script
+#
+id=$(buildah from scratch)
+
+now=$(date --rfc-3339=seconds)
+readme=$(mktemp -t README.XXXXXXXX)
+ME=$(basename $0)
+
+cat >| $readme <<EOF
+This is a dummy image intended solely for skopeo testing.
+
+This image was created $now
+
+The script used to create this image is available as $ME
+EOF
+
+buildah copy $id $readme /README
+buildah copy $id $0      /$ME
+
+buildah commit $id my_tmp_image
+buildah rm     $id
+
+#
+# Step 2: create a manifest list, then add the above image but with
+# an os+arch override.
+#
+buildah manifest create $imgname:$imgtag
+
+buildah manifest add \
+        --os amigaos \
+        --arch mc68000 \
+        --variant 1000 \
+        $imgname:$imgtag my_tmp_image
+
+# Done. Show instructions.
+cat <<EOF
+DONE!
+
+You can inspect the created image with:
+
+    skopeo inspect --raw containers-storage:localhost/$imgname:$imgtag | jq .
+
+(FIXME: is there a way to, like, mount the image and verify the files?)
+
+If you're happy with this image, you can now:
+
+    buildah manifest push --all $imgname:$imgtag docker://quay.io/libpod/$imgname:$imgtag
+
+Once done, you urgently need to:
+
+    buildah rmi $imgname:$imgtag  my_tmp_image
+
+If you don't do this, 'podman images' will barf catastrophically!
+EOF


### PR DESCRIPTION
Switch to using images from quay.io/libpod instead, where
we're not (yet) subject to rate limiting.

Disable (skip) one test that I have no idea how to migrate,
because it needs only-one-arch images from docker.io/$arch.

Signed-off-by: Ed Santiago <santiago@redhat.com>