### PR TITLE
release-1.4: Introduce DISABLE_DOCS to skip doc generation while building from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,9 @@ build-container:
 	${CONTAINER_RUNTIME} build ${BUILD_ARGS} -t "$(IMAGE)" .
 
 $(MANPAGES): %: %.md
+ifneq ($(DISABLE_DOCS), 1)
 	sed -e 's/\((skopeo.*\.md)\)//' -e 's/\[\(skopeo.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $@
+endif
 
 docs: $(MANPAGES)
 
@@ -164,8 +166,10 @@ install-binary: bin/skopeo
 	install -m 755 bin/skopeo ${DESTDIR}${BINDIR}/skopeo
 
 install-docs: docs
+ifneq ($(DISABLE_DOCS), 1)
 	install -d -m 755 ${DESTDIR}${MANDIR}/man1
 	install -m 644 docs/*.1 ${DESTDIR}${MANDIR}/man1
+endif
 
 install-completions:
 	install -m 755 -d ${DESTDIR}${BASHCOMPLETIONSDIR}

--- a/install.md
+++ b/install.md
@@ -168,6 +168,12 @@ cd $GOPATH/src/github.com/containers/skopeo && make bin/skopeo
 
 By default the `make` command (make all) will build bin/skopeo and the documentation locally.
 
+Building of documentation requires `go-md2man`. On systems that do not have this tool, the
+document generation can be skipped by passing `DISABLE_DOCS=1`:
+```
+DISABLE_DOCS=1 make
+```
+
 ### Building documentation
 
 To build the manual you will need go-md2man.


### PR DESCRIPTION
This PR is for the 1.4.x release series and brings in the changes that were merged recently against the master branch in https://github.com/containers/skopeo/pull/1443