### PR TITLE
sigstore test env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ endif
 # Multiple scripts are sensitive to this value, make sure it's exported/available
 # N/B: Need to use 'command -v' here for compatibility with MacOS.
 export CONTAINER_RUNTIME ?= $(if $(shell command -v podman),podman,docker)
+export COMPOSE_CMD ?= $(if $(shell command -v podman-compose),podman-compose,docker-compose)
 GOMD2MAN ?= $(if $(shell command -v go-md2man),go-md2man,$(GOBIN)/go-md2man)
 
 # Go module support: set `-mod=vendor` to use the vendored sources.
@@ -71,6 +72,18 @@ CI ?=
 # This env. var. is interpreted by some tests as a permission to
 # modify local configuration files and services.
 export SKOPEO_CONTAINER_TESTS ?= $(if $(CI),1,0)
+
+# The following env vars are only required for sigstore integration tests
+# see hack/sigstore-setup
+export VAULT_TOKEN ?= testtoken
+export VAULT_ADDR ?= http://localhost:8200/
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_REGION ?= us-east-1
+export AWS_ENDPOINT ?= localhost:4566
+export AWS_TLS_INSECURE_SKIP_VERIFY ?= 1
+export OIDC_ISSUER ?= http://127.0.0.1:5556/auth
+export OIDC_ID ?= sigstore
 
 # This is a compromise, we either use a container for this or require
 # the local user to have a compatible python3 development environment.
@@ -221,6 +234,12 @@ test-system-local: bin/skopeo
 test-unit:
 	# Just call (make test unit-local) here instead of worrying about environment differences
 	$(CONTAINER_RUN) $(MAKE) test-unit-local
+
+sigstore-testenv-up:
+	cd hack/sigstore-setup && ./sigstore-setup.sh setup
+
+sigstore-testenv-down:
+	cd hack/sigstore-setup && ./sigstore-setup.sh cleanup
 
 validate:
 	$(CONTAINER_RUN) $(MAKE) validate-local

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -56,7 +56,7 @@ _run_setup() {
     dnf erase -y skopeo
 
     # Required for testing the SIF transport
-    dnf install -y fakeroot squashfs-tools
+    dnf install -y fakeroot squashfs-tools podman-compose
 
     msg "Removing systemd-resolved from nsswitch.conf"
     # /etc/resolv.conf is already set to bypass systemd-resolvd
@@ -119,7 +119,9 @@ _run_integration() {
     # Ensure we start with a clean-slate
     podman system reset --force
 
+    make sigstore-testenv-up
     make test-integration-local BUILDTAGS="$BUILDTAGS"
+    make sigstore-testenv-down
 }
 
 _run_system() {

--- a/hack/sigstore-setup/dex-config.yml
+++ b/hack/sigstore-setup/dex-config.yml
@@ -1,0 +1,43 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This config is borrowed/copied from https://raw.githubusercontent.com/sigstore/sigstore/main/test/e2e/dex-config.yml
+
+issuer: http://127.0.0.1:5556/auth
+
+storage:
+  type: memory
+
+# Configuration for the HTTP endpoints.
+web:
+  http: 0.0.0.0:5556
+
+logger:
+  level: debug
+
+oauth2:
+  responseTypes: [ "code" ]
+  skipApprovalScreen: true
+  alwaysShowLoginScreen: false
+
+staticClients:
+- id: sigstore
+  name: 'Sigstore Mock'
+  public: true
+
+connectors:
+- type: mockCallback
+  id: mock
+  name: Mock

--- a/hack/sigstore-setup/docker-compose.yml
+++ b/hack/sigstore-setup/docker-compose.yml
@@ -1,0 +1,40 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is copied from sigstore/sigstore
+# See https://github.com/sigstore/sigstore/blob/main/test/e2e/docker-compose.yml
+
+version: "3.8"
+services:
+  vault:
+    image: docker.io/library/vault:1.9.6
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_TOKEN}
+    ports:
+      - 8200:8200
+    privileged: true
+  localstack:
+    image: docker.io/localstack/localstack:0.12.16
+    ports:
+      - 4566:4566
+    environment:
+      - SERVICES=kms
+  dex:
+    image: docker.io/dexidp/dex:v2.31.1
+    ports:
+      - "5556:5556"
+    volumes:
+      - ./dex-config.yml:/etc/dex/dex-config.yml:z
+    command: ["dex", "serve", "/etc/dex/dex-config.yml"]

--- a/hack/sigstore-setup/sigstore-setup.sh
+++ b/hack/sigstore-setup/sigstore-setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is copied from sigstore/sigstore
+# replacing docker-compose with podman-compose
+# See https://github.com/sigstore/sigstore/blob/main/test/e2e/e2e-test.sh
+
+set -ex
+
+cleanup() {
+  echo "cleanup"
+  $COMPOSE_CMD down
+}
+
+run=$1
+if [ $run = "cleanup" ]
+then
+    cleanup
+else
+  trap cleanup ERR
+
+  echo "starting services"
+
+  $COMPOSE_CMD up -d
+
+  count=0
+
+  echo -n "waiting up to 60 sec for system to start"
+
+  until [ $($CONTAINER_RUNTIME ps -a --format "{{.Status}} {{.Image}}" | grep -e vault | grep -c -e Up) == 1 -a $($COMPOSE_CMD logs localstack | grep -c Ready) == 1 ];
+  do
+    if [ $count -eq 12 ]; then
+      echo "! timeout reached"
+      exit 1
+    else
+      echo -n "."
+      sleep 5
+      let 'count+=1'
+    fi
+  done
+
+  echo "sigstore setup complete"
+fi

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -28,8 +28,8 @@ func init() {
 }
 
 const (
-	v2DockerRegistryURL   = "localhost:5555" // Update also policy.json
-	v2s1DockerRegistryURL = "localhost:5556"
+	v2DockerRegistryURL   = "localhost:8888" // Update also policy.json, registries.yaml
+	v2s1DockerRegistryURL = "localhost:8889"
 	knownWindowsOnlyImage = "docker://mcr.microsoft.com/windows/nanoserver:1909"
 	knownListImage        = "docker://registry.fedoraproject.org/fedora-minimal" // could have either ":latest" or "@sha256:..." appended
 )

--- a/integration/fixtures/policy.json
+++ b/integration/fixtures/policy.json
@@ -6,7 +6,7 @@
     ],
     "transports": {
         "docker": {
-            "localhost:5555": [
+            "localhost:8888": [
                 {
                     "type": "signedBy",
                     "keyType": "GPGKeys",

--- a/integration/fixtures/registries.yaml
+++ b/integration/fixtures/registries.yaml
@@ -1,6 +1,6 @@
 docker:
-   localhost:5555:
+   localhost:8888:
         lookaside: file://@lookaside@
-   localhost:5555/public:
+   localhost:8888/public:
         lookaside-staging: file://@split-staging@
         lookaside: @split-read@


### PR DESCRIPTION
This PR introduces 2 make targets:
```
make sigstore-testenv-up
make sigstore-testenv-down
```
This will enable testing for[ addition of sigstore image signing/verification](https://github.com/containers/image/pull/1364)

/cc @lukehinds @mtrmac @vrothberg  :) 