### PR TITLE
Remove the extra (defaults to true) help msg

### DIFF
--- a/cmd/skopeo/flag.go
+++ b/cmd/skopeo/flag.go
@@ -21,6 +21,7 @@ type optionalBoolValue optionalBool
 func optionalBoolFlag(fs *pflag.FlagSet, p *optionalBool, name, usage string) *pflag.Flag {
 	flag := fs.VarPF(internalNewOptionalBoolValue(p), name, "", usage)
 	flag.NoOptDefVal = "true"
+	flag.DefValue = "false"
 	return flag
 }
 

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -63,7 +63,7 @@ func (opts *deprecatedTLSVerifyOption) warnIfUsed(alternatives []string) {
 func deprecatedTLSVerifyFlags() (pflag.FlagSet, *deprecatedTLSVerifyOption) {
 	opts := deprecatedTLSVerifyOption{}
 	fs := pflag.FlagSet{}
-	flag := optionalBoolFlag(&fs, &opts.tlsVerify, "tls-verify", "require HTTPS and verify certificates when accessing the container registry (defaults to true)")
+	flag := optionalBoolFlag(&fs, &opts.tlsVerify, "tls-verify", "require HTTPS and verify certificates when accessing the container registry")
 	flag.Hidden = true
 	return fs, &opts
 }
@@ -130,7 +130,7 @@ func dockerImageFlags(global *globalOptions, shared *sharedImageOptions, depreca
 	}
 	fs.Var(newOptionalStringValue(&flags.registryToken), flagPrefix+"registry-token", "Provide a Bearer token for accessing the registry")
 	fs.StringVar(&flags.dockerCertPath, flagPrefix+"cert-dir", "", "use certificates at `PATH` (*.crt, *.cert, *.key) to connect to the registry or daemon")
-	optionalBoolFlag(&fs, &flags.tlsVerify, flagPrefix+"tls-verify", "require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)")
+	optionalBoolFlag(&fs, &flags.tlsVerify, flagPrefix+"tls-verify", "require HTTPS and verify certificates when talking to the container registry or daemon")
 	fs.BoolVar(&flags.noCreds, flagPrefix+"no-creds", false, "Access the registry anonymously")
 	return fs, &flags
 }

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -120,7 +120,7 @@ Access the registry anonymously.
 
 **--src-tls-verify** _bool-value_
 
-Require HTTPS and verify certificates when talking to container source registry or daemon (defaults to true).
+Require HTTPS and verify certificates when talking to container source registry or daemon. Default to source registry setting.
 
 **--dest-cert-dir** _path_
 
@@ -132,7 +132,7 @@ Access the registry anonymously.
 
 **--dest-tls-verify** _bool-value_
 
-Require HTTPS and verify certificates when talking to container destination registry or daemon (defaults to true).
+Require HTTPS and verify certificates when talking to container destination registry or daemon. Default to destination registry setting.
 
 **--src-daemon-host** _host_
 

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -62,7 +62,7 @@ Directory to use to share blobs across OCI repositories.
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 ## EXAMPLES
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -67,7 +67,7 @@ Directory to use to share blobs across OCI repositories.
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 ## EXAMPLES
 

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -41,7 +41,7 @@ The number of times to retry. Retry wait time will be exponentially increased ba
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 ## REPOSITORY NAMES
 

--- a/docs/skopeo-login.1.md
+++ b/docs/skopeo-login.1.md
@@ -49,7 +49,7 @@ Print usage statement
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 **--verbose**, **-v**
 

--- a/docs/skopeo-logout.1.md
+++ b/docs/skopeo-logout.1.md
@@ -31,7 +31,7 @@ Print usage statement
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon (defaults to true)
+Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 ## EXAMPLES
 

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -74,13 +74,13 @@ Print usage statement.
 
 **--src-no-creds** _bool-value_ Access the registry anonymously.
 
-**--src-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to a container source registry or daemon (defaults to true).
+**--src-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to a container source registry or daemon. Default to source registry entry in registry.conf setting.
 
 **--dest-cert-dir** _path_ Use certificates (*.crt, *.cert, *.key) at _path_ to connect to the destination registry or daemon.
 
 **--dest-no-creds** _bool-value_  Access the registry anonymously.
 
-**--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to a container destination registry or daemon (defaults to true).
+**--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to a container destination registry or daemon. Default to destination registry entry in registry.conf setting.
 
 **--src-registry-token** _Bearer token_ for accessing the source registry.
 


### PR DESCRIPTION
By default skopeo checks to see if the user actually uses one of the
--*tls-verify flags. Their initial value is ignored.  Setting the
initial value to false causes Cobra to not display the default value on
the screen when the user runs a `skopeo --help` command.

If the user does not specify a --*tls-verify option, it falls back to
using the value specified in the registries.conf file.

Fixes: #1383

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>