### PR TITLE
systemtests: if registry times out, show container logs

### DIFF
--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -359,6 +359,7 @@ start_registry() {
         timeout=$(expr $timeout - 1)
         sleep 1
     done
+    log_and_run $PODMAN logs $name
     die "Timed out waiting for registry container to respond on :$port"
 }
 


### PR DESCRIPTION
the 'signing' test is flaking; symptom is that we can never
connect to the port on the registry:

   https://api.cirrus-ci.com/v1/task/6208385738604544/logs/system.log

By all indications, the registry is up, i.e., the 'podman rm -f reg'
in teardown() succeeds, as shown by the 53c (CID) in the log. (It
bothers me that the FAIL message from die() does not appear in the
log, and I can't figure out why).

To try to diagnose this, run 'podman logs' on the registry upon
failure.

Signed-off-by: Ed Santiago <santiago@redhat.com>