### PR TITLE
Introduce DISABLE_DOCS to skip doc generation while building from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,9 @@ bin/skopeo.%:
 local-cross: bin/skopeo.darwin.amd64 bin/skopeo.linux.arm bin/skopeo.linux.arm64 bin/skopeo.windows.386.exe bin/skopeo.windows.amd64.exe
 
 $(MANPAGES): %: %.md
+ifneq ($(DISABLE_DOCS), 1)
 	sed -e 's/\((skopeo.*\.md)\)//' -e 's/\[\(skopeo.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $@
+endif
 
 docs: $(MANPAGES)
 
@@ -179,8 +181,10 @@ install-binary: bin/skopeo
 	install -m 755 bin/skopeo ${DESTDIR}${BINDIR}/skopeo
 
 install-docs: docs
+ifneq ($(DISABLE_DOCS), 1)
 	install -d -m 755 ${DESTDIR}${MANDIR}/man1
 	install -m 644 docs/*.1 ${DESTDIR}${MANDIR}/man1
+endif
 
 install-completions:
 	install -m 755 -d ${DESTDIR}${BASHCOMPLETIONSDIR}

--- a/install.md
+++ b/install.md
@@ -168,6 +168,12 @@ cd $GOPATH/src/github.com/containers/skopeo && make bin/skopeo
 
 By default the `make` command (make all) will build bin/skopeo and the documentation locally.
 
+Building of documentation requires `go-md2man`. On systems that do not have this tool, the
+document generation can be skipped by passing `DISABLE_DOCS=1`:
+```
+DISABLE_DOCS=1 make
+```
+
 ### Building documentation
 
 To build the manual you will need go-md2man.


### PR DESCRIPTION
As discussed in https://github.com/containers/skopeo/issues/1411 the commit in this PR introduces a way to disable docs generation while building from source. This will allows `DISABLE_DOCS=1 make install` command to be used on setups where `go-md2man` tool isn't available for doc generation.
