### PR TITLE
Improve documentation of skopeo inspect

### DIFF
--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -11,6 +11,9 @@ skopeo\-inspect - Return low-level information about _image-name_ in a registry.
 Return low-level information about _image-name_ in a registry.
 See [skopeo(1)](skopeo.1.md) for the format of _image-name_.
 
+The default output includes data from various sources: user input (**Name**), the remote repository, if any (**RepoTags**), the top-level manifest (**Digest**),
+and a per-architecture/OS image matching the current run-time environment (most other values).
+To see values for a different architecture/OS, use the **--override-os** / **--override-arch** options documented in [skopeo(1)](skopeo.1.md).
 
 ## OPTIONS
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -8,9 +8,9 @@ skopeo\-inspect - Return low-level information about _image-name_ in a registry.
 
 ## DESCRIPTION
 
-Return low-level information about _image-name_ in a registry
+Return low-level information about _image-name_ in a registry.
+See [skopeo(1)](skopeo.1.md) for the format of _image-name_.
 
-_image-name_ name of image to retrieve information about
 
 ## OPTIONS
 


### PR DESCRIPTION
- Make the documentation of _image-name_ more useful
- Document how some data is repo/manifest/architecture-specific, to fix #1345 .