### PR TITLE
Set cobra.Command.CompletionOption already in createApp

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -45,6 +45,11 @@ func createApp() (*cobra.Command, *globalOptions) {
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		// Currently, skopeo uses manually written completions.  Cobra allows
+		// for auto-generating completions for various shells.  Podman is
+		// already making us of that.  If Skopeo decides to follow, please
+		// remove the line below (and hide the `completion` command).
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 	}
 	if gitCommit != "" {
 		rootCommand.Version = fmt.Sprintf("%s commit: %s", version.Version, gitCommit)
@@ -102,11 +107,6 @@ func main() {
 		return
 	}
 	rootCmd, _ := createApp()
-	// Currently, skopeo uses manually written completions.  Cobra allows
-	// for auto-generating completions for various shells.  Podman is
-	// already making us of that.  If Skopeo decides to follow, please
-	// remove the line below (and hide the `completion` command).
-	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	if err := rootCmd.Execute(); err != nil {
 		logrus.Fatal(err)
 	}


### PR DESCRIPTION
... because our unit tests use `createApp`, so the current `main()`-only edit is not visible to unit tests.

Cc: @vrothberg , I’m afraid I have missed this originally.