### PR TITLE
Add the missing import and a gitignore entry for bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ result
 
 # ignore JetBrains IDEs (GoLand) config folder
 .idea
+
+# Ignore the bin directory
+bin

--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/common/pkg/retry"
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
 	encconfig "github.com/containers/ocicrypt/config"


### PR DESCRIPTION
Compilation error in copy.go fixed by adding the import statement.