### PR TITLE
[release-1.3] Cirrus: Disable OSX task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,6 +65,7 @@ validate_task:
 
 
 cross_task:
+    only_if: 1 == 0
     macos_instance:
         image: catalina-xcode
     setup_script: |


### PR DESCRIPTION
Release-branches infrequently change, but the OSX VM images constantly
change.  Disable this test to avoid encountering flakes.

Signed-off-by: Chris Evich <cevich@redhat.com>