### PR TITLE
Fix two instances of unused err found by go-staticcheck

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -568,6 +568,7 @@ func (s *CopySuite) TestCopyEncryption(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer os.RemoveAll(keysDir)
 	undecryptedImgDir, err := ioutil.TempDir("", "copy-5")
+	c.Assert(err, check.IsNil)
 	defer os.RemoveAll(undecryptedImgDir)
 	multiLayerImageDir, err := ioutil.TempDir("", "copy-6")
 	c.Assert(err, check.IsNil)

--- a/integration/openshift.go
+++ b/integration/openshift.go
@@ -62,6 +62,7 @@ func (cluster *openshiftCluster) startMaster(c *check.C) {
 	cmd := cluster.clusterCmd(nil, "openshift", "start", "master")
 	cluster.processes = append(cluster.processes, cmd)
 	stdout, err := cmd.StdoutPipe()
+	c.Assert(err, check.IsNil)
 	// Send both to the same pipe. This might cause the two streams to be mixed up,
 	// but logging actually goes only to stderr - this primarily ensure we log any
 	// unexpected output to stdout.


### PR DESCRIPTION
\*cough\* Go is an easy-to-use, hard-to-misuse language \*cough\*