### PR TITLE
proxy: Add `GetConfig`, add manifest list support, add an integration test

### DIFF
--- a/cmd/skopeo/proxy.go
+++ b/cmd/skopeo/proxy.go
@@ -491,11 +491,11 @@ func (h *proxyHandler) FinishPipe(args []interface{}) (replyBuf, error) {
 
 	var ret replyBuf
 
-	pipeidf, ok := args[0].(float64)
-	if !ok {
-		return ret, fmt.Errorf("finishpipe: expecting pipeid, not %T", args[0])
+	pipeidv, err := parseUint64(args[0])
+	if err != nil {
+		return ret, err
 	}
-	pipeid := uint32(pipeidf)
+	pipeid := uint32(pipeidv)
 
 	f, ok := h.activePipes[pipeid]
 	if !ok {
@@ -507,7 +507,7 @@ func (h *proxyHandler) FinishPipe(args []interface{}) (replyBuf, error) {
 	// And only now do we close the write half; this forces the client to call this API
 	f.w.Close()
 	// Propagate any errors from the goroutine worker
-	err := f.err
+	err = f.err
 	delete(h.activePipes, pipeid)
 	return ret, err
 }

--- a/cmd/skopeo/proxy.go
+++ b/cmd/skopeo/proxy.go
@@ -201,14 +201,14 @@ func (h *proxyHandler) OpenImage(args []interface{}) (replyBuf, error) {
 	var ret replyBuf
 
 	if h.sysctx == nil {
-		return ret, fmt.Errorf("Must invoke Initialize")
+		return ret, fmt.Errorf("client error: must invoke Initialize")
 	}
 	if len(args) != 1 {
 		return ret, fmt.Errorf("invalid request, expecting one argument")
 	}
 	imageref, ok := args[0].(string)
 	if !ok {
-		return ret, fmt.Errorf("Expecting string imageref, not %T", args[0])
+		return ret, fmt.Errorf("expecting string imageref, not %T", args[0])
 	}
 
 	imgRef, err := alltransports.ParseImageName(imageref)
@@ -237,7 +237,7 @@ func (h *proxyHandler) CloseImage(args []interface{}) (replyBuf, error) {
 	var ret replyBuf
 
 	if h.sysctx == nil {
-		return ret, fmt.Errorf("Must invoke Initialize")
+		return ret, fmt.Errorf("client error: must invoke Initialize")
 	}
 	if len(args) != 1 {
 		return ret, fmt.Errorf("invalid request, expecting one argument")
@@ -255,7 +255,7 @@ func (h *proxyHandler) CloseImage(args []interface{}) (replyBuf, error) {
 func parseImageID(v interface{}) (uint32, error) {
 	imgidf, ok := v.(float64)
 	if !ok {
-		return 0, fmt.Errorf("Expecting integer imageid, not %T", v)
+		return 0, fmt.Errorf("expecting integer imageid, not %T", v)
 	}
 	return uint32(imgidf), nil
 }
@@ -264,10 +264,10 @@ func parseImageID(v interface{}) (uint32, error) {
 func parseUint64(v interface{}) (uint64, error) {
 	f, ok := v.(float64)
 	if !ok {
-		return 0, fmt.Errorf("Expecting numeric, not %T", v)
+		return 0, fmt.Errorf("expecting numeric, not %T", v)
 	}
 	if f > maxJSONFloat {
-		return 0, fmt.Errorf("Out of range integer for numeric %f", f)
+		return 0, fmt.Errorf("out of range integer for numeric %f", f)
 	}
 	return uint64(f), nil
 }
@@ -279,7 +279,7 @@ func (h *proxyHandler) parseImageFromID(v interface{}) (*openImage, error) {
 	}
 	imgref, ok := h.images[imgid]
 	if !ok {
-		return nil, fmt.Errorf("No image %v", imgid)
+		return nil, fmt.Errorf("no image %v", imgid)
 	}
 	return imgref, nil
 }
@@ -368,7 +368,7 @@ func (h *proxyHandler) GetManifest(args []interface{}) (replyBuf, error) {
 	var ret replyBuf
 
 	if h.sysctx == nil {
-		return ret, fmt.Errorf("Must invoke Initialize")
+		return ret, fmt.Errorf("client error: must invoke Initialize")
 	}
 	if len(args) != 1 {
 		return ret, fmt.Errorf("invalid request, expecting one argument")
@@ -397,9 +397,9 @@ func (h *proxyHandler) GetManifest(args []interface{}) (replyBuf, error) {
 		break
 	// Explicitly reject e.g. docker schema 1 type with a "legacy" note
 	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType:
-		return ret, fmt.Errorf("Unsupported legacy manifest MIME type: %s", manifestType)
+		return ret, fmt.Errorf("unsupported legacy manifest MIME type: %s", manifestType)
 	default:
-		return ret, fmt.Errorf("Unsupported manifest MIME type: %s", manifestType)
+		return ret, fmt.Errorf("unsupported manifest MIME type: %s", manifestType)
 	}
 
 	// We always return the original digest, as that's what clients need to do pull-by-digest
@@ -438,7 +438,7 @@ func (h *proxyHandler) GetConfig(args []interface{}) (replyBuf, error) {
 	var ret replyBuf
 
 	if h.sysctx == nil {
-		return ret, fmt.Errorf("Must invoke Initialize")
+		return ret, fmt.Errorf("client error: must invoke Initialize")
 	}
 	if len(args) != 1 {
 		return ret, fmt.Errorf("invalid request, expecting: [imgid]")
@@ -474,7 +474,7 @@ func (h *proxyHandler) GetBlob(args []interface{}) (replyBuf, error) {
 	var ret replyBuf
 
 	if h.sysctx == nil {
-		return ret, fmt.Errorf("Must invoke Initialize")
+		return ret, fmt.Errorf("client error: must invoke Initialize")
 	}
 	if len(args) != 3 {
 		return ret, fmt.Errorf("found %d args, expecting (imgid, digest, size)", len(args))
@@ -517,7 +517,7 @@ func (h *proxyHandler) GetBlob(args []interface{}) (replyBuf, error) {
 			return
 		}
 		if n != int64(size) {
-			f.err = fmt.Errorf("Expected %d bytes in blob, got %d", size, n)
+			f.err = fmt.Errorf("expected %d bytes in blob, got %d", size, n)
 		}
 		if !verifier.Verified() {
 			f.err = fmt.Errorf("corrupted blob, expecting %s", d.String())

--- a/integration/procutils.go
+++ b/integration/procutils.go
@@ -1,0 +1,12 @@
+//go:build !linux
+// +build !linux
+
+package main
+
+import (
+	"os/exec"
+)
+
+// cmdLifecycleToParentIfPossible tries to exit if the parent process exits (only works on Linux)
+func cmdLifecycleToParentIfPossible(c *exec.Cmd) {
+}

--- a/integration/procutils_linux.go
+++ b/integration/procutils_linux.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// cmdLifecyleToParentIfPossible is a thin wrapper around prctl(PR_SET_PDEATHSIG)
+// on Linux.
+func cmdLifecycleToParentIfPossible(c *exec.Cmd) {
+	c.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+}

--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/containers/image/v5/manifest"
+)
+
+// This image is known to be x86_64 only right now
+const knownNotManifestListedImage_x8664 = "docker://quay.io/coreos/11bot"
+
+const expectedProxySemverMajor = "0.2"
+
+// request is copied from proxy.go
+// We intentionally copy to ensure that we catch any unexpected "API" changes
+// in the JSON.
+type request struct {
+	// Method is the name of the function
+	Method string `json:"method"`
+	// Args is the arguments (parsed inside the fuction)
+	Args []interface{} `json:"args"`
+}
+
+// reply is copied from proxy.go
+type reply struct {
+	// Success is true if and only if the call succeeded.
+	Success bool `json:"success"`
+	// Value is an arbitrary value (or values, as array/map) returned from the call.
+	Value interface{} `json:"value"`
+	// PipeID is an index into open pipes, and should be passed to FinishPipe
+	PipeID uint32 `json:"pipeid"`
+	// Error should be non-empty if Success == false
+	Error string `json:"error"`
+}
+
+// maxMsgSize is also copied from proxy.go
+const maxMsgSize = 32 * 1024
+
+type proxy struct {
+	c *net.UnixConn
+}
+
+type pipefd struct {
+	// id is the remote identifier "pipeid"
+	id uint
+	fd *os.File
+}
+
+func (self *proxy) call(method string, args []interface{}) (rval interface{}, fd *pipefd, err error) {
+	req := request{
+		Method: method,
+		Args:   args,
+	}
+	reqbuf, err := json.Marshal(&req)
+	if err != nil {
+		return
+	}
+	n, err := self.c.Write(reqbuf)
+	if err != nil {
+		return
+	}
+	if n != len(reqbuf) {
+		err = fmt.Errorf("short write during call of %d bytes", n)
+		return
+	}
+	oob := make([]byte, syscall.CmsgSpace(1))
+	replybuf := make([]byte, maxMsgSize)
+	n, oobn, _, _, err := self.c.ReadMsgUnix(replybuf, oob)
+	if err != nil {
+		err = fmt.Errorf("reading reply: %v", err)
+		return
+	}
+	var reply reply
+	err = json.Unmarshal(replybuf[0:n], &reply)
+	if err != nil {
+		err = fmt.Errorf("Failed to parse reply: %w", err)
+		return
+	}
+	if !reply.Success {
+		err = fmt.Errorf("remote error: %s", reply.Error)
+		return
+	}
+
+	if reply.PipeID > 0 {
+		var scms []syscall.SocketControlMessage
+		scms, err = syscall.ParseSocketControlMessage(oob[:oobn])
+		if err != nil {
+			err = fmt.Errorf("failed to parse control message: %v", err)
+			return
+		}
+		if len(scms) != 1 {
+			err = fmt.Errorf("Expected 1 received fd, found %d", len(scms))
+			return
+		}
+		var fds []int
+		fds, err = syscall.ParseUnixRights(&scms[0])
+		if err != nil {
+			err = fmt.Errorf("failed to parse unix rights: %v", err)
+			return
+		}
+		fd = &pipefd{
+			fd: os.NewFile(uintptr(fds[0]), "replyfd"),
+			id: uint(reply.PipeID),
+		}
+	}
+
+	rval = reply.Value
+	return
+}
+
+func newProxy() (*proxy, error) {
+	fds, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_SEQPACKET, 0)
+	if err != nil {
+		return nil, err
+	}
+	myfd := os.NewFile(uintptr(fds[0]), "myfd")
+	defer myfd.Close()
+	theirfd := os.NewFile(uintptr(fds[1]), "theirfd")
+	defer theirfd.Close()
+
+	mysock, err := net.FileConn(myfd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Note ExtraFiles starts at 3
+	proc := exec.Command("skopeo", "experimental-image-proxy", "--sockfd", "3")
+	proc.Stderr = os.Stderr
+	proc.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+	proc.ExtraFiles = append(proc.ExtraFiles, theirfd)
+
+	if err = proc.Start(); err != nil {
+		return nil, err
+	}
+
+	return &proxy{
+		c: mysock.(*net.UnixConn),
+	}, nil
+}
+
+func init() {
+	check.Suite(&ProxySuite{})
+}
+
+type ProxySuite struct {
+}
+
+func (s *ProxySuite) SetUpSuite(c *check.C) {
+}
+
+func (s *ProxySuite) TearDownSuite(c *check.C) {
+}
+
+func initOci(p string) error {
+	err := ioutil.WriteFile(filepath.Join(p, "oci-layout"), []byte("{\"imageLayoutVersion\":\"1.0.0\"}"), 0644)
+	if err != nil {
+		return err
+	}
+
+	blobdir := filepath.Join(p, "blobs/sha256")
+	err = os.MkdirAll(blobdir, 0755)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type byteFetch struct {
+	content []byte
+	err     error
+}
+
+func (s *ProxySuite) TestProxy(c *check.C) {
+	p, err := newProxy()
+	c.Assert(err, check.IsNil)
+
+	v, fd, err := p.call("Initialize", nil)
+	c.Assert(err, check.IsNil)
+	semver, ok := v.(string)
+	if !ok {
+		c.Fatalf("Unexpected value %T", v)
+	}
+	if !strings.HasPrefix(semver, expectedProxySemverMajor) {
+		c.Fatalf("Unexpected semver %s", semver)
+	}
+	c.Assert(fd, check.IsNil)
+
+	v, fd, err = p.call("OpenImage", []interface{}{knownNotManifestListedImage_x8664})
+	c.Assert(err, check.IsNil)
+	c.Assert(fd, check.IsNil)
+
+	imgidv, ok := v.(float64)
+	c.Assert(ok, check.Equals, true)
+	imgid := uint32(imgidv)
+
+	v, fd, err = p.call("GetManifest", []interface{}{imgid})
+	c.Assert(err, check.IsNil)
+	c.Assert(fd, check.NotNil)
+	fetchchan := make(chan byteFetch)
+	go func() {
+		manifestBytes, err := ioutil.ReadAll(fd.fd)
+		fetchchan <- byteFetch{
+			content: manifestBytes,
+			err:     err,
+		}
+	}()
+	_, _, err = p.call("FinishPipe", []interface{}{fd.id})
+	c.Assert(err, check.IsNil)
+	fetchRes := <-fetchchan
+	c.Assert(fetchRes.err, check.IsNil)
+
+	_, err = manifest.OCI1FromManifest(fetchRes.content)
+	c.Assert(err, check.IsNil)
+
+	td, err := ioutil.TempDir("", "skopeo-proxy")
+	defer os.RemoveAll(td)
+
+	c.Assert(initOci(td), check.IsNil)
+}

--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -186,9 +186,7 @@ func newProxy() (*proxy, error) {
 	// Note ExtraFiles starts at 3
 	proc := exec.Command("skopeo", "experimental-image-proxy", "--sockfd", "3")
 	proc.Stderr = os.Stderr
-	proc.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGTERM,
-	}
+	cmdLifecycleToParentIfPossible(proc)
 	proc.ExtraFiles = append(proc.ExtraFiles, theirfd)
 
 	if err = proc.Start(); err != nil {


### PR DESCRIPTION
proxy: Add an API to fetch the config upconverted to OCI

While the caller could fetch this today as a blob, it'd be in
either docker or oci schema.  In keeping with the model of having
this proxy only expose OCI, add an API which uses the c/image logic
to do the conversion.

This is necessary for callers to get the diffIDs, and in general
to implement something like an external `skopeo copy`.

---

proxy: Add a helper to return a byte array

Since this is shared between the manifest and config paths.

---

proxy: Use float → int helper for pipeid

Just noticed while scrolling past the code.

---

tests/integration/proxy_test: New test that exercises `proxy.go`

I debated adding "reverse dependency testing" using
https://crates.io/crates/containers-image-proxy
but I think it's easier to reuse the test infrastructure here.

This also starts fleshing out a Go client for the proxy (not
that this is going to be something most Go projects would want
versus vendoring c/image...but hey, maybe it'll be useful).

Now what I hit in trying to use the main test images is currently
the proxy fails on manifest lists, so I'll need to fix that.

---

proxy: Add support for manifest lists

We need to support manifest lists. I'm not sure how I missed this
originally.  At least now we have integration tests that cover this.

The issue here is fairly subtle - the way c/image works right now,
`image.FromUnparsedImage` does pick a matching image from a list
by default.  But it also overrides `GetManifest()` to return the
original manifest list, which defeats our goal here.

Handle this by adding explicit manifest list support code.  We'll
want this anyways for future support for `GetRawManifest` or so
which exposes OCI manifest lists to the client.

---

proxy_test: Add a helper method to call without fd

To verify in one place.

---

proxy_test: Add helper to read all from a reply

Prep for testing `GetConfig`.

---

proxy_test: Test `GetConfig`

Now that we have a test suite, let's use it more.

---

