### PR TITLE
Use bytes.ReplaceAll instead of bytes.Replace(..., -1)

### DIFF
--- a/integration/utils.go
+++ b/integration/utils.go
@@ -166,7 +166,7 @@ func fileFromFixture(c *check.C, inputPath string, edits map[string]string) stri
 	contents, err := os.ReadFile(inputPath)
 	c.Assert(err, check.IsNil)
 	for template, value := range edits {
-		updated := bytes.Replace(contents, []byte(template), []byte(value), -1)
+		updated := bytes.ReplaceAll(contents, []byte(template), []byte(value))
 		c.Assert(bytes.Equal(updated, contents), check.Equals, false, check.Commentf("Replacing %s in %#v failed", template, string(contents))) // Verify that the template has matched something and we are not silently ignoring it.
 		contents = updated
 	}


### PR DESCRIPTION
... for a trivial improvement in readability.

Should not change behavior.