### PR TITLE
Add system tests

### DIFF
--- a/systemtest/030-local-registry-tls.bats
+++ b/systemtest/030-local-registry-tls.bats
@@ -8,7 +8,7 @@ load helpers
 function setup() {
     standard_setup
 
-    start_registry --with-cert reg
+    start_registry --with-cert --enable-delete=true reg
 }
 
 @test "local registry, with cert" {
@@ -21,6 +21,15 @@ function setup() {
     run_skopeo copy --src-cert-dir=$TESTDIR/client-auth \
                docker://localhost:5000/busybox:unsigned \
                dir:$TESTDIR/extracted
+
+    # inspect with cert
+    run_skopeo inspect --cert-dir=$TESTDIR/client-auth \
+               docker://localhost:5000/busybox:unsigned
+    expect_output --substring "localhost:5000/busybox"
+
+    # delete with cert
+    run_skopeo delete --cert-dir=$TESTDIR/client-auth \
+               docker://localhost:5000/busybox:unsigned
 }
 
 teardown() {


### PR DESCRIPTION
Add system tests for the following subcommands and flags:
- skopeo copy --format
- skopeo copy --additional-tag
- skopeo copy --dest-shared-blob-dir
- skopeo copy --src-shared-blob-dir
- skopeo inspect --tls-verify --cert-dir
- skopeo delete --tls-verify --cert-dir
- skopeo copy --dest-creds
- skopeo copy --src-creds
- skopeo copy --authfile
- skopeo inspect --authfile
- skopeo delete --authfile
- skopeo copy --remove-signatures
- skopeo standalone-sign
- skopeo standalone-verify
- skopeo manifest-digest

Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>