### PR TITLE
Fix bug that prevented useful diagnostics on registry fail

### DIFF
--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -356,7 +356,7 @@ start_registry() {
             return
         fi
 
-        timeout=$(expr $timeout - 1)
+        timeout=$(( timeout - 1 ))
         sleep 1
     done
     log_and_run $PODMAN logs $name


### PR DESCRIPTION
Sigh. 'expr 1 - 1' yields 0 (correctly) but also exits 1. This
is even documented in the man page, but I didn't know it. And
thus, on the final iteration, when timeout reached 0, BATS
errored out on the expr instead of continuing to the 'podman logs'
or the 'die' message.

Solution is super trivial: use $(( ... )) instead of expr.

Signed-off-by: Ed Santiago <santiago@redhat.com>