### PR TITLE
disable `completion` command

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -102,6 +102,11 @@ func main() {
 		return
 	}
 	rootCmd, _ := createApp()
+	// Currently, skopeo uses manually written completions.  Cobra allows
+	// for auto-generating completions for various shells.  Podman is
+	// already making us of that.  If Skopeo decides to follow, please
+	// remove the line below (and hide the `completion` command).
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	if err := rootCmd.Execute(); err != nil {
 		logrus.Fatal(err)
 	}


### PR DESCRIPTION
Disable the implicit `completion` command that cobra 1.2.x added.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>