### PR TITLE
Bump skopoeoimage Dockerfiles to user Fedora 33

### DIFF
--- a/contrib/skopeoimage/stable/Dockerfile
+++ b/contrib/skopeoimage/stable/Dockerfile
@@ -6,7 +6,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:33
 
 # Don't include container-selinux and remove
 # directories used by yum that are just taking

--- a/contrib/skopeoimage/testing/Dockerfile
+++ b/contrib/skopeoimage/testing/Dockerfile
@@ -7,7 +7,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:33
 
 # Don't include container-selinux and remove
 # directories used by yum that are just taking

--- a/contrib/skopeoimage/upstream/Dockerfile
+++ b/contrib/skopeoimage/upstream/Dockerfile
@@ -6,7 +6,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:33
 
 # Don't include container-selinux and remove
 # directories used by yum that are just taking


### PR DESCRIPTION
The quay.io/skopeo/testing:latest image was showing v1.2.0 for a version when it
should have been showing at least v1.2.1.  The issue was the Fedora tag in the
Dockerfiles used to build the images was set to 32 and not the later 33.

Addresses: #1204

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>