### PR TITLE
install.md Building Docs needs MacOS section

### DIFF
--- a/install.md
+++ b/install.md
@@ -182,6 +182,11 @@ sudo apt-get install go-md2man
 sudo dnf install go-md2man
 ```
 
+```
+# MacOS:
+brew install go-md2man
+```
+
 Then
 
 ```bash


### PR DESCRIPTION
The Building Documentation section of the `install.md` also needs a MacOS section because go-md2man is not present there, by default, either.