### PR TITLE
Cirrus: Disable OSX task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,7 +84,7 @@ doccheck_task:
       "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" doccheck
 
 osx_task:
-    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
+    only_if: $CI != $CI
     depends_on:
         - validate
     macos_instance:
@@ -105,7 +105,7 @@ osx_task:
 
 cross_task:
     alias: cross
-    only_if: *not_docs
+    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
     depends_on:
         - validate
     gce_instance:


### PR DESCRIPTION
Release-branches infrequently change, but the OSX VM images constantly
change.  Disable this test to avoid encountering flakes.

Signed-off-by: Chris Evich <cevich@redhat.com>