### PR TITLE
[CI:DOCS] Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -18,6 +18,9 @@ on:
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
 
+permissions:
+    contents: read
+
 env:
     # Debug-mode can reveal secrets, only enable by a secret value.
     # Ref: https://help.github.com/en/actions/configuring-and-managing-workflows/managing-a-workflow-run#enabling-step-debug-logging
@@ -32,12 +35,12 @@ jobs:
     cron_failures:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
               with:
                   persist-credentials: false
 
             # Avoid duplicating cron_failures.sh in skopeo repo.
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
               with:
                   repository: containers/podman
                   path: '_podman'
@@ -71,7 +74,7 @@ jobs:
             - if: steps.cron.outputs.failures > 0
               name: Send failure notification e-mail
               # Ref: https://github.com/dawidd6/action-send-mail
-              uses: dawidd6/action-send-mail@v2.2.2
+              uses: dawidd6/action-send-mail@a80d851dc950256421f1d1d735a2dc1ef314ac8f # v2.2.2
               with:
                 server_address: ${{secrets.ACTION_MAIL_SERVER}}
                 server_port: 465
@@ -83,14 +86,14 @@ jobs:
                 body: file://./artifacts/email_body.txt
 
             - if: always()
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
               with:
                   name: ${{ github.job }}_artifacts
                   path: artifacts/*
 
             - if: failure()
               name: Send error notification e-mail
-              uses: dawidd6/action-send-mail@v2.2.2
+              uses: dawidd6/action-send-mail@a80d851dc950256421f1d1d735a2dc1ef314ac8f # v2.2.2
               with:
                 server_address: ${{secrets.ACTION_MAIL_SERVER}}
                 server_port: 465

--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -18,6 +18,9 @@ on:
   # allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   multi:
     name: multi-arch image build
@@ -50,19 +53,19 @@ jobs:
           - 5000:5000
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1
         with:
           driver-opts: network=host
           install: true
 
       - name: Build and locally push image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: contrib/${{ env.REPONAME }}image/${{ matrix.source }}
           file: ./contrib/${{ env.REPONAME }}image/${{ matrix.source }}/Dockerfile
@@ -162,7 +165,7 @@ jobs:
 
       # Push to $REPONAME_QUAY_REGISTRY for stable, testing. and upstream
       - name: Login to ${{ env.REPONAME_QUAY_REGISTRY }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         if: steps.reponame_reg.outputs.push == 'true'
         with:
           registry: ${{ env.REPONAME_QUAY_REGISTRY }}
@@ -172,7 +175,7 @@ jobs:
           password: ${{ secrets.REPONAME_QUAY_PASSWORD }}
 
       - name: Push images to ${{ steps.reponame_reg.outputs.fqin }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         if: steps.reponame_reg.outputs.push == 'true'
         with:
           cache-from: type=registry,ref=localhost:5000/${{ env.REPONAME }}/${{ matrix.source }}
@@ -188,7 +191,7 @@ jobs:
       # Push to $CONTAINERS_QUAY_REGISTRY only stable
       - name: Login to ${{ env.CONTAINERS_QUAY_REGISTRY }}
         if: steps.containers_reg.outputs.push == 'true'
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           registry: ${{ env.CONTAINERS_QUAY_REGISTRY}}
           username: ${{ secrets.CONTAINERS_QUAY_USERNAME }}
@@ -196,7 +199,7 @@ jobs:
 
       - name: Push images to ${{ steps.containers_reg.outputs.fqin }}
         if: steps.containers_reg.outputs.push == 'true'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           cache-from: type=registry,ref=localhost:5000/${{ env.REPONAME }}/${{ matrix.source }}
           cache-to: type=inline

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,13 +7,17 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
-
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'


### PR DESCRIPTION
This corresponds to similar changes made in Buildah and Podman: https://github.com/containers/podman/pull/13564 https://github.com/containers/buildah/pull/3872

+ Pin actions to a full length commit SHA is currently the only way
  to use an action as an immutable release. Pinning to a particular SHA
  helps mitigate the risk of a bad actor adding a backdoor to the action's
  repository, as they would need to generate a SHA-1 collision for a valid
  Git object payload. Ref:
  https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

+ Explicitly set permissions for actions to minimum required.  The
  defaults are (unfortunately) overly permissive: Ref:
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token