### PR TITLE
Accept repositories on login/logout

### DIFF
--- a/cmd/skopeo/login.go
+++ b/cmd/skopeo/login.go
@@ -38,6 +38,7 @@ func (opts *loginOptions) run(args []string, stdout io.Writer) error {
 	defer cancel()
 	opts.loginOpts.Stdout = stdout
 	opts.loginOpts.Stdin = os.Stdin
+	opts.loginOpts.AcceptRepositories = true
 	sys := opts.global.newSystemContext()
 	if opts.tlsVerify.present {
 		sys.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!opts.tlsVerify.value)

--- a/cmd/skopeo/logout.go
+++ b/cmd/skopeo/logout.go
@@ -34,6 +34,7 @@ func logoutCmd(global *globalOptions) *cobra.Command {
 
 func (opts *logoutOptions) run(args []string, stdout io.Writer) error {
 	opts.logoutOpts.Stdout = stdout
+	opts.logoutOpts.AcceptRepositories = true
 	sys := opts.global.newSystemContext()
 	if opts.tlsVerify.present {
 		sys.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!opts.tlsVerify.value)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now synchronize the behavior with Podman and accept repositories during login and logout per default.
#### How to verify it
Login/logout with a repository and verify `auth.json`. Push and pull should use the credentials in the same way as the Podman integration tests described in https://github.com/containers/podman/pull/11054.
#### Which issue(s) this PR fixes:

Requires https://github.com/containers/skopeo/pull/1395

#### Special notes for your reviewer:
Incorporates with https://github.com/containers/podman/pull/11054
#### Does this PR introduce a user-facing change?

```release-note
Accept repositories (and registry namespaces) on login/logout and during push/pull.
```

