### PR TITLE
Stop test producing output in source directory

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -1190,12 +1190,14 @@ func (s *SkopeoSuite) TestCopySrcAndDestWithAuth(c *check.C) {
 }
 
 func (s *CopySuite) TestCopyNoPanicOnHTTPResponseWithoutTLSVerifyFalse(c *check.C) {
+	topDir, err := ioutil.TempDir("", "no-panic-on-https-response-without-tls-verify-false")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(topDir)
+
 	const ourRegistry = "docker://" + v2DockerRegistryURL + "/"
 
-	// dir:test isn't created beforehand just because we already know this could
-	// just fail when evaluating the src
 	assertSkopeoFails(c, ".*server gave HTTP response to HTTPS client.*",
-		"copy", ourRegistry+"foobar", "dir:test")
+		"copy", ourRegistry+"foobar", "dir:"+topDir)
 }
 
 func (s *CopySuite) TestCopySchemaConversion(c *check.C) {


### PR DESCRIPTION
Use a dynamic temp dir for test

This test was incorrectly assuming that nothing would be made on disk,
but it was putting files into the source directory.

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>