### PR TITLE
Update to benefit from Go 1.16

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	commonFlag "github.com/containers/common/pkg/flag"
@@ -265,7 +265,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 			if err != nil {
 				return err
 			}
-			if err = ioutil.WriteFile(opts.digestFile, []byte(manifestDigest.String()), 0644); err != nil {
+			if err = os.WriteFile(opts.digestFile, []byte(manifestDigest.String()), 0644); err != nil {
 				return fmt.Errorf("Failed to write digest to file %q: %w", opts.digestFile, err)
 			}
 		}

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -122,7 +121,7 @@ func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 		}
 	}
 
-	tmpDir, err := ioutil.TempDir(".", "layers-")
+	tmpDir, err := os.MkdirTemp(".", "layers-")
 	if err != nil {
 		return err
 	}

--- a/cmd/skopeo/manifest.go
+++ b/cmd/skopeo/manifest.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/spf13/cobra"
@@ -31,7 +31,7 @@ func (opts *manifestDigestOptions) run(args []string, stdout io.Writer) error {
 	}
 	manifestPath := args[0]
 
-	man, err := ioutil.ReadFile(manifestPath)
+	man, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return fmt.Errorf("Error reading manifest from %s: %v", manifestPath, err)
 	}

--- a/cmd/skopeo/signing.go
+++ b/cmd/skopeo/signing.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/containers/image/v5/pkg/cli"
 	"github.com/containers/image/v5/signature"
@@ -39,7 +39,7 @@ func (opts *standaloneSignOptions) run(args []string, stdout io.Writer) error {
 	dockerReference := args[1]
 	fingerprint := args[2]
 
-	manifest, err := ioutil.ReadFile(manifestPath)
+	manifest, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return fmt.Errorf("Error reading %s: %v", manifestPath, err)
 	}
@@ -60,7 +60,7 @@ func (opts *standaloneSignOptions) run(args []string, stdout io.Writer) error {
 		return fmt.Errorf("Error creating signature: %v", err)
 	}
 
-	if err := ioutil.WriteFile(opts.output, signature, 0644); err != nil {
+	if err := os.WriteFile(opts.output, signature, 0644); err != nil {
 		return fmt.Errorf("Error writing signature to %s: %v", opts.output, err)
 	}
 	return nil
@@ -89,11 +89,11 @@ func (opts *standaloneVerifyOptions) run(args []string, stdout io.Writer) error 
 	expectedFingerprint := args[2]
 	signaturePath := args[3]
 
-	unverifiedManifest, err := ioutil.ReadFile(manifestPath)
+	unverifiedManifest, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return fmt.Errorf("Error reading manifest from %s: %v", manifestPath, err)
 	}
-	unverifiedSignature, err := ioutil.ReadFile(signaturePath)
+	unverifiedSignature, err := os.ReadFile(signaturePath)
 	if err != nil {
 		return fmt.Errorf("Error reading signature from %s: %v", signaturePath, err)
 	}
@@ -139,7 +139,7 @@ func (opts *untrustedSignatureDumpOptions) run(args []string, stdout io.Writer) 
 	}
 	untrustedSignaturePath := args[0]
 
-	untrustedSignature, err := ioutil.ReadFile(untrustedSignaturePath)
+	untrustedSignature, err := os.ReadFile(untrustedSignaturePath)
 	if err != nil {
 		return fmt.Errorf("Error reading untrusted signature from %s: %v", untrustedSignaturePath, err)
 	}

--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -77,7 +76,7 @@ func TestStandaloneSign(t *testing.T) {
 	assertTestFailed(t, out, err, "/dev/full")
 
 	// Success
-	sigOutput, err := ioutil.TempFile("", "sig")
+	sigOutput, err := os.CreateTemp("", "sig")
 	require.NoError(t, err)
 	defer os.Remove(sigOutput.Name())
 	out, err = runSkopeo("standalone-sign", "-o", sigOutput.Name(),
@@ -85,9 +84,9 @@ func TestStandaloneSign(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, out)
 
-	sig, err := ioutil.ReadFile(sigOutput.Name())
+	sig, err := os.ReadFile(sigOutput.Name())
 	require.NoError(t, err)
-	manifest, err := ioutil.ReadFile(manifestPath)
+	manifest, err := os.ReadFile(manifestPath)
 	require.NoError(t, err)
 	mech, err = signature.NewGPGSigningMechanism()
 	require.NoError(t, err)

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -140,7 +139,7 @@ func (tls *tlsVerifyConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 // It returns a new unmarshaled sourceConfig object and any error encountered.
 func newSourceConfig(yamlFile string) (sourceConfig, error) {
 	var cfg sourceConfig
-	source, err := ioutil.ReadFile(yamlFile)
+	source, err := os.ReadFile(yamlFile)
 	if err != nil {
 		return cfg, err
 	}

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -258,11 +259,11 @@ func imagesToCopyFromRepo(sys *types.SystemContext, repoRef reference.Named) ([]
 // and any error encountered.
 func imagesToCopyFromDir(dirPath string) ([]types.ImageReference, error) {
 	var sourceReferences []types.ImageReference
-	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && info.Name() == "manifest.json" {
+		if !d.IsDir() && d.Name() == "manifest.json" {
 			dirname := filepath.Dir(path)
 			ref, err := directory.Transport.ParseReference(dirname)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/skopeo
 
-go 1.15
+go 1.16
 
 require (
 	github.com/containers/common v0.47.5

--- a/go.sum
+++ b/go.sum
@@ -335,7 +335,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
@@ -804,7 +803,6 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.0.0 h1:CcuG/HvWNkkaqCUpJifQY8z7qEMBJya6aLPx6ftGyjQ=
 github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -831,15 +832,15 @@ func (s *CopySuite) TestCopyCompression(c *check.C) {
 
 func findRegularFiles(c *check.C, root string) []string {
 	result := []string{}
-	err := filepath.Walk(root, filepath.WalkFunc(func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.Mode().IsRegular() {
+		if d.Type().IsRegular() {
 			result = append(result, path)
 		}
 		return nil
-	}))
+	})
 	c.Assert(err, check.IsNil)
 	return result
 }

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -73,7 +72,7 @@ func (s *CopySuite) SetUpSuite(c *check.C) {
 		runCommandWithInput(c, batchInput, gpgBinary, "--batch", "--gen-key")
 
 		out := combinedOutputOfCommand(c, gpgBinary, "--armor", "--export", fmt.Sprintf("%s@example.com", key))
-		err := ioutil.WriteFile(filepath.Join(s.gpgHome, fmt.Sprintf("%s-pubkey.gpg", key)),
+		err := os.WriteFile(filepath.Join(s.gpgHome, fmt.Sprintf("%s-pubkey.gpg", key)),
 			[]byte(out), 0600)
 		c.Assert(err, check.IsNil)
 	}
@@ -134,7 +133,7 @@ func (s *CopySuite) TestCopyNoneWithManifestList(c *check.C) {
 	assertSkopeoSucceeds(c, "", "copy", "--multi-arch=index-only", knownListImage, "dir:"+dir1)
 
 	manifestPath := filepath.Join(dir1, "manifest.json")
-	readManifest, err := ioutil.ReadFile(manifestPath)
+	readManifest, err := os.ReadFile(manifestPath)
 	c.Assert(err, check.IsNil)
 	mimeType := manifest.GuessMIMEType(readManifest)
 	c.Assert(mimeType, check.Equals, "application/vnd.docker.distribution.manifest.list.v2+json")
@@ -209,7 +208,7 @@ func (s *CopySuite) TestCopyWithDigestfileOutput(c *check.C) {
 	dir1 := c.MkDir()
 	digestOutPath := filepath.Join(tempdir, "digest.txt")
 	assertSkopeoSucceeds(c, "", "copy", "--digestfile="+digestOutPath, knownListImage, "dir:"+dir1)
-	readDigest, err := ioutil.ReadFile(digestOutPath)
+	readDigest, err := os.ReadFile(digestOutPath)
 	c.Assert(err, check.IsNil)
 	_, err = digest.Parse(string(readDigest))
 	c.Assert(err, check.IsNil)
@@ -490,9 +489,9 @@ func (s *CopySuite) TestCopyEncryption(c *check.C) {
 	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
 	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(keysDir+"/private.key", privateKeyBytes, 0644)
+	err = os.WriteFile(keysDir+"/private.key", privateKeyBytes, 0644)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(keysDir+"/public.key", publicKeyBytes, 0644)
+	err = os.WriteFile(keysDir+"/public.key", publicKeyBytes, 0644)
 	c.Assert(err, check.IsNil)
 
 	// We can either perform encryption or decryption on the image.
@@ -516,7 +515,7 @@ func (s *CopySuite) TestCopyEncryption(c *check.C) {
 	invalidPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	c.Assert(err, check.IsNil)
 	invalidPrivateKeyBytes := x509.MarshalPKCS1PrivateKey(invalidPrivateKey)
-	err = ioutil.WriteFile(keysDir+"/invalid_private.key", invalidPrivateKeyBytes, 0644)
+	err = os.WriteFile(keysDir+"/invalid_private.key", invalidPrivateKeyBytes, 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoFails(c, ".*no suitable key unwrapper found or none of the private keys could be used for decryption.*",
 		"copy", "--decryption-key", keysDir+"/invalid_private.key",
@@ -556,7 +555,7 @@ func (s *CopySuite) TestCopyEncryption(c *check.C) {
 }
 
 func matchLayerBlobBinaryType(c *check.C, ociImageDirPath string, contentType string, matchCount int) {
-	files, err := ioutil.ReadDir(ociImageDirPath)
+	files, err := os.ReadDir(ociImageDirPath)
 	c.Assert(err, check.IsNil)
 
 	foundCount := 0
@@ -592,7 +591,7 @@ func assertDirImagesAreEqual(c *check.C, dir1, dir2 string) {
 	digests := []digest.Digest{}
 	for _, dir := range []string{dir1, dir2} {
 		manifestPath := filepath.Join(dir, "manifest.json")
-		m, err := ioutil.ReadFile(manifestPath)
+		m, err := os.ReadFile(manifestPath)
 		c.Assert(err, check.IsNil)
 		digest, err := manifest.Digest(m)
 		c.Assert(err, check.IsNil)
@@ -610,7 +609,7 @@ func assertSchema1DirImagesAreEqualExceptNames(c *check.C, dir1, ref1, dir2, ref
 	manifests := []map[string]interface{}{}
 	for dir, ref := range map[string]string{dir1: ref1, dir2: ref2} {
 		manifestPath := filepath.Join(dir, "manifest.json")
-		m, err := ioutil.ReadFile(manifestPath)
+		m, err := os.ReadFile(manifestPath)
 		c.Assert(err, check.IsNil)
 		data := map[string]interface{}{}
 		err = json.Unmarshal(m, &data)

--- a/integration/openshift.go
+++ b/integration/openshift.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -193,7 +192,7 @@ func (cluster *openshiftCluster) startRegistry(c *check.C) {
 		// The default configuration currently already contains acceptschema2: false
 	})
 	// Make sure the configuration contains "acceptschema2: false", because eventually it will be enabled upstream and this function will need to be updated.
-	configContents, err := ioutil.ReadFile(schema1Config)
+	configContents, err := os.ReadFile(schema1Config)
 	c.Assert(err, check.IsNil)
 	c.Assert(string(configContents), check.Matches, "(?s).*acceptschema2: false.*")
 	cluster.processes = append(cluster.processes, cluster.startRegistryProcess(c, 5005, schema1Config))
@@ -237,7 +236,7 @@ func (cluster *openshiftCluster) dockerLogin(c *check.C) {
 			}`, port, authValue))
 	}
 	configJSON := `{"auths": {` + strings.Join(auths, ",") + `}}`
-	err = ioutil.WriteFile(filepath.Join(cluster.dockerDir, "config.json"), []byte(configJSON), 0600)
+	err = os.WriteFile(filepath.Join(cluster.dockerDir, "config.json"), []byte(configJSON), 0600)
 	c.Assert(err, check.IsNil)
 }
 

--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -144,7 +144,7 @@ func (p *proxy) callReadAllBytes(method string, args []interface{}) (rval interf
 	}
 	fetchchan := make(chan byteFetch)
 	go func() {
-		manifestBytes, err := ioutil.ReadAll(fd.fd)
+		manifestBytes, err := io.ReadAll(fd.fd)
 		fetchchan <- byteFetch{
 			content: manifestBytes,
 			err:     err,

--- a/integration/registry.go
+++ b/integration/registry.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -67,7 +66,7 @@ http:
 		username = "testuser"
 		password = "testpassword"
 		email = "test@test.org"
-		if err := ioutil.WriteFile(htpasswdPath, []byte(userpasswd), os.FileMode(0644)); err != nil {
+		if err := os.WriteFile(htpasswdPath, []byte(userpasswd), os.FileMode(0644)); err != nil {
 			return nil, err
 		}
 		htpasswd = fmt.Sprintf(`auth:

--- a/integration/signing_test.go
+++ b/integration/signing_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -65,7 +64,7 @@ func (s *SigningSuite) TestSignVerifySmoke(c *check.C) {
 	manifestPath := "fixtures/image.manifest.json"
 	dockerReference := "testing/smoketest"
 
-	sigOutput, err := ioutil.TempFile("", "sig")
+	sigOutput, err := os.CreateTemp("", "sig")
 	c.Assert(err, check.IsNil)
 	defer os.Remove(sigOutput.Name())
 	assertSkopeoSucceeds(c, "^$", "standalone-sign", "-o", sigOutput.Name(),

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -102,11 +103,11 @@ func (s *SyncSuite) TearDownSuite(c *check.C) {
 
 func assertNumberOfManifestsInSubdirs(c *check.C, dir string, expectedCount int) {
 	nManifests := 0
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && info.Name() == "manifest.json" {
+		if !d.IsDir() && d.Name() == "manifest.json" {
 			nManifests++
 			return filepath.SkipDir
 		}

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -100,6 +100,22 @@ func (s *SyncSuite) TearDownSuite(c *check.C) {
 	}
 }
 
+func assertNumberOfManifestsInSubdirs(c *check.C, dir string, expectedCount int) {
+	nManifests := 0
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.Name() == "manifest.json" {
+			nManifests++
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(nManifests, check.Equals, expectedCount)
+}
+
 func (s *SyncSuite) TestDocker2DirTagged(c *check.C) {
 	tmpDir := c.MkDir()
 
@@ -280,21 +296,7 @@ func (s *SyncSuite) TestYamlUntagged(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(len(localTags), check.Not(check.Equals), 0)
 	c.Assert(len(localTags), check.Equals, len(tags))
-
-	nManifests := 0
-	//count the number of manifest.json in dir1
-	err = filepath.Walk(dir1, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() && info.Name() == "manifest.json" {
-			nManifests++
-			return filepath.SkipDir
-		}
-		return nil
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(nManifests, check.Equals, len(tags))
+	assertNumberOfManifestsInSubdirs(c, dir1, len(tags))
 }
 
 func (s *SyncSuite) TestYamlRegex2Dir(c *check.C) {
@@ -314,20 +316,7 @@ k8s.gcr.io:
 	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoSucceeds(c, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
-
-	nManifests := 0
-	err = filepath.Walk(dir1, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() && info.Name() == "manifest.json" {
-			nManifests++
-			return filepath.SkipDir
-		}
-		return nil
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(nManifests, check.Equals, nTags)
+	assertNumberOfManifestsInSubdirs(c, dir1, nTags)
 }
 
 func (s *SyncSuite) TestYamlDigest2Dir(c *check.C) {
@@ -344,20 +333,7 @@ k8s.gcr.io:
 	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoSucceeds(c, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
-
-	nManifests := 0
-	err = filepath.Walk(dir1, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() && info.Name() == "manifest.json" {
-			nManifests++
-			return filepath.SkipDir
-		}
-		return nil
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(nManifests, check.Equals, 1)
+	assertNumberOfManifestsInSubdirs(c, dir1, 1)
 }
 
 func (s *SyncSuite) TestYaml2Dir(c *check.C) {
@@ -395,20 +371,7 @@ quay.io:
 	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoSucceeds(c, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
-
-	nManifests := 0
-	err = filepath.Walk(dir1, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() && info.Name() == "manifest.json" {
-			nManifests++
-			return filepath.SkipDir
-		}
-		return nil
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(nManifests, check.Equals, nTags)
+	assertNumberOfManifestsInSubdirs(c, dir1, nTags)
 }
 
 func (s *SyncSuite) TestYamlTLSVerify(c *check.C) {

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -82,7 +81,7 @@ func (s *SyncSuite) SetUpSuite(c *check.C) {
 		runCommandWithInput(c, batchInput, gpgBinary, "--batch", "--gen-key")
 
 		out := combinedOutputOfCommand(c, gpgBinary, "--armor", "--export", fmt.Sprintf("%s@example.com", key))
-		err := ioutil.WriteFile(filepath.Join(gpgHome, fmt.Sprintf("%s-pubkey.gpg", key)),
+		err := os.WriteFile(filepath.Join(gpgHome, fmt.Sprintf("%s-pubkey.gpg", key)),
 			[]byte(out), 0600)
 		c.Assert(err, check.IsNil)
 	}
@@ -256,7 +255,7 @@ func (s *SyncSuite) TestYamlUntagged(c *check.C) {
 
 	// sync to the local registry
 	yamlFile := path.Join(tmpDir, "registries.yaml")
-	err = ioutil.WriteFile(yamlFile, []byte(yamlConfig), 0644)
+	err = os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoSucceeds(c, "", "sync", "--scoped", "--src", "yaml", "--dest", "docker", "--dest-tls-verify=false", yamlFile, v2DockerRegistryURL)
 	// sync back from local registry to a folder
@@ -268,7 +267,7 @@ func (s *SyncSuite) TestYamlUntagged(c *check.C) {
     %s: []
 `, v2DockerRegistryURL, imagePath)
 
-	err = ioutil.WriteFile(yamlFile, []byte(yamlConfig), 0644)
+	err = os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoSucceeds(c, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
 
@@ -312,7 +311,7 @@ k8s.gcr.io:
 	c.Assert(nTags, check.Not(check.Equals), 0)
 
 	yamlFile := path.Join(tmpDir, "registries.yaml")
-	err := ioutil.WriteFile(yamlFile, []byte(yamlConfig), 0644)
+	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoSucceeds(c, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
 
@@ -342,7 +341,7 @@ k8s.gcr.io:
     - sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610
 `
 	yamlFile := path.Join(tmpDir, "registries.yaml")
-	err := ioutil.WriteFile(yamlFile, []byte(yamlConfig), 0644)
+	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoSucceeds(c, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
 
@@ -393,7 +392,7 @@ quay.io:
 	c.Assert(nTags, check.Not(check.Equals), 0)
 
 	yamlFile := path.Join(tmpDir, "registries.yaml")
-	err := ioutil.WriteFile(yamlFile, []byte(yamlConfig), 0644)
+	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 	c.Assert(err, check.IsNil)
 	assertSkopeoSucceeds(c, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
 
@@ -456,7 +455,7 @@ func (s *SyncSuite) TestYamlTLSVerify(c *check.C) {
 	for _, cfg := range testCfg {
 		yamlConfig := fmt.Sprintf(yamlTemplate, v2DockerRegistryURL, cfg.tlsVerify, image, tag)
 		yamlFile := path.Join(tmpDir, "registries.yaml")
-		err := ioutil.WriteFile(yamlFile, []byte(yamlConfig), 0644)
+		err := os.WriteFile(yamlFile, []byte(yamlConfig), 0644)
 		c.Assert(err, check.IsNil)
 
 		cfg.checker(c, cfg.msg, "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -3,8 +3,8 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -163,7 +163,7 @@ func modifyEnviron(env []string, name, value string) []string {
 // fileFromFixtureFixture applies edits to inputPath and returns a path to the temporary file.
 // Callers should defer os.Remove(the_returned_path)
 func fileFromFixture(c *check.C, inputPath string, edits map[string]string) string {
-	contents, err := ioutil.ReadFile(inputPath)
+	contents, err := os.ReadFile(inputPath)
 	c.Assert(err, check.IsNil)
 	for template, value := range edits {
 		updated := bytes.Replace(contents, []byte(template), []byte(value), -1)
@@ -171,7 +171,7 @@ func fileFromFixture(c *check.C, inputPath string, edits map[string]string) stri
 		contents = updated
 	}
 
-	file, err := ioutil.TempFile("", "policy.json")
+	file, err := os.CreateTemp("", "policy.json")
 	c.Assert(err, check.IsNil)
 	path := file.Name()
 
@@ -187,7 +187,7 @@ func fileFromFixture(c *check.C, inputPath string, edits map[string]string) stri
 func runDecompressDirs(c *check.C, regexp string, args ...string) {
 	c.Logf("Running %s %s", decompressDirsBinary, strings.Join(args, " "))
 	for i, dir := range args {
-		m, err := ioutil.ReadFile(filepath.Join(dir, "manifest.json"))
+		m, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
 		c.Assert(err, check.IsNil)
 		c.Logf("manifest %d before: %s", i+1, string(m))
 	}
@@ -197,7 +197,7 @@ func runDecompressDirs(c *check.C, regexp string, args ...string) {
 		if len(out) > 0 {
 			c.Logf("output: %s", out)
 		}
-		m, err := ioutil.ReadFile(filepath.Join(dir, "manifest.json"))
+		m, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
 		c.Assert(err, check.IsNil)
 		c.Logf("manifest %d after: %s", i+1, string(m))
 	}
@@ -208,7 +208,7 @@ func runDecompressDirs(c *check.C, regexp string, args ...string) {
 
 // Verify manifest in a dir: image at dir is expectedMIMEType.
 func verifyManifestMIMEType(c *check.C, dir string, expectedMIMEType string) {
-	manifestBlob, err := ioutil.ReadFile(filepath.Join(dir, "manifest.json"))
+	manifestBlob, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
 	c.Assert(err, check.IsNil)
 	mimeType := manifest.GuessMIMEType(manifestBlob)
 	c.Assert(mimeType, check.Equals, expectedMIMEType)


### PR DESCRIPTION
After https://github.com/containers/storage/pull/1176 requiring Go 1.16, Skopeo will effectively require Go 1.16 as soon as it updates to that version of c/storage; so, update as well.

This is mostly trivial updates to remove references `io/ioutil`, along with a few very small optimizations (`ReadDir` and `WalkDir` not calling `lstat(2)` on every entry).