### PR TITLE
Fix skipping tests in test container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ ifeq ($(GOBIN),)
 GOBIN := $(GOPATH)/bin
 endif
 
+# Required for integration-tests to detect they are running inside a specific
+# container image.  Env. var defined in image, make does not automatically
+# pass to children unless explicitly exported
+export container_magic
 CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
 GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
 

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -35,6 +35,9 @@ if [[ "$container_magic" != "85531765-346b-4316-bdb8-358e4cca9e5d" ]]; then
 		echo "# Try this instead: make all"
 		echo "#"
 	} >&2
+else
+    echo "# I appear to be running inside my designated container image, good!"
+    export SKOPEO_CONTAINER_TESTS=1
 fi
 
 echo


### PR DESCRIPTION
Without this env. var. being set from hack/make.sh, many/most
integration tests will `SKIP`.  Fix this by notifying the user
and setting the magic `SKOPEO_CONTAINER_TESTS` variable.

Signed-off-by: Chris Evich <cevich@redhat.com>