### PR TITLE
Reintroduce the GNU semantics of DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ export GOPROXY=https://proxy.golang.org
 # (and the user will probably find out because the cgo compilation will fail).
 GPGME_ENV := CGO_CFLAGS="$(shell gpgme-config --cflags 2>/dev/null)" CGO_LDFLAGS="$(shell gpgme-config --libs 2>/dev/null)"
 
-# Normally empty, DESTDIR can be used to relocate the entire install-tree
+# The following variables very roughly follow https://www.gnu.org/prep/standards/standards.html#Makefile-Conventions .
 DESTDIR ?=
-CONTAINERSCONFDIR ?= ${DESTDIR}/etc/containers
+PREFIX ?= /usr/local
+CONTAINERSCONFDIR ?= /etc/containers
 REGISTRIESDDIR ?= ${CONTAINERSCONFDIR}/registries.d
-SIGSTOREDIR ?= ${DESTDIR}/var/lib/containers/sigstore
-PREFIX ?= ${DESTDIR}/usr/local
+SIGSTOREDIR ?= /var/lib/containers/sigstore
 BINDIR ?= ${PREFIX}/bin
 MANDIR ?= ${PREFIX}/share/man
 BASHCOMPLETIONSDIR ?= ${PREFIX}/share/bash-completion/completions
@@ -153,23 +153,23 @@ clean:
 	rm -rf bin docs/*.1
 
 install: install-binary install-docs install-completions
-	install -d -m 755 ${SIGSTOREDIR}
-	install -d -m 755 ${CONTAINERSCONFDIR}
-	install -m 644 default-policy.json ${CONTAINERSCONFDIR}/policy.json
-	install -d -m 755 ${REGISTRIESDDIR}
-	install -m 644 default.yaml ${REGISTRIESDDIR}/default.yaml
+	install -d -m 755 ${DESTDIR}${SIGSTOREDIR}
+	install -d -m 755 ${DESTDIR}${CONTAINERSCONFDIR}
+	install -m 644 default-policy.json ${DESTDIR}${CONTAINERSCONFDIR}/policy.json
+	install -d -m 755 ${DESTDIR}${REGISTRIESDDIR}
+	install -m 644 default.yaml ${DESTDIR}${REGISTRIESDDIR}/default.yaml
 
 install-binary: bin/skopeo
-	install -d -m 755 ${BINDIR}
-	install -m 755 bin/skopeo ${BINDIR}/skopeo
+	install -d -m 755 ${DESTDIR}${BINDIR}
+	install -m 755 bin/skopeo ${DESTDIR}${BINDIR}/skopeo
 
 install-docs: docs
-	install -d -m 755 ${MANDIR}/man1
-	install -m 644 docs/*.1 ${MANDIR}/man1
+	install -d -m 755 ${DESTDIR}${MANDIR}/man1
+	install -m 644 docs/*.1 ${DESTDIR}${MANDIR}/man1
 
 install-completions:
-	install -m 755 -d ${BASHCOMPLETIONSDIR}
-	install -m 644 completions/bash/skopeo ${BASHCOMPLETIONSDIR}/skopeo
+	install -m 755 -d ${DESTDIR}${BASHCOMPLETIONSDIR}
+	install -m 644 completions/bash/skopeo ${DESTDIR}${BASHCOMPLETIONSDIR}/skopeo
 
 shell: build-container
 	$(CONTAINER_RUN) bash


### PR DESCRIPTION
This partially reverts commit a81cd747341e04783e7e3a94a76c4444c3bd5cd8 so that most path variables like `PREFIX` and `BINDIR` refer to paths on the installed system, and `DESTDIR` is used only in `make install`, following the philosophy of the GNU coding standards for path variables. (But not precisely the variable names, which are lowercase in the standard, nor the principle that even `SYSCONFDIR` should be under `$PREFIX`.)

Keep the use of `?=` instead of `=` because it somewhat better expresses the idea that the values can be overridden.

Use `${DESTDIR}${BINDIR}` instead of `${DESTDIR}/${BINDIR}` etc, so that a plain `make install` does not use paths like `//usr/bin/...` ; strictly speaking they are IIRC reserved by POSIX, and more importantly it just looks untidy :)

Cc: @cevich This originally appeared in #1252, and I might be missing something that expects the other semantics.