### PR TITLE
skopeo images: set authfile to /tmp/auth.json

### DIFF
--- a/contrib/skopeoimage/stable/Dockerfile
+++ b/contrib/skopeoimage/stable/Dockerfile
@@ -27,7 +27,7 @@ RUN echo skopeo:100000:65536 > /etc/subuid
 RUN echo skopeo:100000:65536 > /etc/subgid
 
 # Point to the Authorization file
-ENV REGISTRY_AUTH_FILE=/auth.json
+ENV REGISTRY_AUTH_FILE=/tmp/auth.json
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/bin/skopeo"]

--- a/contrib/skopeoimage/testing/Dockerfile
+++ b/contrib/skopeoimage/testing/Dockerfile
@@ -28,7 +28,7 @@ RUN echo skopeo:100000:65536 > /etc/subuid
 RUN echo skopeo:100000:65536 > /etc/subgid
 
 # Point to the Authorization file
-ENV REGISTRY_AUTH_FILE=/auth.json
+ENV REGISTRY_AUTH_FILE=/tmp/auth.json
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/bin/skopeo"]

--- a/contrib/skopeoimage/upstream/Dockerfile
+++ b/contrib/skopeoimage/upstream/Dockerfile
@@ -48,7 +48,7 @@ RUN echo skopeo:100000:65536 > /etc/subuid
 RUN echo skopeo:100000:65536 > /etc/subgid
 
 # Point to the Authorization file
-ENV REGISTRY_AUTH_FILE=/auth.json
+ENV REGISTRY_AUTH_FILE=/tmp/auth.json
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/bin/skopeo"]


### PR DESCRIPTION
The Skopeo images set `REGISTRY_AUTH_FILE=/auth.json` which is breaking
non-root users inside the container from logging in (`/` is writable by
root only).  Setting it to `/tmp/auth.json` will support running
non-root users inside the container.

Fixes: #1233
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>