### PR TITLE
[release-1.6] Backport the F36 CI image change

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,12 +23,12 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
-    FEDORA_NAME: "fedora-35"
-    PRIOR_FEDORA_NAME: "fedora-34"
+    FEDORA_NAME: "fedora-36"
+    PRIOR_FEDORA_NAME: "fedora-35"
     UBUNTU_NAME: "ubuntu-2110"
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c4764556961513472"
+    IMAGE_SUFFIX: "c4955393725038592"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -30,12 +30,6 @@ else
     ) > /dev/stderr
 fi
 
-OS_RELEASE_ID="$(source /etc/os-release; echo $ID)"
-# GCE image-name compatible string representation of distribution _major_ version
-OS_RELEASE_VER="$(source /etc/os-release; echo $VERSION_ID | tr -d '.')"
-# Combined to ease some usage
-OS_REL_VER="${OS_RELEASE_ID}-${OS_RELEASE_VER}"
-
 # This is the magic interpreted by the tests to allow modifying local config/services.
 SKOPEO_CONTAINER_TESTS=1
 

--- a/hack/make/test-system
+++ b/hack/make/test-system
@@ -1,14 +1,21 @@
 #!/bin/bash
 set -e
 
-# Before running podman for the first time, make sure
-# to set storage to vfs (not overlay): podman-in-podman
-# doesn't work with overlay. And, disable mountopt,
-# which causes error with vfs.
-sed -i \
-    -e 's/^driver\s*=.*/driver = "vfs"/' \
-    -e 's/^mountopt/#mountopt/' \
-    /etc/containers/storage.conf
+# These tests can run in/outside of a container.  However,
+# not all storage drivers are supported in a container
+# environment.  Detect this and setup storage when
+# running in a container.
+if ((SKOPEO_CONTAINER_TESTS)) && [[ -r /etc/containers/storage.conf ]]; then
+    sed -i \
+        -e 's/^driver\s*=.*/driver = "vfs"/' \
+        -e 's/^mountopt/#mountopt/' \
+        /etc/containers/storage.conf
+elif ((SKOPEO_CONTAINER_TESTS)); then
+    cat >> /etc/containers/storage.conf << EOF
+[storage]
+driver = "vfs"
+EOF
+fi
 
 # Build skopeo, install into /usr/bin
 make PREFIX=/usr install


### PR DESCRIPTION
… from #1631 , so that tests on this branch, and c/image tests on the 5.19 branch, can run.

Compare https://github.com/containers/image/pull/1540 .