### PR TITLE
[CI:DOCS] skopeo.spec.rpkg: Fix syntax highlighting

### DIFF
--- a/skopeo.spec.rpkg
+++ b/skopeo.spec.rpkg
@@ -1,10 +1,13 @@
 # For automatic rebuilds in COPR
 
-# CAUTION: This is not a replacement for RPMs provided by your distro.
-# Only intended to build and test the latest unreleased changes.
-
 # The following tag is to get correct syntax highlighting for this file in vim text editor
 # vim: syntax=spec
+
+# Any additinoal comments should go below this line or else syntax highlighting
+# may not work.
+
+# CAUTION: This is not a replacement for RPMs provided by your distro.
+# Only intended to build and test the latest unreleased changes.
 
 %global gomodulesmode GO111MODULE=on
 %global with_debug 1


### PR DESCRIPTION
For whatever reason, the comment rearrangement is
required for vim rpm synatx highlighting to work.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@vrothberg @mtrmac @rhatdan PTAL.