### PR TITLE
BROKEN try to filter out --tls-verify from skopeo --help

### DIFF
--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -14,7 +14,7 @@ import (
 
 // fakeGlobalOptions creates globalOptions and sets it according to flags.
 func fakeGlobalOptions(t *testing.T, flags []string) (*globalOptions, *cobra.Command) {
-	app, opts := createApp()
+	app, opts := createApp(false)
 	cmd := &cobra.Command{}
 	app.AddCommand(cmd)
 	err := cmd.ParseFlags(flags)


### PR DESCRIPTION
Apparently that part works, but (skopeo inspect --tls-verify) doesn't show up...

Signed-off-by: Miloslav Trmač <mitr@redhat.com>