### PR TITLE
Makefile: Ensure policy.json uses new variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,8 @@ clean:
 
 install: install-binary install-docs install-completions
 	install -d -m 755 ${DESTDIR}/${SIGSTOREDIR}
-	install -d -m 755 ${DESTDIR}/${CONTAINERSCONFIGDIR}
-	install -m 644 default-policy.json ${DESTDIR}/${CONTAINERSCONFIGDIR}/policy.json
+	install -d -m 755 ${DESTDIR}/${CONTAINERSCONFDIR}
+	install -m 644 default-policy.json ${DESTDIR}/${CONTAINERSCONFDIR}/policy.json
 	install -d -m 755 ${DESTDIR}/${REGISTRIESDDIR}
 	install -m 644 default.yaml ${DESTDIR}/${REGISTRIESDDIR}/default.yaml
 


### PR DESCRIPTION
In 18e6c6f17b1ef900e3a3ce4cde94ab23073b9ebf there where changes to
better handle PREFIX and DESTDIR in the Makefile. "CONTAINERSCONFIGDIR"
was renamed to "CONTAINERSCONFDIR" without ensuring it was correct in
the install block. This results in policy.json being isntalled into
"${DESTDIR}/" which is "/policy.json" for Linux distros.

Signed-off-by: Morten Linderud <morten@linderud.pw>