### PR TITLE
Remove older distro docs

### DIFF
--- a/install.md
+++ b/install.md
@@ -44,14 +44,6 @@ sudo dnf -y install skopeo
 sudo yum -y install skopeo
 ```
 
-Newer Skopeo releases may be available on the repositories provided by the
-Kubic project. Beware, these may not be suitable for production environments.
-
-```sh
-sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/devel:kubic:libcontainers:stable.repo
-sudo yum -y install skopeo
-```
-
 ### openSUSE
 
 ```sh
@@ -87,49 +79,6 @@ sudo apt-get update
 sudo apt-get -y install skopeo
 ```
 
-If you would prefer newer (though not as well-tested) packages,
-the [Kubic project](https://build.opensuse.org/package/show/devel:kubic:libcontainers:stable/skopeo)
-provides packages for Debian 10 and newer. The packages in Kubic project repos are more frequently
-updated than the one in Debian's official repositories, due to how Debian works.
-The build sources for the Kubic packages can be found [here](https://gitlab.com/rhcontainerbot/skopeo/-/tree/debian/debian).
-
-CAUTION: On Debian 11 and newer, including Debian Testing and Sid, we highly recommend you use Buildah, Podman and Skopeo ONLY from EITHER the Kubic repo
-OR the official Debian repos. Mixing and matching may lead to unpredictable situations including installation conflicts.
-
-```bash
-# Debian 10
-echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/Release.key | sudo apt-key add -
-sudo apt-get update
-sudo apt-get -y install skopeo
-
-# Debian Testing
-echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_Testing/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_Testing/Release.key | sudo apt-key add -
-sudo apt-get update
-sudo apt-get -y install skopeo
-
-# Debian Sid/Unstable
-echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_Unstable/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_Unstable/Release.key | sudo apt-key add -
-sudo apt-get update
-sudo apt-get -y install skopeo
-```
-
-
-### Raspberry Pi OS armhf (ex Raspbian)
-
-The Kubic project provides packages for Raspbian 10.
-
-```bash
-# Raspbian 10
-echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Raspbian_10/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Raspbian_10/Release.key | sudo apt-key add -
-sudo apt-get update -qq
-sudo apt-get -qq -y install skopeo
-```
-
-
 ### Raspberry Pi OS arm64 (beta)
 
 Raspberry Pi OS uses the standard Debian's repositories,
@@ -150,7 +99,7 @@ sudo apt-get -y install skopeo
 
 If you would prefer newer (though not as well-tested) packages,
 the [Kubic project](https://build.opensuse.org/package/show/devel:kubic:libcontainers:stable/skopeo)
-provides packages for active Ubuntu releases 18.04 and newer (it should also work with direct derivatives like Pop!\_OS).
+provides packages for active Ubuntu releases 20.04 and newer (it should also work with direct derivatives like Pop!\_OS).
 Checkout the [Kubic project page](https://build.opensuse.org/package/show/devel:kubic:libcontainers:stable/skopeo)
 for a list of supported Ubuntu version and
 architecture combinations. **NOTE:** The command `sudo apt-get -y upgrade`


### PR DESCRIPTION
This commit removes installation steps for older distros:

1. Amazon Linux 2
2. CentOS 7
3. Debian 10
4. Raspbian 10
5. Raspberry Pi OS armhf

We're no longer building new packages for these distros and the
installation steps for older packages are no longer guaranteed to work.
So, these are best removed from the official docs.

Related blog post (also applies to skopeo):
https://podman.io/blogs/2021/03/02/podman-support-for-older-distros.html

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@TomSweeneyRedHat @rhatdan @vrothberg PTAL