### PR TITLE
Cirrus: Bump Fedora to release 35 & Ubuntu to 21.10

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,12 +23,12 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
-    FEDORA_NAME: "fedora-34"
-    PRIOR_FEDORA_NAME: "fedora-33"
-    UBUNTU_NAME: "ubuntu-2104"
+    FEDORA_NAME: "fedora-35"
+    PRIOR_FEDORA_NAME: "fedora-34"
+    UBUNTU_NAME: "ubuntu-2110"
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c6431352024203264"
+    IMAGE_SUFFIX: "c6226133906620416"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -58,10 +58,6 @@ _run_setup() {
         return
     fi
 
-    # This is required as part of the standard Fedora GCE VM setup
-    growpart /dev/sda 1
-    resize2fs /dev/sda1
-
     # VM's come with the distro. skopeo package pre-installed
     dnf erase -y skopeo
 


### PR DESCRIPTION
The Fedora 35 cloud images have switched to UEFI boot with a GPT
partition. Formerly, all Fedora images included support for runtime
re-partitioning. However, the requirement to test alternate storage
has since been dropped/removed.  Rather than maintain a disused
feature, and supporting scripts, these Fedora VM images have reverted
to the default: Automatically resize to 100% on boot.

Signed-off-by: Chris Evich <cevich@redhat.com>