### PR TITLE
[release-1.4] pin go

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,12 +90,13 @@ osx_task:
     macos_instance:
         image: catalina-xcode
     setup_script: |
-        export PATH=$GOPATH/bin:$PATH
+        # /usr/local/opt/go@1.16 will be populated by (brew install go@1.16) below
+        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:$PATH
         brew update
-        brew install gpgme go go-md2man
+        brew install gpgme go@1.16 go-md2man
         go get -u golang.org/x/lint/golint
     test_script: |
-        export PATH=$GOPATH/bin:$PATH
+        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:$PATH
         go version
         go env
         make validate-local test-unit-local bin/skopeo

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,7 +84,7 @@ doccheck_task:
       "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" doccheck
 
 osx_task:
-    only_if: $CI != $CI
+    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
     depends_on:
         - validate
     macos_instance:
@@ -105,7 +105,7 @@ osx_task:
 
 cross_task:
     alias: cross
-    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
+    only_if: *not_docs
     depends_on:
         - validate
     gce_instance:


### PR DESCRIPTION
1.17 has changed the expected `gofmt` format, and we don't want to follow such changes on the stable branch.

Then re-enable the `osx` task disabled in #1449.

An alternative to #1446 .