### PR TITLE
Update on Building on Ubuntu

### DIFF
--- a/install.md
+++ b/install.md
@@ -146,7 +146,7 @@ sudo dnf install gpgme-devel libassuan-devel btrfs-progs-devel device-mapper-dev
 
 ```bash
 # Ubuntu (`libbtrfs-dev` requires Ubuntu 18.10 and above):
-sudo apt install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev
+sudo apt install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config
 ```
 
 ```bash


### PR DESCRIPTION
Build on Ubuntu should include pkg-config otherwise it will fail:
```
skopeo (main) # make bin/skopeo
CGO_CFLAGS="" CGO_LDFLAGS="-L/usr/lib/x86_64-linux-gnu -lgpgme -lassuan -lgpg-error" GO111MODULE=on go build -mod=vendor "-buildmode=pie" -ldflags '-X main.gitCommit=a8f0c902060288bd02db15bf6671c8cd0149704e ' -gcflags "" -tags "  " -o bin/skopeo ./cmd/skopeo
# pkg-config --cflags  -- devmapper
pkg-config: exec: "pkg-config": executable file not found in $PATH
make: *** [Makefile:134: bin/skopeo] Error 2
```