### PR TITLE
Add an option to allow copying image indexes alone

### DIFF
--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -40,6 +40,7 @@ _skopeo_copy() {
     --src-authfile
     --dest-authfile
     --format -f
+    --multi-arch
     --sign-by
     --src-creds --screds
     --src-cert-dir

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -66,6 +66,17 @@ MANIFEST TYPE (oci, v2s1, or v2s2) to use in the destination (default is manifes
 
 Print usage statement
 
+**--multi-arch**
+
+Control what is copied if _source-image_ refers to a multi-architecture image. Default is system.
+
+Options:
+- system: Copy only the image that matches the system architecture
+- all: Copy the full multi-architecture image
+- index-only: Copy only the index
+
+The index-only option usually fails unless the referenced per-architecture images are already present in the destination, or the target registry supports sparse indexes.
+
 **--quiet**, **-q**
 
 Suppress output information when copying images.


### PR DESCRIPTION
This new --list-processing option deprecates the --all option and, when
an image index is copied, allows the user to select between copying the
image associated with the system platform, all images in the index, or
just the index itself without attempting to copy the images.

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>