### PR TITLE
Fix sync command description

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $ skopeo copy oci:busybox_ocilayout:latest dir:existingemptydirectory
 $ skopeo delete docker://localhost:5000/imagename:latest
 ```
 
-## Syncing registries
+## Syncing repositories
 ```console
 $ skopeo sync --src docker --dest dir registry.example.com/busybox /media/usb
 ```
@@ -207,7 +207,7 @@ Please read the [contribution guide](CONTRIBUTING.md) if you want to collaborate
 | [skopeo-manifest-digest(1)](/docs/skopeo-manifest-digest.1.md)    | Compute a manifest digest for a manifest-file and write it to standard output.   |
 | [skopeo-standalone-sign(1)](/docs/skopeo-standalone-sign.1.md)    | Debugging tool - Publish and sign an image in one step.                                                         |
 | [skopeo-standalone-verify(1)](/docs/skopeo-standalone-verify.1.md)| Verify an image signature.                                                    |
-| [skopeo-sync(1)](/docs/skopeo-sync.1.md)           | Synchronize images between container registries and local directories.                       |
+| [skopeo-sync(1)](/docs/skopeo-sync.1.md)           | Synchronize images between container repositories and local directories.                       |
 
 License
 -


### PR DESCRIPTION
As far as I understand, the `sync` command only works at a repository level. It is not able to sync a whole registry, iterating over the catalog.