### PR TITLE
tests: skip sif test on RHEL

### DIFF
--- a/systemtest/020-copy.bats
+++ b/systemtest/020-copy.bats
@@ -125,6 +125,10 @@ function setup() {
     run podman --root $TESTDIR/podmanroot images
     expect_output --substring "mine"
 
+    # rootless cleanup needs to be done with unshare due to subuids
+    if [[ "$(id -u)" != "0" ]]; then
+        run podman unshare rm -rf $TESTDIR/podmanroot
+    fi
 }
 
 # shared blob directory
@@ -145,6 +149,8 @@ function setup() {
 }
 
 @test "copy: sif image" {
+    type -path fakeroot || skip "'fakeroot' tool not available"
+
     local localimg=dir:$TESTDIR/dir
 
     run_skopeo copy sif:${TEST_SOURCE_DIR}/testdata/busybox_latest.sif $localimg


### PR DESCRIPTION
(or, more precisely, if fakeroot binary not in $PATH).

Solves RHEL gating-test failure.

Also, fix rootless cleanup bug (need unshare, to avoid EPERM)

Signed-off-by: Ed Santiago <santiago@redhat.com>