### PR TITLE
Github workflow: Fix yaml syntax

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -99,4 +99,4 @@ jobs:
                 subject: Github workflow error on ${{github.repository}}
                 to: ${{env.RCPTCSV}}
                 from: ${{secrets.ACTION_MAIL_SENDER}}
-                body: Job failed: https://github.com/${{github.repository}}/runs/${{github.job}}?check_suite_focus=true
+                body: "Job failed: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"


### PR DESCRIPTION
Same problem as addressed in
https://github.com/containers/podman/pull/13005 I neglected to include
in https://github.com/containers/skopeo/pull/1546 for whatever reason.
This commit makes it right.

Signed-off-by: Chris Evich <cevich@redhat.com>