### PR TITLE
Revert "integration tests: disable `ls` for logs"

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -1092,12 +1092,10 @@ func copyWithSignedIdentity(c *check.C, src, dest, signedIdentity, signBy, regis
 
 	signingDir := filepath.Join(topDir, "signing-temp")
 	assertSkopeoSucceeds(c, "", "copy", "--src-tls-verify=false", src, "dir:"+signingDir)
-	// Unknown error in Travis: https://github.com/containers/skopeo/issues/1093
-	//	c.Logf("%s", combinedOutputOfCommand(c, "ls", "-laR", signingDir))
+	c.Logf("%s", combinedOutputOfCommand(c, "ls", "-laR", signingDir))
 	assertSkopeoSucceeds(c, "^$", "standalone-sign", "-o", filepath.Join(signingDir, "signature-1"),
 		filepath.Join(signingDir, "manifest.json"), signedIdentity, signBy)
-	// Unknown error in Travis: https://github.com/containers/skopeo/issues/1093
-	//	c.Logf("%s", combinedOutputOfCommand(c, "ls", "-laR", signingDir))
+	c.Logf("%s", combinedOutputOfCommand(c, "ls", "-laR", signingDir))
 	assertSkopeoSucceeds(c, "", "--registries.d", registriesDir, "copy", "--dest-tls-verify=false", "dir:"+signingDir, dest)
 }
 


### PR DESCRIPTION
This reverts commit 65c5b0bf8d391ab19c86c0e7d337c457369ecba5.

We never diagnosed the cause for #1093; but now that we are on a different CI implementation, let’s just blindly try to see if it happens to work now.