### PR TITLE
[CI:DOCS] Makefile: include cautionary note for rpm target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,5 +249,7 @@ vendor:
 vendor-in-container:
 	podman run --privileged --rm --env HOME=/root -v $(CURDIR):/src -w /src quay.io/libpod/golang:1.16 $(MAKE) vendor
 
+# CAUTION: This is not a replacement for RPMs provided by your distro.
+# Only intended to build and test the latest unreleased changes.
 rpm:
 	rpkg local

--- a/skopeo.spec.rpkg
+++ b/skopeo.spec.rpkg
@@ -1,5 +1,8 @@
 # For automatic rebuilds in COPR
 
+# CAUTION: This is not a replacement for RPMs provided by your distro.
+# Only intended to build and test the latest unreleased changes.
+
 # The following tag is to get correct syntax highlighting for this file in vim text editor
 # vim: syntax=spec
 


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@mtrmac I got too excited and merged the previous rpm PR. Just adding a cautionary note for any users tempted to use the rpm target.

@rhatdan @vrothberg PTAL