### PR TITLE
Cirrus: Fix only_if error

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,23 +64,6 @@ validate_task:
     script: make validate-local
 
 
-cross_task:
-    only_if: 1 == 0
-    macos_instance:
-        image: catalina-xcode
-    setup_script: |
-        export PATH=$GOPATH/bin:$PATH
-        brew install gpgme go go-md2man
-        go get -u golang.org/x/lint/golint
-    test_script: |
-        export PATH=$GOPATH/bin:$PATH
-        go version
-        go env
-        make validate-local test-unit-local bin/skopeo
-        sudo make install
-        /usr/local/bin/skopeo -v
-
-
 #####
 ##### NOTE: This task is subtantially duplicated in the containers/image
 ##### repository's `.cirrus.yml`.  Changes made here should be fully merged
@@ -157,7 +140,6 @@ success_task:
     # N/B: ALL tasks must be listed here, minus their '_task' suffix.
     depends_on:
         - validate
-        - cross
         - test_skopeo
         - meta
     container: *smallcontainer


### PR DESCRIPTION
The logic parser for `only_if` and `skip` is a little weird in that it
wants a boolean, but doesn't support using them.  In this case, using `1
== 0` results in an error from the parser:

`Error while parsing tasks: INVALID_ARGUMENT: internal boolevator error:
parsing error: 1 == 0 :1:1 - 1:2 unexpected Int while scanning
extensions!`

However, since the goal is to block this particular task from running
(essentially) indefinitely, it's easier to just remove it.  We can rely
on git recording it's history in case it needs to be recovered in the
future.

Signed-off-by: Chris Evich <cevich@redhat.com>