### PR TITLE
Fix --tls-verify

### DIFF
--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -20,7 +20,7 @@ type deleteOptions struct {
 
 func deleteCmd(global *globalOptions) *cobra.Command {
 	sharedFlags, sharedOpts := sharedImageFlags()
-	imageFlags, imageOpts := imageFlags(global, sharedOpts, "", "")
+	imageFlags, imageOpts := imageFlags(global, sharedOpts, nil, "", "")
 	retryFlags, retryOpts := retryFlags()
 	opts := deleteOptions{
 		global:    global,

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -34,7 +34,7 @@ type inspectOptions struct {
 
 func inspectCmd(global *globalOptions) *cobra.Command {
 	sharedFlags, sharedOpts := sharedImageFlags()
-	imageFlags, imageOpts := imageFlags(global, sharedOpts, "", "")
+	imageFlags, imageOpts := imageFlags(global, sharedOpts, nil, "", "")
 	retryFlags, retryOpts := retryFlags()
 	opts := inspectOptions{
 		global:    global,

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -25,7 +25,7 @@ type layersOptions struct {
 
 func layersCmd(global *globalOptions) *cobra.Command {
 	sharedFlags, sharedOpts := sharedImageFlags()
-	imageFlags, imageOpts := imageFlags(global, sharedOpts, "", "")
+	imageFlags, imageOpts := imageFlags(global, sharedOpts, nil, "", "")
 	retryFlags, retryOpts := retryFlags()
 	opts := layersOptions{
 		global:    global,

--- a/cmd/skopeo/list_tags.go
+++ b/cmd/skopeo/list_tags.go
@@ -30,7 +30,7 @@ type tagsOptions struct {
 
 func tagsCmd(global *globalOptions) *cobra.Command {
 	sharedFlags, sharedOpts := sharedImageFlags()
-	imageFlags, imageOpts := dockerImageFlags(global, sharedOpts, "", "")
+	imageFlags, imageOpts := dockerImageFlags(global, sharedOpts, nil, "", "")
 	retryFlags, retryOpts := retryFlags()
 
 	opts := tagsOptions{

--- a/cmd/skopeo/logout.go
+++ b/cmd/skopeo/logout.go
@@ -4,12 +4,14 @@ import (
 	"io"
 
 	"github.com/containers/common/pkg/auth"
+	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
 )
 
 type logoutOptions struct {
 	global     *globalOptions
 	logoutOpts auth.LogoutOptions
+	tlsVerify  optionalBool
 }
 
 func logoutCmd(global *globalOptions) *cobra.Command {
@@ -24,12 +26,17 @@ func logoutCmd(global *globalOptions) *cobra.Command {
 		Example: `skopeo logout quay.io`,
 	}
 	adjustUsage(cmd)
-	cmd.Flags().AddFlagSet(auth.GetLogoutFlags(&opts.logoutOpts))
+	flags := cmd.Flags()
+	optionalBoolFlag(flags, &opts.tlsVerify, "tls-verify", "require HTTPS and verify certificates when accessing the registry")
+	flags.AddFlagSet(auth.GetLogoutFlags(&opts.logoutOpts))
 	return cmd
 }
 
 func (opts *logoutOptions) run(args []string, stdout io.Writer) error {
 	opts.logoutOpts.Stdout = stdout
 	sys := opts.global.newSystemContext()
+	if opts.tlsVerify.present {
+		sys.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!opts.tlsVerify.value)
+	}
 	return auth.Logout(sys, &opts.logoutOpts, args)
 }

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -38,6 +39,35 @@ func commandAction(handler func(args []string, stdout io.Writer) error) func(cmd
 	}
 }
 
+// deprecatedTLSVerifyOption represents a deprecated --tls-verify option,
+// which was accepted for all subcommands, for a time.
+// Every user should call deprecatedTLSVerifyOption.warnIfUsed() as part of handling the CLI,
+// whether or not the value actually ends up being used.
+// DO NOT ADD ANY NEW USES OF THIS; just call dockerImageFlags with an appropriate, possibly empty, flagPrefix.
+type deprecatedTLSVerifyOption struct {
+	tlsVerify optionalBool // FIXME FIXME: Warn if this is used, or even if it is ignored.
+}
+
+// warnIfUsed warns if tlsVerify was set by the user, and suggests alternatives (which should
+// start with "--").
+// Every user should call this as part of handling the CLI, whether or not the value actually
+// ends up being used.
+func (opts *deprecatedTLSVerifyOption) warnIfUsed(alternatives []string) {
+	if opts.tlsVerify.present {
+		logrus.Warnf("'--tls-verify' is deprecated, instead use: %s", strings.Join(alternatives, ", "))
+	}
+}
+
+// deprecatedTLSVerifyFlags prepares the CLI flag writing into deprecatedTLSVerifyOption, and the managed deprecatedTLSVerifyOption structure.
+// DO NOT ADD ANY NEW USES OF THIS; just call dockerImageFlags with an appropriate, possibly empty, flagPrefix.
+func deprecatedTLSVerifyFlags() (pflag.FlagSet, *deprecatedTLSVerifyOption) {
+	opts := deprecatedTLSVerifyOption{}
+	fs := pflag.FlagSet{}
+	flag := optionalBoolFlag(&fs, &opts.tlsVerify, "tls-verify", "require HTTPS and verify certificates when accessing the container registry (defaults to true)")
+	flag.Hidden = true
+	return fs, &opts
+}
+
 // sharedImageOptions collects CLI flags which are image-related, but do not change across images.
 // This really should be a part of globalOptions, but that would break existing users of (skopeo copy --authfile=).
 type sharedImageOptions struct {
@@ -56,14 +86,15 @@ func sharedImageFlags() (pflag.FlagSet, *sharedImageOptions) {
 // the same across subcommands, but may be different for each image
 // (e.g. may differ between the source and destination of a copy)
 type dockerImageOptions struct {
-	global         *globalOptions      // May be shared across several imageOptions instances.
-	shared         *sharedImageOptions // May be shared across several imageOptions instances.
-	authFilePath   optionalString      // Path to a */containers/auth.json (prefixed version to override shared image option).
-	credsOption    optionalString      // username[:password] for accessing a registry
-	registryToken  optionalString      // token to be used directly as a Bearer token when accessing the registry
-	dockerCertPath string              // A directory using Docker-like *.{crt,cert,key} files for connecting to a registry or a daemon
-	tlsVerify      optionalBool        // Require HTTPS and verify certificates (for docker: and docker-daemon:)
-	noCreds        bool                // Access the registry anonymously
+	global              *globalOptions             // May be shared across several imageOptions instances.
+	shared              *sharedImageOptions        // May be shared across several imageOptions instances.
+	deprecatedTLSVerify *deprecatedTLSVerifyOption // May be shared across several imageOptions instances, or nil.
+	authFilePath        optionalString             // Path to a */containers/auth.json (prefixed version to override shared image option).
+	credsOption         optionalString             // username[:password] for accessing a registry
+	registryToken       optionalString             // token to be used directly as a Bearer token when accessing the registry
+	dockerCertPath      string                     // A directory using Docker-like *.{crt,cert,key} files for connecting to a registry or a daemon
+	tlsVerify           optionalBool               // Require HTTPS and verify certificates (for docker: and docker-daemon:)
+	noCreds             bool                       // Access the registry anonymously
 }
 
 // imageOptions collects CLI flags which are the same across subcommands, but may be different for each image
@@ -76,11 +107,12 @@ type imageOptions struct {
 
 // dockerImageFlags prepares a collection of docker-transport specific CLI flags
 // writing into imageOptions, and the managed imageOptions structure.
-func dockerImageFlags(global *globalOptions, shared *sharedImageOptions, flagPrefix, credsOptionAlias string) (pflag.FlagSet, *imageOptions) {
+func dockerImageFlags(global *globalOptions, shared *sharedImageOptions, deprecatedTLSVerify *deprecatedTLSVerifyOption, flagPrefix, credsOptionAlias string) (pflag.FlagSet, *imageOptions) {
 	flags := imageOptions{
 		dockerImageOptions: dockerImageOptions{
-			global: global,
-			shared: shared,
+			global:              global,
+			shared:              shared,
+			deprecatedTLSVerify: deprecatedTLSVerify,
 		},
 	}
 
@@ -104,8 +136,8 @@ func dockerImageFlags(global *globalOptions, shared *sharedImageOptions, flagPre
 }
 
 // imageFlags prepares a collection of CLI flags writing into imageOptions, and the managed imageOptions structure.
-func imageFlags(global *globalOptions, shared *sharedImageOptions, flagPrefix, credsOptionAlias string) (pflag.FlagSet, *imageOptions) {
-	dockerFlags, opts := dockerImageFlags(global, shared, flagPrefix, credsOptionAlias)
+func imageFlags(global *globalOptions, shared *sharedImageOptions, deprecatedTLSVerify *deprecatedTLSVerifyOption, flagPrefix, credsOptionAlias string) (pflag.FlagSet, *imageOptions) {
+	dockerFlags, opts := dockerImageFlags(global, shared, deprecatedTLSVerify, flagPrefix, credsOptionAlias)
 
 	fs := pflag.FlagSet{}
 	fs.StringVar(&opts.sharedBlobDir, flagPrefix+"shared-blob-dir", "", "`DIRECTORY` to use to share blobs across OCI repositories")
@@ -134,6 +166,10 @@ func (opts *imageOptions) newSystemContext() (*types.SystemContext, error) {
 	ctx.DockerDaemonCertPath = opts.dockerCertPath
 	if opts.dockerImageOptions.authFilePath.present {
 		ctx.AuthFilePath = opts.dockerImageOptions.authFilePath.value
+	}
+	if opts.deprecatedTLSVerify != nil && opts.deprecatedTLSVerify.tlsVerify.present {
+		// If both this deprecated option and a non-deprecated option is present, we use the latter value.
+		ctx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!opts.deprecatedTLSVerify.tlsVerify.value)
 	}
 	if opts.tlsVerify.present {
 		ctx.DockerDaemonInsecureSkipTLSVerify = !opts.tlsVerify.value
@@ -171,8 +207,8 @@ type imageDestOptions struct {
 }
 
 // imageDestFlags prepares a collection of CLI flags writing into imageDestOptions, and the managed imageDestOptions structure.
-func imageDestFlags(global *globalOptions, shared *sharedImageOptions, flagPrefix, credsOptionAlias string) (pflag.FlagSet, *imageDestOptions) {
-	genericFlags, genericOptions := imageFlags(global, shared, flagPrefix, credsOptionAlias)
+func imageDestFlags(global *globalOptions, shared *sharedImageOptions, deprecatedTLSVerify *deprecatedTLSVerifyOption, flagPrefix, credsOptionAlias string) (pflag.FlagSet, *imageDestOptions) {
+	genericFlags, genericOptions := imageFlags(global, shared, deprecatedTLSVerify, flagPrefix, credsOptionAlias)
 	opts := imageDestOptions{imageOptions: genericOptions}
 	fs := pflag.FlagSet{}
 	fs.AddFlagSet(&genericFlags)

--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -170,6 +170,8 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 		BigFilesTemporaryDir:              "/srv",
 	}, res)
 
+	// Global/per-command tlsVerify behavior is tested in TestTLSVerifyFlags.
+
 	// Invalid option values in imageOptions
 	opts = fakeImageDestOptions(t, "dest-", []string{}, []string{"--dest-creds", ""})
 	_, err = opts.newSystemContext()
@@ -177,34 +179,58 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 }
 
 func TestTLSVerifyFlags(t *testing.T) {
-	for _, c := range []struct {
-		global, cmd          string
-		expectedDocker       types.OptionalBool
-		expectedDockerDaemon bool
+	type systemContextOpts interface { // Either *imageOptions or *imageDestOptions
+		newSystemContext() (*types.SystemContext, error)
+	}
+
+	for _, creator := range []struct {
+		name    string
+		newOpts func(globalFlags, cmdFlags []string) systemContextOpts
 	}{
-		{"", "", types.OptionalBoolUndefined, false},
-		{"", "false", types.OptionalBoolTrue, true},
-		{"", "true", types.OptionalBoolFalse, false},
-		{"false", "", types.OptionalBoolTrue, false},
-		{"false", "false", types.OptionalBoolTrue, true},
-		{"false", "true", types.OptionalBoolFalse, false},
-		{"true", "", types.OptionalBoolFalse, false},
-		{"true", "false", types.OptionalBoolTrue, true},
-		{"true", "true", types.OptionalBoolFalse, false},
+		{
+			"imageFlags",
+			func(globalFlags, cmdFlags []string) systemContextOpts {
+				return fakeImageOptions(t, "dest-", globalFlags, cmdFlags)
+			},
+		},
+		{
+			"imageDestFlags",
+			func(globalFlags, cmdFlags []string) systemContextOpts {
+				return fakeImageDestOptions(t, "dest-", globalFlags, cmdFlags)
+			},
+		},
 	} {
-		globalFlags := []string{}
-		if c.global != "" {
-			globalFlags = append(globalFlags, "--tls-verify="+c.global)
-		}
-		cmdFlags := []string{}
-		if c.cmd != "" {
-			cmdFlags = append(cmdFlags, "--dest-tls-verify="+c.cmd)
-		}
-		opts := fakeImageOptions(t, "dest-", globalFlags, cmdFlags)
-		res, err := opts.newSystemContext()
-		require.NoError(t, err)
-		assert.Equal(t, c.expectedDocker, res.DockerInsecureSkipTLSVerify, "%#v", c)
-		assert.Equal(t, c.expectedDockerDaemon, res.DockerDaemonInsecureSkipTLSVerify, "%#v", c)
+		t.Run(creator.name, func(t *testing.T) {
+			for _, c := range []struct {
+				global, cmd          string
+				expectedDocker       types.OptionalBool
+				expectedDockerDaemon bool
+			}{
+				{"", "", types.OptionalBoolUndefined, false},
+				{"", "false", types.OptionalBoolTrue, true},
+				{"", "true", types.OptionalBoolFalse, false},
+				{"false", "", types.OptionalBoolTrue, false},
+				{"false", "false", types.OptionalBoolTrue, true},
+				{"false", "true", types.OptionalBoolFalse, false},
+				{"true", "", types.OptionalBoolFalse, false},
+				{"true", "false", types.OptionalBoolTrue, true},
+				{"true", "true", types.OptionalBoolFalse, false},
+			} {
+				globalFlags := []string{}
+				if c.global != "" {
+					globalFlags = append(globalFlags, "--tls-verify="+c.global)
+				}
+				cmdFlags := []string{}
+				if c.cmd != "" {
+					cmdFlags = append(cmdFlags, "--dest-tls-verify="+c.cmd)
+				}
+				opts := creator.newOpts(globalFlags, cmdFlags)
+				res, err := opts.newSystemContext()
+				require.NoError(t, err)
+				assert.Equal(t, c.expectedDocker, res.DockerInsecureSkipTLSVerify, "%#v", c)
+				assert.Equal(t, c.expectedDockerDaemon, res.DockerDaemonInsecureSkipTLSVerify, "%#v", c)
+			}
+		})
 	}
 }
 

--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,17 +18,26 @@ func fakeGlobalOptions(t *testing.T, flags []string) (*globalOptions, *cobra.Com
 	app, opts := createApp()
 	cmd := &cobra.Command{}
 	app.AddCommand(cmd)
-	err := cmd.ParseFlags(flags)
+	err := app.ParseFlags(flags)
 	require.NoError(t, err)
 	return opts, cmd
 }
 
 // fakeImageOptions creates imageOptions and sets it according to globalFlags/cmdFlags.
-func fakeImageOptions(t *testing.T, flagPrefix string, globalFlags []string, cmdFlags []string) *imageOptions {
+func fakeImageOptions(t *testing.T, flagPrefix string, useDeprecatedTLSVerify bool,
+	globalFlags []string, cmdFlags []string) *imageOptions {
 	globalOpts, cmd := fakeGlobalOptions(t, globalFlags)
 	sharedFlags, sharedOpts := sharedImageFlags()
-	imageFlags, imageOpts := imageFlags(globalOpts, sharedOpts, flagPrefix, "")
+	var deprecatedTLSVerifyFlag pflag.FlagSet
+	var deprecatedTLSVerifyOpt *deprecatedTLSVerifyOption
+	if useDeprecatedTLSVerify {
+		deprecatedTLSVerifyFlag, deprecatedTLSVerifyOpt = deprecatedTLSVerifyFlags()
+	}
+	imageFlags, imageOpts := imageFlags(globalOpts, sharedOpts, deprecatedTLSVerifyOpt, flagPrefix, "")
 	cmd.Flags().AddFlagSet(&sharedFlags)
+	if useDeprecatedTLSVerify {
+		cmd.Flags().AddFlagSet(&deprecatedTLSVerifyFlag)
+	}
 	cmd.Flags().AddFlagSet(&imageFlags)
 	err := cmd.ParseFlags(cmdFlags)
 	require.NoError(t, err)
@@ -36,7 +46,7 @@ func fakeImageOptions(t *testing.T, flagPrefix string, globalFlags []string, cmd
 
 func TestImageOptionsNewSystemContext(t *testing.T) {
 	// Default state
-	opts := fakeImageOptions(t, "dest-", []string{}, []string{})
+	opts := fakeImageOptions(t, "dest-", true, []string{}, []string{})
 	res, err := opts.newSystemContext()
 	require.NoError(t, err)
 	assert.Equal(t, &types.SystemContext{
@@ -44,7 +54,7 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 	}, res)
 
 	// Set everything to non-default values.
-	opts = fakeImageOptions(t, "dest-", []string{
+	opts = fakeImageOptions(t, "dest-", true, []string{
 		"--registries.d", "/srv/registries.d",
 		"--override-arch", "overridden-arch",
 		"--override-os", "overridden-os",
@@ -83,17 +93,26 @@ func TestImageOptionsNewSystemContext(t *testing.T) {
 	// Global/per-command tlsVerify behavior is tested in TestTLSVerifyFlags.
 
 	// Invalid option values
-	opts = fakeImageOptions(t, "dest-", []string{}, []string{"--dest-creds", ""})
+	opts = fakeImageOptions(t, "dest-", true, []string{}, []string{"--dest-creds", ""})
 	_, err = opts.newSystemContext()
 	assert.Error(t, err)
 }
 
 // fakeImageDestOptions creates imageDestOptions and sets it according to globalFlags/cmdFlags.
-func fakeImageDestOptions(t *testing.T, flagPrefix string, globalFlags []string, cmdFlags []string) *imageDestOptions {
+func fakeImageDestOptions(t *testing.T, flagPrefix string, useDeprecatedTLSVerify bool,
+	globalFlags []string, cmdFlags []string) *imageDestOptions {
 	globalOpts, cmd := fakeGlobalOptions(t, globalFlags)
 	sharedFlags, sharedOpts := sharedImageFlags()
-	imageFlags, imageOpts := imageDestFlags(globalOpts, sharedOpts, flagPrefix, "")
+	var deprecatedTLSVerifyFlag pflag.FlagSet
+	var deprecatedTLSVerifyOpt *deprecatedTLSVerifyOption
+	if useDeprecatedTLSVerify {
+		deprecatedTLSVerifyFlag, deprecatedTLSVerifyOpt = deprecatedTLSVerifyFlags()
+	}
+	imageFlags, imageOpts := imageDestFlags(globalOpts, sharedOpts, deprecatedTLSVerifyOpt, flagPrefix, "")
 	cmd.Flags().AddFlagSet(&sharedFlags)
+	if useDeprecatedTLSVerify {
+		cmd.Flags().AddFlagSet(&deprecatedTLSVerifyFlag)
+	}
 	cmd.Flags().AddFlagSet(&imageFlags)
 	err := cmd.ParseFlags(cmdFlags)
 	require.NoError(t, err)
@@ -102,7 +121,7 @@ func fakeImageDestOptions(t *testing.T, flagPrefix string, globalFlags []string,
 
 func TestImageDestOptionsNewSystemContext(t *testing.T) {
 	// Default state
-	opts := fakeImageDestOptions(t, "dest-", []string{}, []string{})
+	opts := fakeImageDestOptions(t, "dest-", true, []string{}, []string{})
 	res, err := opts.newSystemContext()
 	require.NoError(t, err)
 	assert.Equal(t, &types.SystemContext{
@@ -122,7 +141,7 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 	os.Setenv("REGISTRY_AUTH_FILE", authFile)
 
 	// Explicitly set everything to default, except for when the default is “not present”
-	opts = fakeImageDestOptions(t, "dest-", []string{}, []string{
+	opts = fakeImageDestOptions(t, "dest-", true, []string{}, []string{
 		"--dest-compress=false",
 	})
 	res, err = opts.newSystemContext()
@@ -133,7 +152,7 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 	}, res)
 
 	// Set everything to non-default values.
-	opts = fakeImageDestOptions(t, "dest-", []string{
+	opts = fakeImageDestOptions(t, "dest-", true, []string{
 		"--registries.d", "/srv/registries.d",
 		"--override-arch", "overridden-arch",
 		"--override-os", "overridden-os",
@@ -173,7 +192,7 @@ func TestImageDestOptionsNewSystemContext(t *testing.T) {
 	// Global/per-command tlsVerify behavior is tested in TestTLSVerifyFlags.
 
 	// Invalid option values in imageOptions
-	opts = fakeImageDestOptions(t, "dest-", []string{}, []string{"--dest-creds", ""})
+	opts = fakeImageDestOptions(t, "dest-", true, []string{}, []string{"--dest-creds", ""})
 	_, err = opts.newSystemContext()
 	assert.Error(t, err)
 }
@@ -185,50 +204,84 @@ func TestTLSVerifyFlags(t *testing.T) {
 
 	for _, creator := range []struct {
 		name    string
-		newOpts func(globalFlags, cmdFlags []string) systemContextOpts
+		newOpts func(useDeprecatedTLSVerify bool, globalFlags, cmdFlags []string) systemContextOpts
 	}{
 		{
 			"imageFlags",
-			func(globalFlags, cmdFlags []string) systemContextOpts {
-				return fakeImageOptions(t, "dest-", globalFlags, cmdFlags)
+			func(useDeprecatedTLSVerify bool, globalFlags, cmdFlags []string) systemContextOpts {
+				return fakeImageOptions(t, "dest-", useDeprecatedTLSVerify, globalFlags, cmdFlags)
 			},
 		},
 		{
 			"imageDestFlags",
-			func(globalFlags, cmdFlags []string) systemContextOpts {
-				return fakeImageDestOptions(t, "dest-", globalFlags, cmdFlags)
+			func(useDeprecatedTLSVerify bool, globalFlags, cmdFlags []string) systemContextOpts {
+				return fakeImageDestOptions(t, "dest-", useDeprecatedTLSVerify, globalFlags, cmdFlags)
 			},
 		},
 	} {
 		t.Run(creator.name, func(t *testing.T) {
 			for _, c := range []struct {
-				global, cmd          string
-				expectedDocker       types.OptionalBool
-				expectedDockerDaemon bool
+				global, deprecatedCmd, cmd string
+				expectedDocker             types.OptionalBool
+				expectedDockerDaemon       bool
 			}{
-				{"", "", types.OptionalBoolUndefined, false},
-				{"", "false", types.OptionalBoolTrue, true},
-				{"", "true", types.OptionalBoolFalse, false},
-				{"false", "", types.OptionalBoolTrue, false},
-				{"false", "false", types.OptionalBoolTrue, true},
-				{"false", "true", types.OptionalBoolFalse, false},
-				{"true", "", types.OptionalBoolFalse, false},
-				{"true", "false", types.OptionalBoolTrue, true},
-				{"true", "true", types.OptionalBoolFalse, false},
+				{"", "", "", types.OptionalBoolUndefined, false},
+				{"", "", "false", types.OptionalBoolTrue, true},
+				{"", "", "true", types.OptionalBoolFalse, false},
+				{"", "false", "", types.OptionalBoolTrue, false},
+				{"", "false", "false", types.OptionalBoolTrue, true},
+				{"", "false", "true", types.OptionalBoolFalse, false},
+				{"", "true", "", types.OptionalBoolFalse, false},
+				{"", "true", "false", types.OptionalBoolTrue, true},
+				{"", "true", "true", types.OptionalBoolFalse, false},
+				{"false", "", "", types.OptionalBoolTrue, false},
+				{"false", "", "false", types.OptionalBoolTrue, true},
+				{"false", "", "true", types.OptionalBoolFalse, false},
+				{"false", "false", "", types.OptionalBoolTrue, false},
+				{"false", "false", "false", types.OptionalBoolTrue, true},
+				{"false", "false", "true", types.OptionalBoolFalse, false},
+				{"false", "true", "", types.OptionalBoolFalse, false},
+				{"false", "true", "false", types.OptionalBoolTrue, true},
+				{"false", "true", "true", types.OptionalBoolFalse, false},
+				{"true", "", "", types.OptionalBoolFalse, false},
+				{"true", "", "false", types.OptionalBoolTrue, true},
+				{"true", "", "true", types.OptionalBoolFalse, false},
+				{"true", "false", "", types.OptionalBoolTrue, false},
+				{"true", "false", "false", types.OptionalBoolTrue, true},
+				{"true", "false", "true", types.OptionalBoolFalse, false},
+				{"true", "true", "", types.OptionalBoolFalse, false},
+				{"true", "true", "false", types.OptionalBoolTrue, true},
+				{"true", "true", "true", types.OptionalBoolFalse, false},
 			} {
 				globalFlags := []string{}
 				if c.global != "" {
 					globalFlags = append(globalFlags, "--tls-verify="+c.global)
 				}
 				cmdFlags := []string{}
+				if c.deprecatedCmd != "" {
+					cmdFlags = append(cmdFlags, "--tls-verify="+c.deprecatedCmd)
+				}
 				if c.cmd != "" {
 					cmdFlags = append(cmdFlags, "--dest-tls-verify="+c.cmd)
 				}
-				opts := creator.newOpts(globalFlags, cmdFlags)
+				opts := creator.newOpts(true, globalFlags, cmdFlags)
 				res, err := opts.newSystemContext()
 				require.NoError(t, err)
 				assert.Equal(t, c.expectedDocker, res.DockerInsecureSkipTLSVerify, "%#v", c)
 				assert.Equal(t, c.expectedDockerDaemon, res.DockerDaemonInsecureSkipTLSVerify, "%#v", c)
+
+				if c.deprecatedCmd == "" { // Test also the behavior when deprecatedTLSFlag is not recognized
+					// Use globalFlags from the previous test
+					cmdFlags := []string{}
+					if c.cmd != "" {
+						cmdFlags = append(cmdFlags, "--dest-tls-verify="+c.cmd)
+					}
+					opts := creator.newOpts(false, globalFlags, cmdFlags)
+					res, err = opts.newSystemContext()
+					require.NoError(t, err)
+					assert.Equal(t, c.expectedDocker, res.DockerInsecureSkipTLSVerify, "%#v", c)
+					assert.Equal(t, c.expectedDockerDaemon, res.DockerDaemonInsecureSkipTLSVerify, "%#v", c)
+				}
 			}
 		})
 	}
@@ -300,7 +353,7 @@ func TestImageOptionsAuthfileOverride(t *testing.T) {
 			}, "/srv/dest-authfile",
 		},
 	} {
-		opts := fakeImageOptions(t, testCase.flagPrefix, []string{}, testCase.cmdFlags)
+		opts := fakeImageOptions(t, testCase.flagPrefix, false, []string{}, testCase.cmdFlags)
 		res, err := opts.newSystemContext()
 		require.NoError(t, err)
 

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -60,6 +60,10 @@ The number of times to retry. Retry wait time will be exponentially increased ba
 
 Directory to use to share blobs across OCI repositories.
 
+**--tls-verify**=_bool_
+
+Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+
 ## EXAMPLES
 
 Mark image example/pause for deletion from the registry.example.com registry:

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -65,6 +65,10 @@ The number of times to retry; retry wait time will be exponentially increased ba
 
 Directory to use to share blobs across OCI repositories.
 
+**--tls-verify**=_bool_
+
+Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+
 ## EXAMPLES
 
 To review information for the image fedora from the docker.io registry:

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -39,6 +39,10 @@ Bearer token for accessing the registry.
 
 The number of times to retry. Retry wait time will be exponentially increased based on the number of failed attempts.
 
+**--tls-verify**=_bool_
+
+Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+
 ## REPOSITORY NAMES
 
 Repository names are transport-specific references as each transport may have its own concept of a "repository" and "tags". Currently, only the Docker transport is supported.

--- a/docs/skopeo-login.1.md
+++ b/docs/skopeo-login.1.md
@@ -47,6 +47,10 @@ Default certificates directory is _/etc/containers/certs.d_.
 
 Print usage statement
 
+**--tls-verify**=_bool_
+
+Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+
 **--verbose**, **-v**
 
 Write more detailed information to stdout

--- a/docs/skopeo-logout.1.md
+++ b/docs/skopeo-logout.1.md
@@ -29,6 +29,10 @@ Remove the cached credentials for all registries in the auth file
 
 Print usage statement
 
+**--tls-verify**=_bool_
+
+Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+
 ## EXAMPLES
 
 ```


### PR DESCRIPTION
- Make the --help presence match deprecation status
- Warn on (skopeo --tls-verify command) again

See https://github.com/containers/skopeo/pull/1350#discussion_r667184279 for past discussion

<s>WIP, this needs unit tests and much more documentation.</s>

@edsantiago I think this works, but I’d very much appreciate a second pair of eyes.