### PR TITLE
Config files live in /usr/local/etc on FreeBSD (highlight in release notes!)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ GPGME_ENV := CGO_CFLAGS="$(shell gpgme-config --cflags 2>/dev/null)" CGO_LDFLAGS
 # The following variables very roughly follow https://www.gnu.org/prep/standards/standards.html#Makefile-Conventions .
 DESTDIR ?=
 PREFIX ?= /usr/local
+ifeq ($(shell uname -s),FreeBSD)
+CONTAINERSCONFDIR ?= /usr/local/etc/containers
+else
 CONTAINERSCONFDIR ?= /etc/containers
+endif
 REGISTRIESDDIR ?= ${CONTAINERSCONFDIR}/registries.d
 SIGSTOREDIR ?= /var/lib/containers/sigstore
 BINDIR ?= ${PREFIX}/bin

--- a/hack/btrfs_installed_tag.sh
+++ b/hack/btrfs_installed_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/ioctl.h>
 EOF

--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/version.h>
 EOF

--- a/hack/libdm_tag.sh
+++ b/hack/libdm_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT

--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 STATUS=$(git status --porcelain)


### PR DESCRIPTION
Config files for non-base packages live in /usr/local/etc and **https://github.com/containers/image/pull/1544** changes the default paths in containers/image. This changes the skopeo Makefile to match.