### PR TITLE
Improve error messages when system image missing

### DIFF
--- a/systemtest/010-inspect.bats
+++ b/systemtest/010-inspect.bats
@@ -102,7 +102,7 @@ END_EXPECT
 
     # By default, 'inspect' tries to match our host os+arch. This should fail.
     run_skopeo 1 inspect $img
-    expect_output --substring "parsing manifest for image: choosing image instance: no image found in manifest list for architecture $arch, variant " \
+    expect_output --substring "parsing manifest for image: error choosing image instance: no image found in manifest list for architecture $arch, variant " \
                   "skopeo inspect, without --raw, fails"
 
     # With --raw, we can inspect

--- a/vendor/github.com/containers/image/v5/image/docker_list.go
+++ b/vendor/github.com/containers/image/v5/image/docker_list.go
@@ -11,15 +11,15 @@ import (
 func manifestSchema2FromManifestList(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
 	list, err := manifest.Schema2ListFromManifest(manblob)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing schema2 manifest list")
+		return nil, errors.Wrapf(err, "error parsing schema2 manifest list")
 	}
 	targetManifestDigest, err := list.ChooseInstance(sys)
 	if err != nil {
-		return nil, errors.Wrapf(err, "choosing image instance")
+		return nil, errors.Wrapf(err, "error choosing image instance")
 	}
 	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading manifest for target platform")
+		return nil, errors.Wrapf(err, "found target platform image in manifest list, but could not load it")
 	}
 
 	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)

--- a/vendor/github.com/containers/image/v5/image/oci_index.go
+++ b/vendor/github.com/containers/image/v5/image/oci_index.go
@@ -11,15 +11,15 @@ import (
 func manifestOCI1FromImageIndex(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
 	index, err := manifest.OCI1IndexFromManifest(manblob)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing OCI1 index")
+		return nil, errors.Wrapf(err, "error parsing OCI1 index")
 	}
 	targetManifestDigest, err := index.ChooseInstance(sys)
 	if err != nil {
-		return nil, errors.Wrapf(err, "choosing image instance")
+		return nil, errors.Wrapf(err, "error choosing image instance")
 	}
 	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading manifest for target platform")
+		return nil, errors.Wrapf(err, "found target platform image in manifest list, but could not load it")
 	}
 
 	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)


### PR DESCRIPTION
When inspecting an image index where the platform image for the current
architecture is missing, be clearer in the error message about what is
wrong.