### PR TITLE
Fix using images from rate-limited docker hub

### DIFF
--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -101,7 +101,7 @@ func (s *SkopeoSuite) TestCopyWithLocalAuth(c *check.C) {
 	assertSkopeoSucceeds(c, wanted, "login", "--tls-verify=false", "--username="+s.regV2WithAuth.username, "--password="+s.regV2WithAuth.password, s.regV2WithAuth.url)
 	// copy to private registry using local authentication
 	imageName := fmt.Sprintf("docker://%s/busybox:mine", s.regV2WithAuth.url)
-	assertSkopeoSucceeds(c, "", "copy", "--dest-tls-verify=false", "docker://docker.io/library/busybox:latest", imageName)
+	assertSkopeoSucceeds(c, "", "copy", "--dest-tls-verify=false", testFQIN+":latest", imageName)
 	// inspect from private registry
 	assertSkopeoSucceeds(c, "", "inspect", "--tls-verify=false", imageName)
 	// logout from the registry

--- a/integration/openshift_shell_test.go
+++ b/integration/openshift_shell_test.go
@@ -20,7 +20,7 @@ to start a container, then within the container:
 
 An example of what can be done within the container:
 	cd ..; make bin/skopeo PREFIX=/usr install
-	./skopeo --tls-verify=false  copy --sign-by=personal@example.com docker://busybox:latest atomic:localhost:5000/myns/personal:personal
+	./skopeo --tls-verify=false  copy --sign-by=personal@example.com docker://quay.io/libpod/busybox:latest atomic:localhost:5000/myns/personal:personal
 	oc get istag personal:personal -o json
 	curl -L -v 'http://localhost:5000/v2/'
 	cat ~/.docker/config.json

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -17,6 +17,10 @@ import (
 const skopeoBinary = "skopeo"
 const decompressDirsBinary = "./decompress-dirs.sh"
 
+const testFQIN = "docker://quay.io/libpod/busybox" // tag left off on purpose, some tests need to add a special one
+const testFQIN64 = "docker://quay.io/libpod/busybox:amd64"
+const testFQINMultiLayer = "docker://quay.io/libpod/alpine_nginx:master" // multi-layer
+
 // consumeAndLogOutputStream takes (f, err) from an exec.*Pipe(), and causes all output to it to be logged to c.
 func consumeAndLogOutputStream(c *check.C, id string, f io.ReadCloser, err error) {
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
The necessary images have been manually copied over to quay.  Code was
updated with centralized constants for the utilized images.  Tests then
all reference the constants (in case the image locations need to change
again).

Signed-off-by: Chris Evich <cevich@redhat.com>