### PR TITLE
Update skopeoimage/README.md that tags are v-prefixed

### DIFF
--- a/contrib/skopeoimage/README.md
+++ b/contrib/skopeoimage/README.md
@@ -18,7 +18,7 @@ default to `/`.
 
 The container images are:
 
-  * `quay.io/containers/skopeo:<version>` and `quay.io/skopeo/stable:<version>` -
+  * `quay.io/containers/skopeo:v<version>` and `quay.io/skopeo/stable:v<version>` -
     These images are built when a new Skopeo version becomes available in
     Fedora.  These images are intended to be unchanging and stable, they will
     never be updated by automation once they've been pushed.  For build details,


### PR DESCRIPTION
The documentation is incomplete that tags are v-prefixed:
- https://github.com/containers/skopeo/blob/2b910649b9d86ac5dcd132ed45bb4c2551515490/contrib/skopeoimage/README.md

```
$ docker pull quay.io/skopeo/stable:1.7.0
Error response from daemon: manifest for quay.io/skopeo/stable:1.7.0 not found: manifest unknown: manifest unknown
```