### PR TITLE
Add local integration and system test targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN set -x \
 
 ENV GOPATH /usr/share/gocode:/go
 ENV PATH $GOPATH/bin:/usr/share/gocode/bin:$PATH
+ENV container_magic 85531765-346b-4316-bdb8-358e4cca9e5d
 RUN go version
 WORKDIR /go/src/github.com/containers/skopeo
 COPY . /go/src/github.com/containers/skopeo

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,11 @@ check: validate test-unit test-integration test-system
 
 # The tests can run out of entropy and block in containers, so replace /dev/random.
 test-integration: build-container
-	$(CONTAINER_RUN) bash -c 'rm -f /dev/random; ln -sf /dev/urandom /dev/random; SKOPEO_CONTAINER_TESTS=1 BUILDTAGS="$(BUILDTAGS)" hack/make.sh test-integration'
+	$(CONTAINER_RUN) bash -c 'rm -f /dev/random; ln -sf /dev/urandom /dev/random; SKOPEO_CONTAINER_TESTS=1 BUILDTAGS="$(BUILDTAGS)" $(MAKE) test-integration-local'
+
+# Intended for CI, shortcut 'build-container' since already running inside container.
+test-integration-local:
+	hack/make.sh test-integration
 
 # complicated set of options needed to run podman-in-podman
 test-system: build-container
@@ -181,10 +185,14 @@ test-system: build-container
 	$(CONTAINER_CMD) --privileged \
 	    -v $$DTEMP:/var/lib/containers:Z -v /run/systemd/journal/socket:/run/systemd/journal/socket \
             "$(IMAGE)" \
-            bash -c 'BUILDTAGS="$(BUILDTAGS)" hack/make.sh test-system'; \
+            bash -c 'BUILDTAGS="$(BUILDTAGS)" $(MAKE) test-system-local'; \
 	rc=$$?; \
 	$(RM) -rf $$DTEMP; \
 	exit $$rc
+
+# Intended for CI, shortcut 'build-container' since already running inside container.
+test-system-local:
+	hack/make.sh test-system
 
 test-unit: build-container
 	# Just call (make test unit-local) here instead of worrying about environment differences

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -25,12 +25,8 @@ export MAKEDIR="$SCRIPTDIR/make"
 
 # We're a nice, sexy, little shell script, and people might try to run us;
 # but really, they shouldn't. We want to be in a container!
-inContainer="AssumeSoInitially"
-if [ "$PWD" != "/go/src/$SKOPEO_PKG" ]; then
-	unset inContainer
-fi
-
-if [ -z "$inContainer" ]; then
+# The magic value is defined inside our Dockerfile.
+if [[ "$container_magic" != "85531765-346b-4316-bdb8-358e4cca9e5d" ]]; then
 	{
 		echo "# WARNING! I don't seem to be running in a Docker container."
 		echo "# The result of this command might be an incorrect build, and will not be"


### PR DESCRIPTION
These tests need to operate as part of the c/image repository CI to
verify downstream-usage.  That environment is already inside the
container built from the Dockerfile (here).  Support this use-case by
adding 'local' targets which bypass the container build.  Also,
simplify the "in-container" check to more specifically verify the exact
container image it's operating under.

Ref: https://github.com/containers/image/pull/1140

Signed-off-by: Chris Evich <cevich@redhat.com>