### PR TITLE
release-1.4: Run (gofmt -s -w)

### DIFF
--- a/cmd/skopeo/cgo_pthread_ordering_workaround.go
+++ b/cmd/skopeo/cgo_pthread_ordering_workaround.go
@@ -1,3 +1,4 @@
+//go:build !containers_image_openpgp
 // +build !containers_image_openpgp
 
 package main

--- a/cmd/skopeo/unshare.go
+++ b/cmd/skopeo/unshare.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package main

--- a/integration/openshift_shell_test.go
+++ b/integration/openshift_shell_test.go
@@ -1,3 +1,4 @@
+//go:build openshift_shell
 // +build openshift_shell
 
 package main


### PR DESCRIPTION
This is a backport of #1427 for the release-1.4 branch.

Marked as draft to ensure there is consensus on this (vs. pinning an earlier Go version).


---

Go 1.17 introduces a much more reasonable build constraint format, and gofmt now fails without using it.

Sadly we still need the old format as well, to support <1.17 builds.

Signed-off-by: Miloslav Trmač <mitr@redhat.com>