### PR TITLE
do not recommend upgrading all packages

### DIFF
--- a/install.md
+++ b/install.md
@@ -81,7 +81,6 @@ provides packages for Ubuntu 20.04 (it should also work with direct derivatives 
 echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
 sudo apt-get update
-sudo apt-get -y upgrade
 sudo apt-get -y install skopeo
 ```
 


### PR DESCRIPTION
The command to install skopeo for Ubuntu 20.04 includes a forced upgrade step for all packages.

Installing skopeo does not require the upgrade step, and it could lead to possible issues completely unrelated to the project.