### PR TITLE
Misc man-page-checker RFCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test-unit: build-container
 	$(CONTAINER_RUN) make test-unit-local BUILDTAGS='$(BUILDTAGS)'
 
 validate: build-container
-	$(CONTAINER_RUN) hack/make.sh validate-git-marks validate-gofmt validate-lint validate-vet
+	$(CONTAINER_RUN) make validate-local
 
 # This target is only intended for development, e.g. executing it from an IDE. Use (make test) for CI or pre-release testing.
 test-all-local: validate-local test-unit-local

--- a/cmd/skopeo/signing.go
+++ b/cmd/skopeo/signing.go
@@ -18,7 +18,7 @@ type standaloneSignOptions struct {
 func standaloneSignCmd() *cobra.Command {
 	opts := standaloneSignOptions{}
 	cmd := &cobra.Command{
-		Use:   "standalone-sign [command options] MANIFEST DOCKER-REFERENCE KEY-FINGERPRINT",
+		Use:   "standalone-sign [command options] MANIFEST DOCKER-REFERENCE KEY-FINGERPRINT --output|-o SIGNATURE",
 		Short: "Create a signature using local files",
 		RunE:  commandAction(opts.run),
 	}

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -1,7 +1,7 @@
 % skopeo-list-tags(1)
 
 ## NAME
-skopeo\-list\-tags - Return a list of tags for the transport-specific image repository.
+skopeo\-list\-tags - List tags in the transport-specific image repository.
 
 ## SYNOPSIS
 **skopeo list-tags** [*options*] _repository-name_

--- a/docs/skopeo-standalone-sign.1.md
+++ b/docs/skopeo-standalone-sign.1.md
@@ -4,7 +4,7 @@
 skopeo\-standalone-sign - Debugging tool - Publish and sign an image in one step.
 
 ## SYNOPSIS
-**skopeo standalone-sign** [*options*] _manifest_ _docker-reference_ _key-fingerprint_
+**skopeo standalone-sign** [*options*] _manifest_ _docker-reference_ _key-fingerprint_ **--output**|**-o** _signature_
 
 ## DESCRIPTION
 This is primarily a debugging tool, or useful for special cases,

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -80,7 +80,7 @@ See [containers-transports(5)](https://github.com/containers/image/blob/master/d
 | [skopeo-copy(1)](skopeo-copy.1.md)        | Copy an image (manifest, filesystem layers, signatures) from one location to another. |
 | [skopeo-delete(1)](skopeo-delete.1.md)    | Mark the _image-name_ for later deletion by the registry's garbage collector.  |
 | [skopeo-inspect(1)](skopeo-inspect.1.md)  | Return low-level information about _image-name_ in a registry.                 |
-| [skopeo-list-tags(1)](skopeo-list-tags.1.md)  | Return a list of tags for the transport-specific image repository.         |
+| [skopeo-list-tags(1)](skopeo-list-tags.1.md)  | List tags in the transport-specific image repository.                      |
 | [skopeo-login(1)](skopeo-login.1.md)  | Login to a container registry. |
 | [skopeo-logout(1)](skopeo-logout.1.md)  | Logout of a container registry. |
 | [skopeo-manifest-digest(1)](skopeo-manifest-digest.1.md)    | Compute a manifest digest for a manifest-file and write it to standard output. |

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -99,6 +99,9 @@ function compare_usage() {
     from_man=$(sed  -E -e 's/^\[\*options\*\][[:space:]]*//' <<<"$from_man")
     from_help=$(sed -E -e 's/^\[command options\][[:space:]]*//'      <<<"$from_help")
 
+    # Constant strings in man page are '**foo**', in --help are 'foo'.
+    from_man=$(sed -E -e 's/\*\*([^*]+)\*\*/\1/g' <<<"$from_man")
+
     # Args in man page are '*foo*', in --help are 'FOO'. Convert all to
     # UPCASE simply because it stands out better to the eye.
     from_man=$(sed -E -e 's/_([a-z-]+)_/\U\1/g' <<<"$from_man")
@@ -121,7 +124,7 @@ for md in *.1.md;do
     # arguments are bracketed by single ones.
     #   E.g. '**skopeo copy** [*options*] _..._'
     # Get the command name, and confirm that it matches the md file name.
-    cmd=$(echo "$synopsis" | sed -E -e 's/(.*)\*\*.*/\1/' | tr -d \*)
+    cmd=$(echo "$synopsis" | sed -E -e 's/^\*\*([^*]+)\*\*.*/\1/' | tr -d \*)
     # Use sed, not tr, so we only replace the first dash: we want
     # skopeo-list-tags -> "skopeo list-tags", not "skopeo list tags"
     md_nodash=$(basename "$md" .1.md | sed -e 's/-/ /')

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -81,7 +81,7 @@ function compare_usage() {
     from_man=$(sed -E -e "s/\*\*$cmd\*\*[[:space:]]*//" <<<"$from_man")
     from_help=$(sed -E -e "s/^[[:space:]]*$cmd[[:space:]]*//" <<<"$from_help")
 
-    # man page lists 'foo [*options*]', help msg shows 'foo [flags]'.
+    # man page lists 'foo [*options*]', help msg shows 'foo [command options]'.
     # Make sure if one has it, the other does too.
     if expr "$from_man" : "\[\*options\*\]" >/dev/null; then
         if expr "$from_help" : "\[command options\]" >/dev/null; then
@@ -102,7 +102,7 @@ function compare_usage() {
     # Constant strings in man page are '**foo**', in --help are 'foo'.
     from_man=$(sed -E -e 's/\*\*([^*]+)\*\*/\1/g' <<<"$from_man")
 
-    # Args in man page are '*foo*', in --help are 'FOO'. Convert all to
+    # Args in man page are '_foo_', in --help are 'FOO'. Convert all to
     # UPCASE simply because it stands out better to the eye.
     from_man=$(sed -E -e 's/_([a-z-]+)_/\U\1/g' <<<"$from_man")
 


### PR DESCRIPTION
@edsantiago A few proposed follow-ups on #1347 .

One non-trivial issue is that the macOS `sed` does not support `\U` in replacements. That doesn’t matter in CI because the CI’s macOS build target runs `validate-local` _before_ building `bin/skopeo`, so the `--help` consistency checks are skipped, but it’s a hassle for local development where a `bin/skopeo` is almost always around:
```console
% hack/man-page-checker 
skopeo copy:              man='Usource-image Udestination-image' help='SOURCE-IMAGE DESTINATION-IMAGE'
skopeo delete:            man='Uimage-name' help='IMAGE-NAME'
…
```

For now this PR just carelessly compares case-insensitively, to have _something_ to fall back on if doing something better turned out to be too difficult.