### PR TITLE
Improve the documentation of boolean flags

### DIFF
--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -113,15 +113,15 @@ Key to be used for decryption of images. Key can point to keys and/or certificat
 
 Credentials for accessing the source registry.
 
-**--dest-compress** _bool-value_
+**--dest-compress**
 
 Compress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source).
 
-**--dest-decompress** _bool-value_
+**--dest-decompress**
 
 Decompress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source).
 
-**--dest-oci-accept-uncompressed-layers** _bool-value_
+**--dest-oci-accept-uncompressed-layers**
 
 Allow uncompressed image layers when saving to an OCI image using the 'oci' transport. (default is to compress things that aren't compressed).
 
@@ -133,11 +133,11 @@ Credentials for accessing the destination registry.
 
 Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the source registry or daemon.
 
-**--src-no-creds** _bool-value_
+**--src-no-creds**
 
 Access the registry anonymously.
 
-**--src-tls-verify** _bool-value_
+**--src-tls-verify**=_bool_
 
 Require HTTPS and verify certificates when talking to container source registry or daemon. Default to source registry setting.
 
@@ -145,11 +145,11 @@ Require HTTPS and verify certificates when talking to container source registry 
 
 Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the destination registry or daemon.
 
-**--dest-no-creds** _bool-value_
+**--dest-no-creds**
 
 Access the registry anonymously.
 
-**--dest-tls-verify** _bool-value_
+**--dest-tls-verify**=_bool_
 
 Require HTTPS and verify certificates when talking to container destination registry or daemon. Default to destination registry setting.
 
@@ -179,7 +179,7 @@ Bearer token for accessing the source registry.
 
 Bearer token for accessing the destination registry.
 
-**--dest-precompute-digests** _bool-value_
+**--dest-precompute-digests**
 
 Precompute digests to ensure layers are not uploaded that already exist on the destination registry. Layers with initially unknown digests (ex. compressing "on the fly") will be temporarily streamed to disk.
 

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -42,7 +42,7 @@ Use docker daemon host at _host_ (`docker-daemon:` transport only)
 
 Print usage statement
 
-**--no-creds** _bool-value_
+**--no-creds**
 
 Access the registry anonymously.
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -77,7 +77,7 @@ The username to access the registry.
 
 The password to access the registry.
 
-**--no-tags**, **-n**=_bool_
+**--no-tags**, **-n**
 
 Do not list the available tags from the repository in the output. When `true`, the `RepoTags` array will be empty.  Defaults to `false`, which includes all available tags.
 

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -27,7 +27,7 @@ Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry.
 
 Print usage statement
 
-**--no-creds** _bool-value_
+**--no-creds**
 
 Access the registry anonymously.
 

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -76,15 +76,15 @@ Print usage statement.
 
 **--src-cert-dir** _path_ Use certificates (*.crt, *.cert, *.key) at _path_ to connect to the source registry or daemon.
 
-**--src-no-creds** _bool-value_ Access the registry anonymously.
+**--src-no-creds** Access the registry anonymously.
 
-**--src-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to a container source registry or daemon. Default to source registry entry in registry.conf setting.
+**--src-tls-verify**=_bool_ Require HTTPS and verify certificates when talking to a container source registry or daemon. Default to source registry entry in registry.conf setting.
 
 **--dest-cert-dir** _path_ Use certificates (*.crt, *.cert, *.key) at _path_ to connect to the destination registry or daemon.
 
-**--dest-no-creds** _bool-value_  Access the registry anonymously.
+**--dest-no-creds** Access the registry anonymously.
 
-**--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to a container destination registry or daemon. Default to destination registry entry in registry.conf setting.
+**--dest-tls-verify**=_bool_ Require HTTPS and verify certificates when talking to a container destination registry or daemon. Default to destination registry entry in registry.conf setting.
 
 **--src-registry-token** _Bearer token_ for accessing the source registry.
 


### PR DESCRIPTION
The Go behavior of boolean flags is as follows:

Accepted values are `--flag`, which is the same as `--flag=true`, and `--flag=false`, which is the default (except for `OptionalBoolFlag`). `--flag {false,true}` is parsed as `--flag=true` with a non-option {`false`,`true`} argument.

So, for almost all flags, document them just as `--flag`, not mentioning the [`=`{`false`,`true`}] part, because users can just
omit `=true`, or the whole flag instead of `=false`.

OTOH, for `tls-verify`, document only the `tls-verify=`{`true`,`false`} variant, because the primary use is `tls-verify=false`, and because `tls-verify` is not “the default”, but equivalent to an explicit `tls-verify=true` (overriding `registries.conf`).

Fixes #1435 .