### PR TITLE
Update c/image and c/common

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -25,7 +25,7 @@ type copyOptions struct {
 	deprecatedTLSVerify      *deprecatedTLSVerifyOption
 	srcImage                 *imageOptions
 	destImage                *imageDestOptions
-	retryOpts                *retry.RetryOptions
+	retryOpts                *retry.Options
 	additionalTags           []string                  // For docker-archive: destinations, in addition to the name:tag specified as destination, also add these
 	removeSignatures         bool                      // Do not copy signatures from the source image
 	signByFingerprint        string                    // Sign the image using a GPG key with the specified fingerprint
@@ -260,7 +260,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 		}
 	}
 
-	return retry.RetryIfNecessary(ctx, func() error {
+	return retry.IfNecessary(ctx, func() error {
 		manifestBytes, err := copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{
 			RemoveSignatures:                 opts.removeSignatures,
 			SignBy:                           opts.signByFingerprint,

--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -15,7 +15,7 @@ import (
 type deleteOptions struct {
 	global    *globalOptions
 	image     *imageOptions
-	retryOpts *retry.RetryOptions
+	retryOpts *retry.Options
 }
 
 func deleteCmd(global *globalOptions) *cobra.Command {
@@ -70,7 +70,7 @@ func (opts *deleteOptions) run(args []string, stdout io.Writer) error {
 	ctx, cancel := opts.global.commandTimeoutContext()
 	defer cancel()
 
-	return retry.RetryIfNecessary(ctx, func() error {
+	return retry.IfNecessary(ctx, func() error {
 		return ref.DeleteImage(ctx, sys)
 	}, opts.retryOpts)
 }

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -26,7 +26,7 @@ import (
 type inspectOptions struct {
 	global        *globalOptions
 	image         *imageOptions
-	retryOpts     *retry.RetryOptions
+	retryOpts     *retry.Options
 	format        string
 	raw           bool // Output the raw manifest instead of parsing information about the image
 	config        bool // Output the raw config blob instead of parsing information about the image
@@ -96,7 +96,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		return err
 	}
 
-	if err := retry.RetryIfNecessary(ctx, func() error {
+	if err := retry.IfNecessary(ctx, func() error {
 		src, err = parseImageSource(ctx, opts.image, imageName)
 		return err
 	}, opts.retryOpts); err != nil {
@@ -109,7 +109,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		}
 	}()
 
-	if err := retry.RetryIfNecessary(ctx, func() error {
+	if err := retry.IfNecessary(ctx, func() error {
 		rawManifest, _, err = src.GetManifest(ctx, nil)
 		return err
 	}, opts.retryOpts); err != nil {
@@ -132,7 +132,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 
 	if opts.config && opts.raw {
 		var configBlob []byte
-		if err := retry.RetryIfNecessary(ctx, func() error {
+		if err := retry.IfNecessary(ctx, func() error {
 			configBlob, err = img.ConfigBlob(ctx)
 			return err
 		}, opts.retryOpts); err != nil {
@@ -145,7 +145,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		return nil
 	} else if opts.config {
 		var config *v1.Image
-		if err := retry.RetryIfNecessary(ctx, func() error {
+		if err := retry.IfNecessary(ctx, func() error {
 			config, err = img.OCIConfig(ctx)
 			return err
 		}, opts.retryOpts); err != nil {
@@ -168,7 +168,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		return nil
 	}
 
-	if err := retry.RetryIfNecessary(ctx, func() error {
+	if err := retry.IfNecessary(ctx, func() error {
 		imgInspect, err = img.Inspect(ctx)
 		return err
 	}, opts.retryOpts); err != nil {

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -19,7 +19,7 @@ import (
 type layersOptions struct {
 	global    *globalOptions
 	image     *imageOptions
-	retryOpts *retry.RetryOptions
+	retryOpts *retry.Options
 }
 
 func layersCmd(global *globalOptions) *cobra.Command {
@@ -68,13 +68,13 @@ func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 		rawSource types.ImageSource
 		src       types.ImageCloser
 	)
-	if err = retry.RetryIfNecessary(ctx, func() error {
+	if err = retry.IfNecessary(ctx, func() error {
 		rawSource, err = parseImageSource(ctx, opts.image, imageName)
 		return err
 	}, opts.retryOpts); err != nil {
 		return err
 	}
-	if err = retry.RetryIfNecessary(ctx, func() error {
+	if err = retry.IfNecessary(ctx, func() error {
 		src, err = image.FromSource(ctx, sys, rawSource)
 		return err
 	}, opts.retryOpts); err != nil {
@@ -145,7 +145,7 @@ func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 			r        io.ReadCloser
 			blobSize int64
 		)
-		if err = retry.RetryIfNecessary(ctx, func() error {
+		if err = retry.IfNecessary(ctx, func() error {
 			r, blobSize, err = rawSource.GetBlob(ctx, types.BlobInfo{Digest: bd.digest, Size: -1}, cache)
 			return err
 		}, opts.retryOpts); err != nil {
@@ -160,7 +160,7 @@ func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 	}
 
 	var manifest []byte
-	if err = retry.RetryIfNecessary(ctx, func() error {
+	if err = retry.IfNecessary(ctx, func() error {
 		manifest, _, err = src.Manifest(ctx)
 		return err
 	}, opts.retryOpts); err != nil {

--- a/cmd/skopeo/list_tags.go
+++ b/cmd/skopeo/list_tags.go
@@ -27,7 +27,7 @@ type tagListOutput struct {
 type tagsOptions struct {
 	global    *globalOptions
 	image     *imageOptions
-	retryOpts *retry.RetryOptions
+	retryOpts *retry.Options
 }
 
 var transportHandlers = map[string]func(ctx context.Context, sys *types.SystemContext, opts *tagsOptions, userInput string) (repositoryName string, tagListing []string, err error){
@@ -120,7 +120,7 @@ func listDockerRepoTags(ctx context.Context, sys *types.SystemContext, opts *tag
 	if err != nil {
 		return
 	}
-	if err = retry.RetryIfNecessary(ctx, func() error {
+	if err = retry.IfNecessary(ctx, func() error {
 		repositoryName, tagListing, err = listDockerTags(ctx, sys, imgRef)
 		return err
 	}, opts.retryOpts); err != nil {

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -33,7 +33,7 @@ type syncOptions struct {
 	deprecatedTLSVerify      *deprecatedTLSVerifyOption
 	srcImage                 *imageOptions     // Source image options
 	destImage                *imageDestOptions // Destination image options
-	retryOpts                *retry.RetryOptions
+	retryOpts                *retry.Options
 	removeSignatures         bool                      // Do not copy signatures from the source image
 	signByFingerprint        string                    // Sign the image using a GPG key with the specified fingerprint
 	signBySigstorePrivateKey string                    // Sign the image using a sigstore private key
@@ -571,7 +571,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 
 	sourceArg := args[0]
 	var srcRepoList []repoDescriptor
-	if err = retry.RetryIfNecessary(ctx, func() error {
+	if err = retry.IfNecessary(ctx, func() error {
 		srcRepoList, err = imagesToCopy(sourceArg, opts.source, sourceCtx)
 		return err
 	}, opts.retryOpts); err != nil {
@@ -657,7 +657,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 				logrus.WithFields(fromToFields).Infof("Would have copied image ref %d/%d", counter+1, len(srcRepo.ImageRefs))
 			} else {
 				logrus.WithFields(fromToFields).Infof("Copying image ref %d/%d", counter+1, len(srcRepo.ImageRefs))
-				if err = retry.RetryIfNecessary(ctx, func() error {
+				if err = retry.IfNecessary(ctx, func() error {
 					_, err = copy.Image(ctx, policyContext, destRef, ref, &options)
 					return err
 				}, opts.retryOpts); err != nil {

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -174,8 +174,8 @@ func imageFlags(global *globalOptions, shared *sharedImageOptions, deprecatedTLS
 	return fs, opts
 }
 
-func retryFlags() (pflag.FlagSet, *retry.RetryOptions) {
-	opts := retry.RetryOptions{}
+func retryFlags() (pflag.FlagSet, *retry.Options) {
+	opts := retry.Options{}
 	fs := pflag.FlagSet{}
 	fs.IntVar(&opts.MaxRetry, "retry-times", 0, "the number of times to possibly retry")
 	return fs, &opts

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/containers/skopeo
 go 1.17
 
 require (
-	github.com/containers/common v0.48.0
+	github.com/containers/common v0.49.0
 	github.com/containers/image/v5 v5.22.0
 	github.com/containers/ocicrypt v1.1.5
 	github.com/containers/storage v1.42.0
@@ -94,6 +94,7 @@ require (
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 // indirect
 	go.opencensus.io v0.23.0 // indirect
+	go.opentelemetry.io/otel/trace v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/containers/common v0.48.0
-	github.com/containers/image/v5 v5.21.2-0.20220712113758-29aec5f7bbbf
+	github.com/containers/image/v5 v5.22.0
 	github.com/containers/ocicrypt v1.1.5
 	github.com/containers/storage v1.42.0
 	github.com/docker/docker v20.10.17+incompatible
@@ -83,7 +83,7 @@ require (
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect
 	github.com/sylabs/sif/v2 v2.7.1 // indirect
 	github.com/tchap/go-patricia v2.3.0+incompatible // indirect
-	github.com/theupdateframework/go-tuf v0.3.0 // indirect
+	github.com/theupdateframework/go-tuf v0.3.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19
 github.com/containers/common v0.48.0 h1:997nnXBZ+eNpfSM7L4SxhhZubQrfEyw3jRyNMTSsNlw=
 github.com/containers/common v0.48.0/go.mod h1:zPLZCfLXfnd1jI0QRsD4By54fP4k1+ifQs+tulIe3o0=
 github.com/containers/image/v5 v5.21.1/go.mod h1:zl35egpcDQa79IEXIuoUe1bW+D1pdxRxYjNlyb3YiXw=
-github.com/containers/image/v5 v5.21.2-0.20220712113758-29aec5f7bbbf h1:EAVt3Tr8n2Iv3L2L4J66vcFB+jHGCSHQlD15+Z2U1Io=
-github.com/containers/image/v5 v5.21.2-0.20220712113758-29aec5f7bbbf/go.mod h1:0+N0ZM9mgMmoZZc6uNcgnEsbX85Ne7b29cIW5lqWwVU=
+github.com/containers/image/v5 v5.22.0 h1:KemxPmD4D2YYOFZN2SgoTk7nBFcnwPiPW0MqjYtknSE=
+github.com/containers/image/v5 v5.22.0/go.mod h1:D8Ksv2RNB8qLJ7xe1P3rgJJOSQpahA6amv2Ax++/YO4=
 github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a h1:spAGlqziZjCJL25C6F1zsQY05tfCKE9F5YwtEWWe6hU=
 github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
@@ -385,7 +385,6 @@ github.com/containers/ocicrypt v1.1.4-0.20220428134531-566b808bdf6f/go.mod h1:xp
 github.com/containers/ocicrypt v1.1.5 h1:UO+gBnBXvMvC7HTXLh0bPgLslfW8HlY+oxYcoSHBcZQ=
 github.com/containers/ocicrypt v1.1.5/go.mod h1:WgjxPWdTJMqYMjf3M6cuIFFA1/MpyyhIM99YInA+Rvc=
 github.com/containers/storage v1.40.0/go.mod h1:zUyPC3CFIGR1OhY1CKkffxgw9+LuH76PGvVcFj38dgs=
-github.com/containers/storage v1.41.0/go.mod h1:Pb0l5Sm/89kolX3o2KolKQ5cCHk5vPNpJrhNaLcdS5s=
 github.com/containers/storage v1.42.0 h1:zm2AQD4NDeTB3JQ8X+Wo5+VRqNB+b4ocEd7Qj6ylPJA=
 github.com/containers/storage v1.42.0/go.mod h1:JiUJwOgOo1dr2DdOUc1MRe2GCAXABYoYmOdPF8yvH78=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -1216,7 +1215,6 @@ github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runc v1.1.0/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runc v1.1.1/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
-github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
 github.com/opencontainers/runc v1.1.3/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1468,8 +1466,9 @@ github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0
 github.com/tenntenn/modver v1.0.1/go.mod h1:bePIyQPb7UeioSRkw3Q0XeMhYZSMx9B8ePqg6SAMGH0=
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.4.11/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
-github.com/theupdateframework/go-tuf v0.3.0 h1:od2sc5+BSkKZhmUG2o2rmruy0BGSmhrbDhCnpxh87X8=
 github.com/theupdateframework/go-tuf v0.3.0/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
+github.com/theupdateframework/go-tuf v0.3.1 h1:NkjMlCuLcDpHNtsWXY4lTmbbQQ5nOM7JSBbOKEEiI1c=
+github.com/theupdateframework/go-tuf v0.3.1/go.mod h1:lhHZ3Vt2pdAh15h0Cc6gWdlI+Okn2ZznD3q/cNjd5jw=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=

--- a/go.sum
+++ b/go.sum
@@ -101,7 +101,6 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -145,7 +144,6 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
-github.com/ProtonMail/go-crypto v0.0.0-20220407094043-a94812496cf5/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20220517143526-88bb52951d5b/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -212,6 +210,7 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
@@ -307,7 +306,7 @@ github.com/containerd/containerd v1.5.1/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTV
 github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0QMhscqVp1AR9c=
 github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
 github.com/containerd/containerd v1.6.1/go.mod h1:1nJz5xCZPusx6jJU8Frfct988y0NpumIq9ODB0kLtoE=
-github.com/containerd/containerd v1.6.3/go.mod h1:gCVGrYRYFm2E8GmuUIbj/NGD7DLZQLzSJQazjVKDOig=
+github.com/containerd/containerd v1.6.6/go.mod h1:ZoP1geJldzCVY3Tonoz7b1IXk8rIX0Nltt5QE4OMNk0=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -326,7 +325,7 @@ github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZH
 github.com/containerd/go-cni v1.0.2/go.mod h1:nrNABBHzu0ZwCug9Ije8hL2xBCYh/pjfMb1aZGrrohk=
 github.com/containerd/go-cni v1.1.0/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
 github.com/containerd/go-cni v1.1.3/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
-github.com/containerd/go-cni v1.1.4/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
+github.com/containerd/go-cni v1.1.6/go.mod h1:BWtoWl5ghVymxu6MBjg79W9NZrCRyHIdUtk4cauMe34=
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328/go.mod h1:PpyHrqVs8FTi9vpyHwPwiNEGaACDxT/N/pLcvMSRA9g=
@@ -364,14 +363,13 @@ github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
-github.com/containernetworking/cni v1.1.0/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
+github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNBDZcxSOplJT5ico8/FLE=
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
-github.com/containers/common v0.48.0 h1:997nnXBZ+eNpfSM7L4SxhhZubQrfEyw3jRyNMTSsNlw=
-github.com/containers/common v0.48.0/go.mod h1:zPLZCfLXfnd1jI0QRsD4By54fP4k1+ifQs+tulIe3o0=
-github.com/containers/image/v5 v5.21.1/go.mod h1:zl35egpcDQa79IEXIuoUe1bW+D1pdxRxYjNlyb3YiXw=
+github.com/containers/common v0.49.0 h1:RvXl6DV+AIiWFAInr9kda8v0kNFYp8Gi6TdMDJxiN0s=
+github.com/containers/common v0.49.0/go.mod h1:veUB/Ny3z9uCvwQTsG1/hxI+9xOprONp3mH3jO4mYqg=
 github.com/containers/image/v5 v5.22.0 h1:KemxPmD4D2YYOFZN2SgoTk7nBFcnwPiPW0MqjYtknSE=
 github.com/containers/image/v5 v5.22.0/go.mod h1:D8Ksv2RNB8qLJ7xe1P3rgJJOSQpahA6amv2Ax++/YO4=
 github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a h1:spAGlqziZjCJL25C6F1zsQY05tfCKE9F5YwtEWWe6hU=
@@ -381,10 +379,8 @@ github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgU
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/ocicrypt v1.1.3/go.mod h1:xpdkbVAuaH3WzbEabUd5yDsl9SwJA5pABH85425Es2g=
-github.com/containers/ocicrypt v1.1.4-0.20220428134531-566b808bdf6f/go.mod h1:xpdkbVAuaH3WzbEabUd5yDsl9SwJA5pABH85425Es2g=
 github.com/containers/ocicrypt v1.1.5 h1:UO+gBnBXvMvC7HTXLh0bPgLslfW8HlY+oxYcoSHBcZQ=
 github.com/containers/ocicrypt v1.1.5/go.mod h1:WgjxPWdTJMqYMjf3M6cuIFFA1/MpyyhIM99YInA+Rvc=
-github.com/containers/storage v1.40.0/go.mod h1:zUyPC3CFIGR1OhY1CKkffxgw9+LuH76PGvVcFj38dgs=
 github.com/containers/storage v1.42.0 h1:zm2AQD4NDeTB3JQ8X+Wo5+VRqNB+b4ocEd7Qj6ylPJA=
 github.com/containers/storage v1.42.0/go.mod h1:JiUJwOgOo1dr2DdOUc1MRe2GCAXABYoYmOdPF8yvH78=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -446,7 +442,6 @@ github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4Kfc
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v20.10.14+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.16+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.17+incompatible h1:JYCuMrWaVNophQTOrMMoSwudOVEfcegoZZrleKc1xwE=
 github.com/docker/docker v20.10.17+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
@@ -517,6 +512,7 @@ github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3nqZCxaQ2Ze/sM=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
@@ -764,7 +760,6 @@ github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75/go.mod h1:g2644b0
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -966,7 +961,6 @@ github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdY
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.2/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.15.4/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.15.7/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
@@ -1104,12 +1098,12 @@ github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQ
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
-github.com/moby/sys/mountinfo v0.6.1/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/moby/sys/signal v0.6.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
@@ -1188,8 +1182,9 @@ github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+t
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
-github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
+github.com/onsi/gomega v1.20.0 h1:8W0cWlwFkflGPLltQvLRB7ZVD5HuP6ng320w2IS245Q=
+github.com/onsi/gomega v1.20.0/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1202,7 +1197,6 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.3-0.20211202193544-a5463b7f9c84/go.mod h1:Qnt1q4cjDNQI9bT832ziho5Iw2BhK8o1KwLOwW56VP4=
 github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 h1:+czc/J8SlhPKLOtVLMQc+xDCFBT73ZStMsRhSsUhsSg=
 github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198/go.mod h1:j4h1pJW6ZcJTgMZWP3+7RlG3zTaP02aDZ/Qw0sppK7Q=
 github.com/opencontainers/image-tools v1.0.0-rc3 h1:ZR837lBIxq6mmwEqfYrbLMuf75eBSHhccVHy6lsBeM4=
@@ -1214,7 +1208,7 @@ github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rm
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runc v1.1.0/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
-github.com/opencontainers/runc v1.1.1/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
+github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
 github.com/opencontainers/runc v1.1.3/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1222,13 +1216,15 @@ github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.3-0.20201121164853-7413a7f753e1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
+github.com/opencontainers/runtime-tools v0.9.1-0.20220714195903-17b3287fafb7/go.mod h1:/tgP02fPXGHkU3/qKK1Y0Db4yqNyGm03vLq/mzHzcS4=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=
 github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
@@ -1266,7 +1262,6 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1/go.mod h1:nSbFQvMj97ZyhFRSJYtut+msi4sOY6zJDGCdSc+/rZU=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/proglottis/gpgme v0.1.1/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
 github.com/proglottis/gpgme v0.1.3 h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU0=
 github.com/proglottis/gpgme v0.1.3/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -1357,6 +1352,7 @@ github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvK
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/seccomp/libseccomp-golang v0.10.0/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/secure-systems-lab/go-securesystemslib v0.3.1/go.mod h1:o8hhjkbNl2gOamKUA/eNW3xUrntHT9L4W89W1nfj43U=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
 github.com/securego/gosec/v2 v2.9.1/go.mod h1:oDcDLcatOJxkCGaCaq8lua1jTnYf6Sou4wdiJ1n4iHc=
@@ -1449,7 +1445,6 @@ github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/sylabs/sif/v2 v2.7.0/go.mod h1:TiyBWsgWeh5yBeQFNuQnvROwswqK7YJT8JA1L53bsXQ=
 github.com/sylabs/sif/v2 v2.7.1 h1:XXt9AP39sQfsMCGOGQ/XP9H47yqZOvAonalkaCaNIYM=
 github.com/sylabs/sif/v2 v2.7.1/go.mod h1:bBse2nEFd3yHkmq6KmAOFEWQg5LdFYiQUdVcgamxlc8=
 github.com/sylvia7788/contextcheck v1.0.4/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=
@@ -1493,6 +1488,7 @@ github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0o
 github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.19.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -1506,7 +1502,6 @@ github.com/valyala/quicktemplate v1.7.0/go.mod h1:sqKJnoaOF88V07vkO+9FL8fb9uZg/V
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
-github.com/vbauerster/mpb/v7 v7.4.1/go.mod h1:Ygg2mV9Vj9sQBWqsK2m2pidcf9H3s6bNKtqd3/M4gBo=
 github.com/vbauerster/mpb/v7 v7.4.2 h1:n917F4d8EWdUKc9c81wFkksyG6P6Mg7IETfKCE1Xqng=
 github.com/vbauerster/mpb/v7 v7.4.2/go.mod h1:UmOiIUI8aPqWXIps0ciik3RKMdzx7+ooQpq+fBcXwBA=
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=

--- a/vendor/github.com/containers/common/pkg/auth/auth.go
+++ b/vendor/github.com/containers/common/pkg/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/image/v5/pkg/docker/config"
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	terminal "golang.org/x/term"
 )
@@ -26,8 +26,8 @@ func GetDefaultAuthFile() string {
 	if authfile := os.Getenv("REGISTRY_AUTH_FILE"); authfile != "" {
 		return authfile
 	}
-	if auth_env := os.Getenv("DOCKER_CONFIG"); auth_env != "" {
-		return filepath.Join(auth_env, "config.json")
+	if authEnv := os.Getenv("DOCKER_CONFIG"); authEnv != "" {
+		return filepath.Join(authEnv, "config.json")
 	}
 	return ""
 }
@@ -39,7 +39,7 @@ func CheckAuthFile(authfile string) error {
 		return nil
 	}
 	if _, err := os.Stat(authfile); err != nil {
-		return errors.Wrap(err, "checking authfile")
+		return fmt.Errorf("checking authfile: %w", err)
 	}
 	return nil
 }
@@ -97,12 +97,12 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 
 	authConfig, err := config.GetCredentials(systemContext, key)
 	if err != nil {
-		return errors.Wrap(err, "get credentials")
+		return fmt.Errorf("get credentials: %w", err)
 	}
 
 	if opts.GetLoginSet {
 		if authConfig.Username == "" {
-			return errors.Errorf("not logged into %s", key)
+			return fmt.Errorf("not logged into %s", key)
 		}
 		fmt.Fprintf(opts.Stdout, "%s\n", authConfig.Username)
 		return nil
@@ -139,7 +139,7 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 
 	username, password, err := getUserAndPass(opts, password, authConfig.Username)
 	if err != nil {
-		return errors.Wrap(err, "getting username and password")
+		return fmt.Errorf("getting username and password: %w", err)
 	}
 
 	if err = docker.CheckAuth(ctx, systemContext, username, password, registry); err == nil {
@@ -158,9 +158,9 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 	}
 	if unauthorized, ok := err.(docker.ErrUnauthorizedForCredentials); ok {
 		logrus.Debugf("error logging into %q: %v", key, unauthorized)
-		return errors.Errorf("error logging into %q: invalid username/password", key)
+		return fmt.Errorf("error logging into %q: invalid username/password", key)
 	}
-	return errors.Wrapf(err, "authenticating creds for %q", key)
+	return fmt.Errorf("authenticating creds for %q: %w", key, err)
 }
 
 // parseCredentialsKey turns the provided argument into a valid credential key
@@ -191,10 +191,10 @@ func parseCredentialsKey(arg string, acceptRepositories bool) (key, registry str
 	// Ideally c/image should provide dedicated validation functionality.
 	ref, err := reference.ParseNormalizedNamed(key)
 	if err != nil {
-		return "", "", errors.Wrapf(err, "parse reference from %q", key)
+		return "", "", fmt.Errorf("parse reference from %q: %w", key, err)
 	}
 	if !reference.IsNameOnly(ref) {
-		return "", "", errors.Errorf("reference %q contains tag or digest", ref.String())
+		return "", "", fmt.Errorf("reference %q contains tag or digest", ref.String())
 	}
 	refRegistry := reference.Domain(ref)
 	if refRegistry != registry { // This should never happen, check just to make sure
@@ -232,7 +232,7 @@ func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (user
 		}
 		username, err = reader.ReadString('\n')
 		if err != nil {
-			return "", "", errors.Wrap(err, "reading username")
+			return "", "", fmt.Errorf("reading username: %w", err)
 		}
 		// If the user just hit enter, use the displayed user from the
 		// the authentication file.  This allows to do a lazy
@@ -246,7 +246,7 @@ func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (user
 		fmt.Fprint(opts.Stdout, "Password: ")
 		pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
-			return "", "", errors.Wrap(err, "reading password")
+			return "", "", fmt.Errorf("reading password: %w", err)
 		}
 		password = string(pass)
 		fmt.Fprintln(opts.Stdout)
@@ -298,14 +298,15 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 	}
 
 	err = config.RemoveAuthentication(systemContext, key)
-	switch errors.Cause(err) {
-	case nil:
+	if err == nil {
 		fmt.Fprintf(opts.Stdout, "Removed login credentials for %s\n", key)
 		return nil
-	case config.ErrNotLoggedIn:
+	}
+
+	if errors.Is(err, config.ErrNotLoggedIn) {
 		authConfig, err := config.GetCredentials(systemContext, key)
 		if err != nil {
-			return errors.Wrap(err, "get credentials")
+			return fmt.Errorf("get credentials: %w", err)
 		}
 
 		authInvalid := docker.CheckAuth(context.Background(), systemContext, authConfig.Username, authConfig.Password, registry)
@@ -313,10 +314,10 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 			fmt.Printf("Not logged into %s with current tool. Existing credentials were established via docker login. Please use docker logout instead.\n", key)
 			return nil
 		}
-		return errors.Errorf("Not logged into %s\n", key)
-	default:
-		return errors.Wrapf(err, "logging out of %q", key)
+		return fmt.Errorf("not logged into %s", key)
 	}
+
+	return fmt.Errorf("logging out of %q: %w", key, err)
 }
 
 // defaultRegistryWhenUnspecified returns first registry from search list of registry.conf
@@ -324,7 +325,7 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 func defaultRegistryWhenUnspecified(systemContext *types.SystemContext) (string, error) {
 	registriesFromFile, err := sysregistriesv2.UnqualifiedSearchRegistries(systemContext)
 	if err != nil {
-		return "", errors.Wrap(err, "getting registry from registry.conf, please specify a registry")
+		return "", fmt.Errorf("getting registry from registry.conf, please specify a registry: %w", err)
 	}
 	if len(registriesFromFile) == 0 {
 		return "", errors.New("no registries found in registries.conf, a registry must be provided")

--- a/vendor/github.com/containers/common/pkg/completion/completion.go
+++ b/vendor/github.com/containers/common/pkg/completion/completion.go
@@ -51,7 +51,7 @@ func AutocompleteCapabilities(cmd *cobra.Command, args []string, toComplete stri
 		offset = 4
 	}
 
-	var completions []string
+	completions := make([]string, 0, len(caps))
 	for _, cap := range caps {
 		completions = append(completions, convertCase(cap)[offset:])
 	}

--- a/vendor/github.com/containers/image/v5/copy/compression.go
+++ b/vendor/github.com/containers/image/v5/copy/compression.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/image/v5/pkg/compression"
 	compressiontypes "github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,7 +27,7 @@ func blobPipelineDetectCompressionStep(stream *sourceStream, srcInfo types.BlobI
 	// This requires us to “peek ahead” into the stream to read the initial part, which requires us to chain through another io.Reader returned by DetectCompression.
 	format, decompressor, reader, err := compression.DetectCompressionFormat(stream.reader) // We could skip this in some cases, but let's keep the code path uniform
 	if err != nil {
-		return bpDetectCompressionStepData{}, perrors.Wrapf(err, "reading blob %s", srcInfo.Digest)
+		return bpDetectCompressionStepData{}, fmt.Errorf("reading blob %s: %w", srcInfo.Digest, err)
 	}
 	stream.reader = reader
 

--- a/vendor/github.com/containers/image/v5/copy/copy.go
+++ b/vendor/github.com/containers/image/v5/copy/copy.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containers/image/v5/internal/imagesource"
 	"github.com/containers/image/v5/internal/pkg/platform"
 	"github.com/containers/image/v5/internal/private"
-	internalsig "github.com/containers/image/v5/internal/signature"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/blobinfocache"
 	"github.com/containers/image/v5/pkg/compression"
@@ -30,7 +29,6 @@ import (
 	encconfig "github.com/containers/ocicrypt/config"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vbauerster/mpb/v7"
 	"golang.org/x/sync/semaphore"
@@ -208,29 +206,37 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 
 	publicDest, err := destRef.NewImageDestination(ctx, options.DestinationCtx)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "initializing destination %s", transports.ImageName(destRef))
+		return nil, fmt.Errorf("initializing destination %s: %w", transports.ImageName(destRef), err)
 	}
 	dest := imagedestination.FromPublic(publicDest)
 	defer func() {
 		if err := dest.Close(); err != nil {
-			retErr = perrors.Wrapf(retErr, " (dest: %v)", err)
+			if retErr != nil {
+				retErr = fmt.Errorf(" (dest: %v): %w", err, retErr)
+			} else {
+				retErr = fmt.Errorf(" (dest: %v)", err)
+			}
 		}
 	}()
 
 	publicRawSource, err := srcRef.NewImageSource(ctx, options.SourceCtx)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "initializing source %s", transports.ImageName(srcRef))
+		return nil, fmt.Errorf("initializing source %s: %w", transports.ImageName(srcRef), err)
 	}
 	rawSource := imagesource.FromPublic(publicRawSource)
 	defer func() {
 		if err := rawSource.Close(); err != nil {
-			retErr = perrors.Wrapf(retErr, " (src: %v)", err)
+			if retErr != nil {
+				retErr = fmt.Errorf(" (src: %v): %w", err, retErr)
+			} else {
+				retErr = fmt.Errorf(" (src: %v)", err)
+			}
 		}
 	}()
 
 	// If reportWriter is not a TTY (e.g., when piping to a file), do not
 	// print the progress bars to avoid long and hard to parse output.
-	// createProgressBar() will print a single line instead.
+	// Instead use printCopyInfo() to print single line "Copying ..." messages.
 	progressOutput := reportWriter
 	if !isTTY(reportWriter) {
 		progressOutput = io.Discard
@@ -281,7 +287,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	unparsedToplevel := image.UnparsedInstance(rawSource, nil)
 	multiImage, err := isMultiImage(ctx, unparsedToplevel)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "determining manifest MIME type for %s", transports.ImageName(srcRef))
+		return nil, fmt.Errorf("determining manifest MIME type for %s: %w", transports.ImageName(srcRef), err)
 	}
 
 	if !multiImage {
@@ -294,21 +300,21 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 		// matches the current system to copy, and copy it.
 		mfest, manifestType, err := unparsedToplevel.Manifest(ctx)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "reading manifest for %s", transports.ImageName(srcRef))
+			return nil, fmt.Errorf("reading manifest for %s: %w", transports.ImageName(srcRef), err)
 		}
 		manifestList, err := manifest.ListFromBlob(mfest, manifestType)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "parsing primary manifest as list for %s", transports.ImageName(srcRef))
+			return nil, fmt.Errorf("parsing primary manifest as list for %s: %w", transports.ImageName(srcRef), err)
 		}
 		instanceDigest, err := manifestList.ChooseInstance(options.SourceCtx) // try to pick one that matches options.SourceCtx
 		if err != nil {
-			return nil, perrors.Wrapf(err, "choosing an image from manifest list %s", transports.ImageName(srcRef))
+			return nil, fmt.Errorf("choosing an image from manifest list %s: %w", transports.ImageName(srcRef), err)
 		}
 		logrus.Debugf("Source is a manifest list; copying (only) instance %s for current system", instanceDigest)
 		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
 
 		if copiedManifest, _, _, err = c.copyOneImage(ctx, policyContext, options, unparsedToplevel, unparsedInstance, nil); err != nil {
-			return nil, perrors.Wrap(err, "copying system image from manifest list")
+			return nil, fmt.Errorf("copying system image from manifest list: %w", err)
 		}
 	} else { /* options.ImageListSelection == CopyAllImages or options.ImageListSelection == CopySpecificImages, */
 		// If we were asked to copy multiple images and can't, that's an error.
@@ -328,7 +334,7 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 	}
 
 	if err := c.dest.Commit(ctx, unparsedToplevel); err != nil {
-		return nil, perrors.Wrap(err, "committing the finished image")
+		return nil, fmt.Errorf("committing the finished image: %w", err)
 	}
 
 	return copiedManifest, nil
@@ -355,7 +361,7 @@ func supportsMultipleImages(dest types.ImageDestination) bool {
 func compareImageDestinationManifestEqual(ctx context.Context, options *Options, src *image.SourcedImage, targetInstance *digest.Digest, dest types.ImageDestination) (bool, []byte, string, digest.Digest, error) {
 	srcManifestDigest, err := manifest.Digest(src.ManifestBlob)
 	if err != nil {
-		return false, nil, "", "", perrors.Wrapf(err, "calculating manifest digest")
+		return false, nil, "", "", fmt.Errorf("calculating manifest digest: %w", err)
 	}
 
 	destImageSource, err := dest.Reference().NewImageSource(ctx, options.DestinationCtx)
@@ -372,7 +378,7 @@ func compareImageDestinationManifestEqual(ctx context.Context, options *Options,
 
 	destManifestDigest, err := manifest.Digest(destManifest)
 	if err != nil {
-		return false, nil, "", "", perrors.Wrapf(err, "calculating manifest digest")
+		return false, nil, "", "", fmt.Errorf("calculating manifest digest: %w", err)
 	}
 
 	logrus.Debugf("Comparing source and destination manifest digests: %v vs. %v", srcManifestDigest, destManifestDigest)
@@ -390,31 +396,19 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	// Parse the list and get a copy of the original value after it's re-encoded.
 	manifestList, manifestType, err := unparsedToplevel.Manifest(ctx)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "reading manifest list")
+		return nil, fmt.Errorf("reading manifest list: %w", err)
 	}
 	originalList, err := manifest.ListFromBlob(manifestList, manifestType)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "parsing manifest list %q", string(manifestList))
+		return nil, fmt.Errorf("parsing manifest list %q: %w", string(manifestList), err)
 	}
 	updatedList := originalList.Clone()
 
-	// Read and/or clear the set of signatures for this list.
-	var sigs []internalsig.Signature
-	if options.RemoveSignatures {
-		sigs = []internalsig.Signature{}
-	} else {
-		c.Printf("Getting image list signatures\n")
-		s, err := c.rawSource.GetSignaturesWithFormat(ctx, nil)
-		if err != nil {
-			return nil, perrors.Wrap(err, "reading signatures")
-		}
-		sigs = s
-	}
-	if len(sigs) != 0 {
-		c.Printf("Checking if image list destination supports signatures\n")
-		if err := c.dest.SupportsSignatures(ctx); err != nil {
-			return nil, perrors.Wrapf(err, "Can not copy signatures to %s", transports.ImageName(c.dest.Reference()))
-		}
+	sigs, err := c.sourceSignatures(ctx, unparsedToplevel, options,
+		"Getting image list signatures",
+		"Checking if image list destination supports signatures")
+	if err != nil {
+		return nil, err
 	}
 
 	// If the destination is a digested reference, make a note of that, determine what digest value we're
@@ -425,7 +419,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 			destIsDigestedReference = true
 			matches, err := manifest.MatchesDigest(manifestList, digested.Digest())
 			if err != nil {
-				return nil, perrors.Wrapf(err, "computing digest of source image's manifest")
+				return nil, fmt.Errorf("computing digest of source image's manifest: %w", err)
 			}
 			if !matches {
 				return nil, errors.New("Digest of source image's manifest would not match destination reference")
@@ -457,7 +451,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 	}
 	selectedListType, otherManifestMIMETypeCandidates, err := c.determineListConversion(manifestType, c.dest.SupportedManifestMIMETypes(), forceListMIMEType)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "determining manifest list type to write to destination")
+		return nil, fmt.Errorf("determining manifest list type to write to destination: %w", err)
 	}
 	if selectedListType != originalList.MIMEType() {
 		if cannotModifyManifestListReason != "" {
@@ -499,7 +493,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 		unparsedInstance := image.UnparsedInstance(c.rawSource, &instanceDigest)
 		updatedManifest, updatedManifestType, updatedManifestDigest, err := c.copyOneImage(ctx, policyContext, options, unparsedToplevel, unparsedInstance, &instanceDigest)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "copying image %d/%d from manifest list", instancesCopied+1, imagesToCopy)
+			return nil, fmt.Errorf("copying image %d/%d from manifest list: %w", instancesCopied+1, imagesToCopy, err)
 		}
 		instancesCopied++
 		// Record the result of a possible conversion here.
@@ -513,7 +507,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 
 	// Now reset the digest/size/types of the manifests in the list to account for any conversions that we made.
 	if err = updatedList.UpdateInstances(updates); err != nil {
-		return nil, perrors.Wrapf(err, "updating manifest list")
+		return nil, fmt.Errorf("updating manifest list: %w", err)
 	}
 
 	// Iterate through supported list types, preferred format first.
@@ -528,7 +522,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 		if thisListType != updatedList.MIMEType() {
 			attemptedList, err = updatedList.ConvertToMIMEType(thisListType)
 			if err != nil {
-				return nil, perrors.Wrapf(err, "converting manifest list to list with MIME type %q", thisListType)
+				return nil, fmt.Errorf("converting manifest list to list with MIME type %q: %w", thisListType, err)
 			}
 		}
 
@@ -536,11 +530,11 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 		// by serializing them both so that we can compare them.
 		attemptedManifestList, err := attemptedList.Serialize()
 		if err != nil {
-			return nil, perrors.Wrapf(err, "encoding updated manifest list (%q: %#v)", updatedList.MIMEType(), updatedList.Instances())
+			return nil, fmt.Errorf("encoding updated manifest list (%q: %#v): %w", updatedList.MIMEType(), updatedList.Instances(), err)
 		}
 		originalManifestList, err := originalList.Serialize()
 		if err != nil {
-			return nil, perrors.Wrapf(err, "encoding original manifest list for comparison (%q: %#v)", originalList.MIMEType(), originalList.Instances())
+			return nil, fmt.Errorf("encoding original manifest list for comparison (%q: %#v): %w", originalList.MIMEType(), originalList.Instances(), err)
 		}
 
 		// If we can't just use the original value, but we have to change it, flag an error.
@@ -587,7 +581,7 @@ func (c *copier) copyMultipleImages(ctx context.Context, policyContext *signatur
 
 	c.Printf("Storing list signatures\n")
 	if err := c.dest.PutSignaturesWithFormat(ctx, sigs, nil); err != nil {
-		return nil, perrors.Wrap(err, "writing signatures")
+		return nil, fmt.Errorf("writing signatures: %w", err)
 	}
 
 	return manifestList, nil
@@ -601,7 +595,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 	multiImage, err := isMultiImage(ctx, unparsedImage)
 	if err != nil {
 		// FIXME FIXME: How to name a reference for the sub-image?
-		return nil, "", "", perrors.Wrapf(err, "determining manifest MIME type for %s", transports.ImageName(unparsedImage.Reference()))
+		return nil, "", "", fmt.Errorf("determining manifest MIME type for %s: %w", transports.ImageName(unparsedImage.Reference()), err)
 	}
 	if multiImage {
 		return nil, "", "", fmt.Errorf("Unexpectedly received a manifest list instead of a manifest for a single image")
@@ -611,11 +605,11 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 	// (The multiImage check above only matches the MIME type, which we have received anyway.
 	// Actual parsing of anything should be deferred.)
 	if allowed, err := policyContext.IsRunningImageAllowed(ctx, unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
-		return nil, "", "", perrors.Wrap(err, "Source image rejected")
+		return nil, "", "", fmt.Errorf("Source image rejected: %w", err)
 	}
 	src, err := image.FromUnparsedImage(ctx, options.SourceCtx, unparsedImage)
 	if err != nil {
-		return nil, "", "", perrors.Wrapf(err, "initializing image from source %s", transports.ImageName(c.rawSource.Reference()))
+		return nil, "", "", fmt.Errorf("initializing image from source %s: %w", transports.ImageName(c.rawSource.Reference()), err)
 	}
 
 	// If the destination is a digested reference, make a note of that, determine what digest value we're
@@ -627,16 +621,16 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 			destIsDigestedReference = true
 			matches, err := manifest.MatchesDigest(src.ManifestBlob, digested.Digest())
 			if err != nil {
-				return nil, "", "", perrors.Wrapf(err, "computing digest of source image's manifest")
+				return nil, "", "", fmt.Errorf("computing digest of source image's manifest: %w", err)
 			}
 			if !matches {
 				manifestList, _, err := unparsedToplevel.Manifest(ctx)
 				if err != nil {
-					return nil, "", "", perrors.Wrapf(err, "reading manifest from source image")
+					return nil, "", "", fmt.Errorf("reading manifest from source image: %w", err)
 				}
 				matches, err = manifest.MatchesDigest(manifestList, digested.Digest())
 				if err != nil {
-					return nil, "", "", perrors.Wrapf(err, "computing digest of source image's manifest")
+					return nil, "", "", fmt.Errorf("computing digest of source image's manifest: %w", err)
 				}
 				if !matches {
 					return nil, "", "", errors.New("Digest of source image's manifest would not match destination reference")
@@ -649,22 +643,11 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 		return nil, "", "", err
 	}
 
-	var sigs []internalsig.Signature
-	if options.RemoveSignatures {
-		sigs = []internalsig.Signature{}
-	} else {
-		c.Printf("Getting image source signatures\n")
-		s, err := src.UntrustedSignatures(ctx)
-		if err != nil {
-			return nil, "", "", perrors.Wrap(err, "reading signatures")
-		}
-		sigs = s
-	}
-	if len(sigs) != 0 {
-		c.Printf("Checking if image destination supports signatures\n")
-		if err := c.dest.SupportsSignatures(ctx); err != nil {
-			return nil, "", "", perrors.Wrapf(err, "Can not copy signatures to %s", transports.ImageName(c.dest.Reference()))
-		}
+	sigs, err := c.sourceSignatures(ctx, src, options,
+		"Getting image source signatures",
+		"Checking if image destination supports signatures")
+	if err != nil {
+		return nil, "", "", err
 	}
 
 	// Determine if we're allowed to modify the manifest.
@@ -778,7 +761,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 		// With ic.cannotModifyManifestReason != "", that would just be a string of repeated failures for the same reason,
 		// so let’s bail out early and with a better error message.
 		if ic.cannotModifyManifestReason != "" {
-			return nil, "", "", perrors.Wrapf(err, "Writing manifest failed and we cannot try conversions: %q", cannotModifyManifestReason)
+			return nil, "", "", fmt.Errorf("writing manifest failed and we cannot try conversions: %q: %w", cannotModifyManifestReason, err)
 		}
 
 		// errs is a list of errors when trying various manifest types. Also serves as an "upload succeeded" flag when set to nil.
@@ -825,7 +808,7 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
 
 	c.Printf("Storing signatures\n")
 	if err := c.dest.PutSignaturesWithFormat(ctx, sigs, targetInstance); err != nil {
-		return nil, "", "", perrors.Wrap(err, "writing signatures")
+		return nil, "", "", fmt.Errorf("writing signatures: %w", err)
 	}
 
 	return manifestBytes, retManifestType, retManifestDigest, nil
@@ -845,11 +828,11 @@ func checkImageDestinationForCurrentRuntime(ctx context.Context, sys *types.Syst
 	if dest.MustMatchRuntimeOS() {
 		c, err := src.OCIConfig(ctx)
 		if err != nil {
-			return perrors.Wrapf(err, "parsing image configuration")
+			return fmt.Errorf("parsing image configuration: %w", err)
 		}
 		wantedPlatforms, err := platform.WantedPlatforms(sys)
 		if err != nil {
-			return perrors.Wrapf(err, "getting current platform information %#v", sys)
+			return fmt.Errorf("getting current platform information %#v: %w", sys, err)
 		}
 
 		options := newOrderedSet()
@@ -1057,13 +1040,13 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 		}
 		pi, err := ic.src.UpdatedImage(ctx, *ic.manifestUpdates)
 		if err != nil {
-			return nil, "", perrors.Wrap(err, "creating an updated image manifest")
+			return nil, "", fmt.Errorf("creating an updated image manifest: %w", err)
 		}
 		pendingImage = pi
 	}
 	man, _, err := pendingImage.Manifest(ctx)
 	if err != nil {
-		return nil, "", perrors.Wrap(err, "reading manifest")
+		return nil, "", fmt.Errorf("reading manifest: %w", err)
 	}
 
 	if err := ic.copyConfig(ctx, pendingImage); err != nil {
@@ -1080,7 +1063,7 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 	}
 	if err := ic.c.dest.PutManifest(ctx, man, instanceDigest); err != nil {
 		logrus.Debugf("Error %v while writing manifest %q", err, string(man))
-		return nil, "", perrors.Wrapf(err, "writing manifest")
+		return nil, "", fmt.Errorf("writing manifest: %w", err)
 	}
 	return man, manifestDigest, nil
 }
@@ -1100,10 +1083,11 @@ func (ic *imageCopier) copyConfig(ctx context.Context, src types.Image) error {
 			defer progressPool.Wait()
 			bar := ic.c.createProgressBar(progressPool, false, srcInfo, "config", "done")
 			defer bar.Abort(false)
+			ic.c.printCopyInfo("config", srcInfo)
 
 			configBlob, err := src.ConfigBlob(ctx)
 			if err != nil {
-				return types.BlobInfo{}, perrors.Wrapf(err, "reading config blob %s", srcInfo.Digest)
+				return types.BlobInfo{}, fmt.Errorf("reading config blob %s: %w", srcInfo.Digest, err)
 			}
 
 			destInfo, err := ic.copyBlobFromStream(ctx, bytes.NewReader(configBlob), srcInfo, nil, true, false, bar, -1, false)
@@ -1155,6 +1139,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		}
 	}
 
+	ic.c.printCopyInfo("blob", srcInfo)
+
 	cachedDiffID := ic.c.blobInfoCache.UncompressedDigest(srcInfo.Digest) // May be ""
 	diffIDIsNeeded := ic.diffIDsAreNeeded && cachedDiffID == ""
 	// When encrypting to decrypting, only use the simple code path. We might be able to optimize more
@@ -1183,7 +1169,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			SrcRef:        srcRef,
 		})
 		if err != nil {
-			return types.BlobInfo{}, "", perrors.Wrapf(err, "trying to reuse blob %s at destination", srcInfo.Digest)
+			return types.BlobInfo{}, "", fmt.Errorf("trying to reuse blob %s at destination: %w", srcInfo.Digest, err)
 		}
 		if reused {
 			logrus.Debugf("Skipping blob %s (already present):", srcInfo.Digest)
@@ -1257,7 +1243,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 
 		srcStream, srcBlobSize, err := ic.c.rawSource.GetBlob(ctx, srcInfo, ic.c.blobInfoCache)
 		if err != nil {
-			return types.BlobInfo{}, "", perrors.Wrapf(err, "reading blob %s", srcInfo.Digest)
+			return types.BlobInfo{}, "", fmt.Errorf("reading blob %s: %w", srcInfo.Digest, err)
 		}
 		defer srcStream.Close()
 
@@ -1273,7 +1259,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 				return types.BlobInfo{}, "", ctx.Err()
 			case diffIDResult := <-diffIDChan:
 				if diffIDResult.err != nil {
-					return types.BlobInfo{}, "", perrors.Wrap(diffIDResult.err, "computing layer DiffID")
+					return types.BlobInfo{}, "", fmt.Errorf("computing layer DiffID: %w", diffIDResult.err)
 				}
 				logrus.Debugf("Computed DiffID %s for layer %s", diffIDResult.digest, srcInfo.Digest)
 				// Don’t record any associations that involve encrypted data. This is a bit crude,

--- a/vendor/github.com/containers/image/v5/copy/digesting_reader.go
+++ b/vendor/github.com/containers/image/v5/copy/digesting_reader.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	digest "github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 )
 
 type digestingReader struct {
@@ -48,7 +47,7 @@ func (d *digestingReader) Read(p []byte) (int, error) {
 			// Coverage: This should not happen, the hash.Hash interface requires
 			// d.digest.Write to never return an error, and the io.Writer interface
 			// requires n2 == len(input) if no error is returned.
-			return 0, perrors.Wrapf(err, "updating digest during verification: %d vs. %d", n2, n)
+			return 0, fmt.Errorf("updating digest during verification: %d vs. %d: %w", n2, n, err)
 		}
 	}
 	if err == io.EOF {

--- a/vendor/github.com/containers/image/v5/copy/encryption.go
+++ b/vendor/github.com/containers/image/v5/copy/encryption.go
@@ -1,12 +1,12 @@
 package copy
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/containers/image/v5/types"
 	"github.com/containers/ocicrypt"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 )
 
 // isOciEncrypted returns a bool indicating if a mediatype is encrypted
@@ -41,7 +41,7 @@ func (c *copier) blobPipelineDecryptionStep(stream *sourceStream, srcInfo types.
 		}
 		reader, decryptedDigest, err := ocicrypt.DecryptLayer(c.ociDecryptConfig, stream.reader, desc, false)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "decrypting layer %s", srcInfo.Digest)
+			return nil, fmt.Errorf("decrypting layer %s: %w", srcInfo.Digest, err)
 		}
 
 		stream.reader = reader
@@ -92,7 +92,7 @@ func (c *copier) blobPipelineEncryptionStep(stream *sourceStream, toEncrypt bool
 		}
 		reader, finalizer, err := ocicrypt.EncryptLayer(c.ociEncryptConfig, stream.reader, desc)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "encrypting blob %s", srcInfo.Digest)
+			return nil, fmt.Errorf("encrypting blob %s: %w", srcInfo.Digest, err)
 		}
 
 		stream.reader = reader
@@ -116,7 +116,7 @@ func (d *bpEncryptionStepData) updateCryptoOperationAndAnnotations(operation *ty
 
 	encryptAnnotations, err := d.finalizer()
 	if err != nil {
-		return perrors.Wrap(err, "Unable to finalize encryption")
+		return fmt.Errorf("Unable to finalize encryption: %w", err)
 	}
 	*operation = types.Encrypt
 	if *annotations == nil {

--- a/vendor/github.com/containers/image/v5/copy/progress_bars.go
+++ b/vendor/github.com/containers/image/v5/copy/progress_bars.go
@@ -38,7 +38,8 @@ type progressBar struct {
 }
 
 // createProgressBar creates a progressBar in pool.  Note that if the copier's reportWriter
-// is io.Discard, the progress bar's output will be discarded
+// is io.Discard, the progress bar's output will be discarded.  Callers may call printCopyInfo()
+// to print a single line instead.
 //
 // NOTE: Every progress bar created within a progress pool must either successfully
 // complete or be aborted, or pool.Wait() will hang. That is typically done
@@ -95,12 +96,18 @@ func (c *copier) createProgressBar(pool *mpb.Progress, partial bool, info types.
 			),
 		)
 	}
-	if c.progressOutput == io.Discard {
-		c.Printf("Copying %s %s\n", kind, info.Digest)
-	}
 	return &progressBar{
 		Bar:          bar,
 		originalSize: info.Size,
+	}
+}
+
+// printCopyInfo prints a "Copying ..." message on the copier if the output is
+// set to `io.Discard`.  In that case, the progress bars won't be rendered but
+// we still want to indicate when blobs and configs are copied.
+func (c *copier) printCopyInfo(kind string, info types.BlobInfo) {
+	if c.progressOutput == io.Discard {
+		c.Printf("Copying %s %s\n", kind, info.Digest)
 	}
 }
 

--- a/vendor/github.com/containers/image/v5/copy/sign.go
+++ b/vendor/github.com/containers/image/v5/copy/sign.go
@@ -1,25 +1,51 @@
 package copy
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/internal/private"
 	internalsig "github.com/containers/image/v5/internal/signature"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/signature/sigstore"
 	"github.com/containers/image/v5/transports"
-	perrors "github.com/pkg/errors"
 )
+
+// sourceSignatures returns signatures from unparsedSource based on options,
+// and verifies that they can be used (to avoid copying a large image when we
+// can tell in advance that it would ultimately fail)
+func (c *copier) sourceSignatures(ctx context.Context, unparsed private.UnparsedImage, options *Options,
+	gettingSignaturesMessage, checkingDestMessage string) ([]internalsig.Signature, error) {
+	var sigs []internalsig.Signature
+	if options.RemoveSignatures {
+		sigs = []internalsig.Signature{}
+	} else {
+		c.Printf("%s\n", gettingSignaturesMessage)
+		s, err := unparsed.UntrustedSignatures(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("reading signatures: %w", err)
+		}
+		sigs = s
+	}
+	if len(sigs) != 0 {
+		c.Printf("%s\n", checkingDestMessage)
+		if err := c.dest.SupportsSignatures(ctx); err != nil {
+			return nil, fmt.Errorf("Can not copy signatures to %s: %w", transports.ImageName(c.dest.Reference()), err)
+		}
+	}
+	return sigs, nil
+}
 
 // createSignature creates a new signature of manifest using keyIdentity.
 func (c *copier) createSignature(manifest []byte, keyIdentity string, passphrase string, identity reference.Named) (internalsig.Signature, error) {
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
-		return nil, perrors.Wrap(err, "initializing GPG")
+		return nil, fmt.Errorf("initializing GPG: %w", err)
 	}
 	defer mech.Close()
 	if err := mech.SupportsSigning(); err != nil {
-		return nil, perrors.Wrap(err, "Signing not supported")
+		return nil, fmt.Errorf("Signing not supported: %w", err)
 	}
 
 	if identity != nil {
@@ -36,7 +62,7 @@ func (c *copier) createSignature(manifest []byte, keyIdentity string, passphrase
 	c.Printf("Signing manifest using simple signing\n")
 	newSig, err := signature.SignDockerManifestWithOptions(manifest, identity.String(), mech, keyIdentity, &signature.SignOptions{Passphrase: passphrase})
 	if err != nil {
-		return nil, perrors.Wrap(err, "creating signature")
+		return nil, fmt.Errorf("creating signature: %w", err)
 	}
 	return internalsig.SimpleSigningFromBlob(newSig), nil
 }

--- a/vendor/github.com/containers/image/v5/directory/directory_dest.go
+++ b/vendor/github.com/containers/image/v5/directory/directory_dest.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containers/image/v5/internal/signature"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -56,7 +55,7 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (private.Im
 	// if the contents don't match throw an error
 	dirExists, err := pathExists(ref.resolvedPath)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "checking for path %q", ref.resolvedPath)
+		return nil, fmt.Errorf("checking for path %q: %w", ref.resolvedPath, err)
 	}
 	if dirExists {
 		isEmpty, err := isDirEmpty(ref.resolvedPath)
@@ -67,7 +66,7 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (private.Im
 		if !isEmpty {
 			versionExists, err := pathExists(ref.versionPath())
 			if err != nil {
-				return nil, perrors.Wrapf(err, "checking if path exists %q", ref.versionPath())
+				return nil, fmt.Errorf("checking if path exists %q: %w", ref.versionPath(), err)
 			}
 			if versionExists {
 				contents, err := os.ReadFile(ref.versionPath())
@@ -83,20 +82,20 @@ func newImageDestination(sys *types.SystemContext, ref dirReference) (private.Im
 			}
 			// delete directory contents so that only one image is in the directory at a time
 			if err = removeDirContents(ref.resolvedPath); err != nil {
-				return nil, perrors.Wrapf(err, "erasing contents in %q", ref.resolvedPath)
+				return nil, fmt.Errorf("erasing contents in %q: %w", ref.resolvedPath, err)
 			}
 			logrus.Debugf("overwriting existing container image directory %q", ref.resolvedPath)
 		}
 	} else {
 		// create directory if it doesn't exist
 		if err := os.MkdirAll(ref.resolvedPath, 0755); err != nil {
-			return nil, perrors.Wrapf(err, "unable to create directory %q", ref.resolvedPath)
+			return nil, fmt.Errorf("unable to create directory %q: %w", ref.resolvedPath, err)
 		}
 	}
 	// create version file
 	err = os.WriteFile(ref.versionPath(), []byte(version), 0644)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "creating version file %q", ref.versionPath())
+		return nil, fmt.Errorf("creating version file %q: %w", ref.versionPath(), err)
 	}
 
 	d := &dirImageDestination{

--- a/vendor/github.com/containers/image/v5/docker/archive/reader.go
+++ b/vendor/github.com/containers/image/v5/docker/archive/reader.go
@@ -7,7 +7,6 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 )
 
 // Reader manages a single Docker archive, allows listing its contents and accessing
@@ -75,7 +74,7 @@ func (r *Reader) List() ([][]types.ImageReference, error) {
 		for _, tag := range image.RepoTags {
 			parsedTag, err := reference.ParseNormalizedNamed(tag)
 			if err != nil {
-				return nil, perrors.Wrapf(err, "Invalid tag %#v in manifest item @%d", tag, imageIndex)
+				return nil, fmt.Errorf("Invalid tag %#v in manifest item @%d: %w", tag, imageIndex, err)
 			}
 			nt, ok := parsedTag.(reference.NamedTagged)
 			if !ok {
@@ -83,14 +82,14 @@ func (r *Reader) List() ([][]types.ImageReference, error) {
 			}
 			ref, err := newReference(r.path, nt, -1, r.archive, nil)
 			if err != nil {
-				return nil, perrors.Wrapf(err, "creating a reference for tag %#v in manifest item @%d", tag, imageIndex)
+				return nil, fmt.Errorf("creating a reference for tag %#v in manifest item @%d: %w", tag, imageIndex, err)
 			}
 			refs = append(refs, ref)
 		}
 		if len(refs) == 0 {
 			ref, err := newReference(r.path, nil, imageIndex, r.archive, nil)
 			if err != nil {
-				return nil, perrors.Wrapf(err, "creating a reference for manifest item @%d", imageIndex)
+				return nil, fmt.Errorf("creating a reference for manifest item @%d: %w", imageIndex, err)
 			}
 			refs = append(refs, ref)
 		}

--- a/vendor/github.com/containers/image/v5/docker/archive/transport.go
+++ b/vendor/github.com/containers/image/v5/docker/archive/transport.go
@@ -12,7 +12,6 @@ import (
 	ctrImage "github.com/containers/image/v5/internal/image"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -73,7 +72,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		if len(parts[1]) > 0 && parts[1][0] == '@' {
 			i, err := strconv.Atoi(parts[1][1:])
 			if err != nil {
-				return nil, perrors.Wrapf(err, "Invalid source index %s", parts[1])
+				return nil, fmt.Errorf("Invalid source index %s: %w", parts[1], err)
 			}
 			if i < 0 {
 				return nil, fmt.Errorf("Invalid source index @%d: must not be negative", i)
@@ -82,7 +81,7 @@ func ParseReference(refString string) (types.ImageReference, error) {
 		} else {
 			ref, err := reference.ParseNormalizedNamed(parts[1])
 			if err != nil {
-				return nil, perrors.Wrapf(err, "docker-archive parsing reference")
+				return nil, fmt.Errorf("docker-archive parsing reference: %w", err)
 			}
 			ref = reference.TagNameOnly(ref)
 			refTagged, isTagged := ref.(reference.NamedTagged)

--- a/vendor/github.com/containers/image/v5/docker/archive/writer.go
+++ b/vendor/github.com/containers/image/v5/docker/archive/writer.go
@@ -2,13 +2,13 @@ package archive
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 )
 
 // Writer manages a single in-progress Docker archive and allows adding images to it.
@@ -61,7 +61,7 @@ func openArchiveForWriting(path string) (*os.File, error) {
 	// only in a different way. Either way, it’s up to the user to not have two writers to the same path.)
 	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "opening file %q", path)
+		return nil, fmt.Errorf("opening file %q: %w", path, err)
 	}
 	succeeded := false
 	defer func() {
@@ -71,7 +71,7 @@ func openArchiveForWriting(path string) (*os.File, error) {
 	}()
 	fhStat, err := fh.Stat()
 	if err != nil {
-		return nil, perrors.Wrapf(err, "statting file %q", path)
+		return nil, fmt.Errorf("statting file %q: %w", path, err)
 	}
 
 	if fhStat.Mode().IsRegular() && fhStat.Size() != 0 {

--- a/vendor/github.com/containers/image/v5/docker/daemon/daemon_dest.go
+++ b/vendor/github.com/containers/image/v5/docker/daemon/daemon_dest.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
 	"github.com/docker/docker/client"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -45,7 +44,7 @@ func newImageDestination(ctx context.Context, sys *types.SystemContext, ref daem
 
 	c, err := newDockerClient(sys)
 	if err != nil {
-		return nil, perrors.Wrap(err, "initializing docker engine client")
+		return nil, fmt.Errorf("initializing docker engine client: %w", err)
 	}
 
 	reader, writer := io.Pipe()
@@ -87,7 +86,7 @@ func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeRe
 
 	resp, err := c.ImageLoad(ctx, reader, true)
 	if err != nil {
-		err = perrors.Wrap(err, "saving image to docker engine")
+		err = fmt.Errorf("saving image to docker engine: %w", err)
 		return
 	}
 	defer resp.Body.Close()

--- a/vendor/github.com/containers/image/v5/docker/daemon/daemon_src.go
+++ b/vendor/github.com/containers/image/v5/docker/daemon/daemon_src.go
@@ -2,11 +2,11 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/image/v5/docker/internal/tarfile"
 	"github.com/containers/image/v5/internal/private"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 )
 
 type daemonImageSource struct {
@@ -26,13 +26,13 @@ type daemonImageSource struct {
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref daemonReference) (private.ImageSource, error) {
 	c, err := newDockerClient(sys)
 	if err != nil {
-		return nil, perrors.Wrap(err, "initializing docker engine client")
+		return nil, fmt.Errorf("initializing docker engine client: %w", err)
 	}
 	// Per NewReference(), ref.StringWithinTransport() is either an image ID (config digest), or a !reference.NameOnly() reference.
 	// Either way ImageSave should create a tarball with exactly one image.
 	inputStream, err := c.ImageSave(ctx, []string{ref.StringWithinTransport()})
 	if err != nil {
-		return nil, perrors.Wrap(err, "loading image from docker engine")
+		return nil, fmt.Errorf("loading image from docker engine: %w", err)
 	}
 	defer inputStream.Close()
 

--- a/vendor/github.com/containers/image/v5/docker/docker_image.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 )
 
 // Image is a Docker-specific implementation of types.ImageCloser with a few extra methods
@@ -67,7 +66,7 @@ func GetRepositoryTags(ctx context.Context, sys *types.SystemContext, ref types.
 	path := fmt.Sprintf(tagsPath, reference.Path(dr.ref))
 	client, err := newDockerClientFromRef(sys, dr, registryConfig, false, "pull")
 	if err != nil {
-		return nil, perrors.Wrap(err, "failed to create client")
+		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
 	tags := make([]string, 0)
@@ -135,7 +134,7 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 	}
 	client, err := newDockerClientFromRef(sys, dr, registryConfig, false, "pull")
 	if err != nil {
-		return "", perrors.Wrap(err, "failed to create client")
+		return "", fmt.Errorf("failed to create client: %w", err)
 	}
 
 	path := fmt.Sprintf(manifestPath, reference.Path(dr.ref), tagOrDigest)
@@ -150,7 +149,7 @@ func GetDigest(ctx context.Context, sys *types.SystemContext, ref types.ImageRef
 
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return "", perrors.Wrapf(registryHTTPResponseToError(res), "reading digest %s in %s", tagOrDigest, dr.ref.Name())
+		return "", fmt.Errorf("reading digest %s in %s: %w", tagOrDigest, dr.ref.Name(), registryHTTPResponseToError(res))
 	}
 
 	dig, err := digest.Parse(res.Header.Get("Docker-Content-Digest"))

--- a/vendor/github.com/containers/image/v5/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image_src.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -52,7 +51,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 	}
 	registry, err := sysregistriesv2.FindRegistry(sys, ref.ref.Name())
 	if err != nil {
-		return nil, perrors.Wrapf(err, "loading registries configuration")
+		return nil, fmt.Errorf("loading registries configuration: %w", err)
 	}
 	if registry == nil {
 		// No configuration was found for the provided reference, so use the
@@ -109,7 +108,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 			// The paired [] at least have some chance of being unambiguous.
 			extras = append(extras, fmt.Sprintf("[%s: %v]", attempts[i].ref.String(), attempts[i].err))
 		}
-		return nil, perrors.Wrapf(primary.err, "(Mirrors also failed: %s): %s", strings.Join(extras, "\n"), primary.ref.String())
+		return nil, fmt.Errorf("(Mirrors also failed: %s): %s: %w", strings.Join(extras, "\n"), primary.ref.String(), primary.err)
 	}
 }
 

--- a/vendor/github.com/containers/image/v5/docker/internal/tarfile/reader.go
+++ b/vendor/github.com/containers/image/v5/docker/internal/tarfile/reader.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containers/image/v5/internal/tmpdir"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 )
 
 // Reader is a ((docker save)-formatted) tar archive that allows random access to any component.
@@ -31,7 +30,7 @@ type Reader struct {
 func NewReaderFromFile(sys *types.SystemContext, path string) (*Reader, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "opening file %q", path)
+		return nil, fmt.Errorf("opening file %q: %w", path, err)
 	}
 	defer file.Close()
 
@@ -39,7 +38,7 @@ func NewReaderFromFile(sys *types.SystemContext, path string) (*Reader, error) {
 	// as a source. Otherwise we pass the stream to NewReaderFromStream.
 	stream, isCompressed, err := compression.AutoDecompress(file)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "detecting compression for file %q", path)
+		return nil, fmt.Errorf("detecting compression for file %q: %w", path, err)
 	}
 	defer stream.Close()
 	if !isCompressed {
@@ -56,7 +55,7 @@ func NewReaderFromStream(sys *types.SystemContext, inputStream io.Reader) (*Read
 	// Save inputStream to a temporary file
 	tarCopyFile, err := os.CreateTemp(tmpdir.TemporaryDirectoryForBigFiles(sys), "docker-tar")
 	if err != nil {
-		return nil, perrors.Wrap(err, "creating temporary file")
+		return nil, fmt.Errorf("creating temporary file: %w", err)
 	}
 	defer tarCopyFile.Close()
 
@@ -72,7 +71,7 @@ func NewReaderFromStream(sys *types.SystemContext, inputStream io.Reader) (*Read
 	// giving users really confusing "invalid tar header" errors).
 	uncompressedStream, _, err := compression.AutoDecompress(inputStream)
 	if err != nil {
-		return nil, perrors.Wrap(err, "auto-decompressing input")
+		return nil, fmt.Errorf("auto-decompressing input: %w", err)
 	}
 	defer uncompressedStream.Close()
 
@@ -81,7 +80,7 @@ func NewReaderFromStream(sys *types.SystemContext, inputStream io.Reader) (*Read
 	// TODO: This can take quite some time, and should ideally be cancellable
 	//       using a context.Context.
 	if _, err := io.Copy(tarCopyFile, uncompressedStream); err != nil {
-		return nil, perrors.Wrapf(err, "copying contents to temporary file %q", tarCopyFile.Name())
+		return nil, fmt.Errorf("copying contents to temporary file %q: %w", tarCopyFile.Name(), err)
 	}
 	succeeded = true
 
@@ -114,7 +113,7 @@ func newReader(path string, removeOnClose bool) (*Reader, error) {
 		return nil, err
 	}
 	if err := json.Unmarshal(bytes, &r.Manifest); err != nil {
-		return nil, perrors.Wrap(err, "decoding tar manifest.json")
+		return nil, fmt.Errorf("decoding tar manifest.json: %w", err)
 	}
 
 	succeeded = true
@@ -147,7 +146,7 @@ func (r *Reader) ChooseManifestItem(ref reference.NamedTagged, sourceIndex int) 
 			for tagIndex, tag := range r.Manifest[i].RepoTags {
 				parsedTag, err := reference.ParseNormalizedNamed(tag)
 				if err != nil {
-					return nil, -1, perrors.Wrapf(err, "Invalid tag %#v in manifest.json item @%d", tag, i)
+					return nil, -1, fmt.Errorf("Invalid tag %#v in manifest.json item @%d: %w", tag, i, err)
 				}
 				if parsedTag.String() == refString {
 					return &r.Manifest[i], tagIndex, nil
@@ -259,7 +258,7 @@ func findTarComponent(inputFile io.Reader, componentPath string) (*tar.Reader, *
 func (r *Reader) readTarComponent(path string, limit int) ([]byte, error) {
 	file, err := r.openTarComponent(path)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "loading tar component %s", path)
+		return nil, fmt.Errorf("loading tar component %s: %w", path, err)
 	}
 	defer file.Close()
 	bytes, err := iolimits.ReadAtMost(file, limit)

--- a/vendor/github.com/containers/image/v5/docker/registries_d.go
+++ b/vendor/github.com/containers/image/v5/docker/registries_d.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/ghodss/yaml"
 	"github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -135,7 +134,7 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 		var config registryConfiguration
 		err = yaml.Unmarshal(configBytes, &config)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "parsing %s", configPath)
+			return nil, fmt.Errorf("parsing %s: %w", configPath, err)
 		}
 
 		if config.DefaultDocker != nil {
@@ -168,7 +167,7 @@ func (config *registryConfiguration) lookasideStorageBaseURL(dr dockerReference,
 	if topLevel != "" {
 		u, err := url.Parse(topLevel)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "Invalid signature storage URL %s", topLevel)
+			return nil, fmt.Errorf("Invalid signature storage URL %s: %w", topLevel, err)
 		}
 		url = u
 	} else {

--- a/vendor/github.com/containers/image/v5/internal/image/docker_list.go
+++ b/vendor/github.com/containers/image/v5/internal/image/docker_list.go
@@ -6,26 +6,25 @@ import (
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 )
 
 func manifestSchema2FromManifestList(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
 	list, err := manifest.Schema2ListFromManifest(manblob)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "parsing schema2 manifest list")
+		return nil, fmt.Errorf("parsing schema2 manifest list: %w", err)
 	}
 	targetManifestDigest, err := list.ChooseInstance(sys)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "choosing image instance")
+		return nil, fmt.Errorf("choosing image instance: %w", err)
 	}
 	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "fetching target platform image selected from manifest list")
+		return nil, fmt.Errorf("fetching target platform image selected from manifest list: %w", err)
 	}
 
 	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
 	if err != nil {
-		return nil, perrors.Wrap(err, "computing manifest digest")
+		return nil, fmt.Errorf("computing manifest digest: %w", err)
 	}
 	if !matches {
 		return nil, fmt.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)

--- a/vendor/github.com/containers/image/v5/internal/image/docker_schema2.go
+++ b/vendor/github.com/containers/image/v5/internal/image/docker_schema2.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -294,7 +293,7 @@ func (m *manifestSchema2) convertToManifestSchema1(ctx context.Context, options 
 				// and anyway this blob is so small that it’s easier to just copy it than to worry about figuring out another location where to get it.
 				info, err := dest.PutBlob(ctx, bytes.NewReader(GzippedEmptyLayer), emptyLayerBlobInfo, none.NoCache, false)
 				if err != nil {
-					return nil, perrors.Wrap(err, "uploading empty layer")
+					return nil, fmt.Errorf("uploading empty layer: %w", err)
 				}
 				if info.Digest != emptyLayerBlobInfo.Digest {
 					return nil, fmt.Errorf("Internal error: Uploaded empty layer has digest %#v instead of %s", info.Digest, emptyLayerBlobInfo.Digest)

--- a/vendor/github.com/containers/image/v5/internal/image/oci_index.go
+++ b/vendor/github.com/containers/image/v5/internal/image/oci_index.go
@@ -6,26 +6,25 @@ import (
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 )
 
 func manifestOCI1FromImageIndex(ctx context.Context, sys *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
 	index, err := manifest.OCI1IndexFromManifest(manblob)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "parsing OCI1 index")
+		return nil, fmt.Errorf("parsing OCI1 index: %w", err)
 	}
 	targetManifestDigest, err := index.ChooseInstance(sys)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "choosing image instance")
+		return nil, fmt.Errorf("choosing image instance: %w", err)
 	}
 	manblob, mt, err := src.GetManifest(ctx, &targetManifestDigest)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "fetching target platform image selected from image index")
+		return nil, fmt.Errorf("fetching target platform image selected from image index: %w", err)
 	}
 
 	matches, err := manifest.MatchesDigest(manblob, targetManifestDigest)
 	if err != nil {
-		return nil, perrors.Wrap(err, "computing manifest digest")
+		return nil, fmt.Errorf("computing manifest digest: %w", err)
 	}
 	if !matches {
 		return nil, fmt.Errorf("Image manifest does not match selected manifest digest %s", targetManifestDigest)

--- a/vendor/github.com/containers/image/v5/internal/image/unparsed.go
+++ b/vendor/github.com/containers/image/v5/internal/image/unparsed.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 )
 
 // UnparsedImage implements types.UnparsedImage .
@@ -61,7 +60,7 @@ func (i *UnparsedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 		if digest, haveDigest := i.expectedManifestDigest(); haveDigest {
 			matches, err := manifest.MatchesDigest(m, digest)
 			if err != nil {
-				return nil, "", perrors.Wrap(err, "computing manifest digest")
+				return nil, "", fmt.Errorf("computing manifest digest: %w", err)
 			}
 			if !matches {
 				return nil, "", fmt.Errorf("Manifest does not match provided manifest digest %s", digest)

--- a/vendor/github.com/containers/image/v5/manifest/docker_schema2.go
+++ b/vendor/github.com/containers/image/v5/manifest/docker_schema2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/image/v5/pkg/strslice"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 )
 
 // Schema2Descriptor is a “descriptor” in docker/distribution schema 2.
@@ -246,7 +245,7 @@ func (m *Schema2) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 		}
 		mimeType, err := updatedMIMEType(schema2CompressionMIMETypeSets, mimeType, info)
 		if err != nil {
-			return perrors.Wrapf(err, "preparing updated manifest, layer %q", info.Digest)
+			return fmt.Errorf("preparing updated manifest, layer %q: %w", info.Digest, err)
 		}
 		m.LayersDescriptors[i].MediaType = mimeType
 		m.LayersDescriptors[i].Digest = info.Digest

--- a/vendor/github.com/containers/image/v5/manifest/docker_schema2_list.go
+++ b/vendor/github.com/containers/image/v5/manifest/docker_schema2_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 )
 
 // Schema2PlatformSpec describes the platform which a particular manifest is
@@ -71,7 +70,7 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 	}
 	for i := range updates {
 		if err := updates[i].Digest.Validate(); err != nil {
-			return perrors.Wrapf(err, "update %d of %d passed to Schema2List.UpdateInstances contained an invalid digest", i+1, len(updates))
+			return fmt.Errorf("update %d of %d passed to Schema2List.UpdateInstances contained an invalid digest: %w", i+1, len(updates), err)
 		}
 		list.Manifests[i].Digest = updates[i].Digest
 		if updates[i].Size < 0 {
@@ -91,7 +90,7 @@ func (list *Schema2List) UpdateInstances(updates []ListUpdate) error {
 func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
 	wantedPlatforms, err := platform.WantedPlatforms(ctx)
 	if err != nil {
-		return "", perrors.Wrapf(err, "getting platform information %#v", ctx)
+		return "", fmt.Errorf("getting platform information %#v: %w", ctx, err)
 	}
 	for _, wantedPlatform := range wantedPlatforms {
 		for _, d := range list.Manifests {
@@ -115,7 +114,7 @@ func (list *Schema2List) ChooseInstance(ctx *types.SystemContext) (digest.Digest
 func (list *Schema2List) Serialize() ([]byte, error) {
 	buf, err := json.Marshal(list)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "marshaling Schema2List %#v", list)
+		return nil, fmt.Errorf("marshaling Schema2List %#v: %w", list, err)
 	}
 	return buf, nil
 }
@@ -190,7 +189,7 @@ func Schema2ListFromManifest(manifest []byte) (*Schema2List, error) {
 		Manifests: []Schema2ManifestDescriptor{},
 	}
 	if err := json.Unmarshal(manifest, &list); err != nil {
-		return nil, perrors.Wrapf(err, "unmarshaling Schema2List %q", string(manifest))
+		return nil, fmt.Errorf("unmarshaling Schema2List %q: %w", string(manifest), err)
 	}
 	if err := validateUnambiguousManifestFormat(manifest, DockerV2ListMediaType,
 		allowedFieldManifests); err != nil {

--- a/vendor/github.com/containers/image/v5/manifest/oci.go
+++ b/vendor/github.com/containers/image/v5/manifest/oci.go
@@ -12,7 +12,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 )
 
 // BlobInfoFromOCI1Descriptor returns a types.BlobInfo based on the input OCI1 descriptor.
@@ -139,7 +138,7 @@ func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 		}
 		mimeType, err := updatedMIMEType(oci1CompressionMIMETypeSets, mimeType, info)
 		if err != nil {
-			return perrors.Wrapf(err, "preparing updated manifest, layer %q", info.Digest)
+			return fmt.Errorf("preparing updated manifest, layer %q: %w", info.Digest, err)
 		}
 		if info.CryptoOperation == types.Encrypt {
 			encMediaType, err := getEncryptedMediaType(mimeType)

--- a/vendor/github.com/containers/image/v5/manifest/oci_index.go
+++ b/vendor/github.com/containers/image/v5/manifest/oci_index.go
@@ -10,7 +10,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	imgspec "github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 )
 
 // OCI1Index is just an alias for the OCI index type, but one which we can
@@ -55,7 +54,7 @@ func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 	}
 	for i := range updates {
 		if err := updates[i].Digest.Validate(); err != nil {
-			return perrors.Wrapf(err, "update %d of %d passed to OCI1Index.UpdateInstances contained an invalid digest", i+1, len(updates))
+			return fmt.Errorf("update %d of %d passed to OCI1Index.UpdateInstances contained an invalid digest: %w", i+1, len(updates), err)
 		}
 		index.Manifests[i].Digest = updates[i].Digest
 		if updates[i].Size < 0 {
@@ -75,7 +74,7 @@ func (index *OCI1Index) UpdateInstances(updates []ListUpdate) error {
 func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest, error) {
 	wantedPlatforms, err := platform.WantedPlatforms(ctx)
 	if err != nil {
-		return "", perrors.Wrapf(err, "getting platform information %#v", ctx)
+		return "", fmt.Errorf("getting platform information %#v: %w", ctx, err)
 	}
 	for _, wantedPlatform := range wantedPlatforms {
 		for _, d := range index.Manifests {
@@ -108,7 +107,7 @@ func (index *OCI1Index) ChooseInstance(ctx *types.SystemContext) (digest.Digest,
 func (index *OCI1Index) Serialize() ([]byte, error) {
 	buf, err := json.Marshal(index)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "marshaling OCI1Index %#v", index)
+		return nil, fmt.Errorf("marshaling OCI1Index %#v: %w", index, err)
 	}
 	return buf, nil
 }
@@ -202,7 +201,7 @@ func OCI1IndexFromManifest(manifest []byte) (*OCI1Index, error) {
 		},
 	}
 	if err := json.Unmarshal(manifest, &index); err != nil {
-		return nil, perrors.Wrapf(err, "unmarshaling OCI1Index %q", string(manifest))
+		return nil, fmt.Errorf("unmarshaling OCI1Index %q: %w", string(manifest), err)
 	}
 	if err := validateUnambiguousManifestFormat(manifest, imgspecv1.MediaTypeImageIndex,
 		allowedFieldManifests); err != nil {

--- a/vendor/github.com/containers/image/v5/oci/archive/oci_src.go
+++ b/vendor/github.com/containers/image/v5/oci/archive/oci_src.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/containers/image/v5/internal/imagesource"
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,13 +30,13 @@ type ociArchiveImageSource struct {
 func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiveReference) (private.ImageSource, error) {
 	tempDirRef, err := createUntarTempDir(sys, ref)
 	if err != nil {
-		return nil, perrors.Wrap(err, "creating temp directory")
+		return nil, fmt.Errorf("creating temp directory: %w", err)
 	}
 
 	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, sys)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
-			return nil, perrors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
+			return nil, fmt.Errorf("deleting temp directory %q: %w", tempDirRef.tempDirectory, err)
 		}
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.Im
 	}
 	tempDirRef, err := createUntarTempDir(sys, ociArchRef)
 	if err != nil {
-		return imgspecv1.Descriptor{}, perrors.Wrap(err, "creating temp directory")
+		return imgspecv1.Descriptor{}, fmt.Errorf("creating temp directory: %w", err)
 	}
 	defer func() {
 		err := tempDirRef.deleteTempDir()
@@ -72,7 +72,7 @@ func LoadManifestDescriptorWithContext(sys *types.SystemContext, imgRef types.Im
 
 	descriptor, err := ocilayout.LoadManifestDescriptor(tempDirRef.ociRefExtracted)
 	if err != nil {
-		return imgspecv1.Descriptor{}, perrors.Wrap(err, "loading index")
+		return imgspecv1.Descriptor{}, fmt.Errorf("loading index: %w", err)
 	}
 	return descriptor, nil
 }

--- a/vendor/github.com/containers/image/v5/oci/archive/oci_transport.go
+++ b/vendor/github.com/containers/image/v5/oci/archive/oci_transport.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/archive"
-	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -159,7 +158,7 @@ func (t *tempDirOCIRef) deleteTempDir() error {
 func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error) {
 	dir, err := os.MkdirTemp(tmpdir.TemporaryDirectoryForBigFiles(sys), "oci")
 	if err != nil {
-		return tempDirOCIRef{}, perrors.Wrapf(err, "creating temp directory")
+		return tempDirOCIRef{}, fmt.Errorf("creating temp directory: %w", err)
 	}
 	ociRef, err := ocilayout.NewReference(dir, image)
 	if err != nil {
@@ -174,7 +173,7 @@ func createOCIRef(sys *types.SystemContext, image string) (tempDirOCIRef, error)
 func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (tempDirOCIRef, error) {
 	tempDirRef, err := createOCIRef(sys, ref.image)
 	if err != nil {
-		return tempDirOCIRef{}, perrors.Wrap(err, "creating oci reference")
+		return tempDirOCIRef{}, fmt.Errorf("creating oci reference: %w", err)
 	}
 	src := ref.resolvedFile
 	dst := tempDirRef.tempDirectory
@@ -186,9 +185,9 @@ func createUntarTempDir(sys *types.SystemContext, ref ociArchiveReference) (temp
 	defer arch.Close()
 	if err := archive.NewDefaultArchiver().Untar(arch, dst, &archive.TarOptions{NoLchown: true}); err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
-			return tempDirOCIRef{}, perrors.Wrapf(err, "deleting temp directory %q", tempDirRef.tempDirectory)
+			return tempDirOCIRef{}, fmt.Errorf("deleting temp directory %q: %w", tempDirRef.tempDirectory, err)
 		}
-		return tempDirOCIRef{}, perrors.Wrapf(err, "untarring file %q", tempDirRef.tempDirectory)
+		return tempDirOCIRef{}, fmt.Errorf("untarring file %q: %w", tempDirRef.tempDirectory, err)
 	}
 	return tempDirRef, nil
 }

--- a/vendor/github.com/containers/image/v5/oci/layout/oci_src.go
+++ b/vendor/github.com/containers/image/v5/oci/layout/oci_src.go
@@ -3,6 +3,7 @@ package layout
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 )
 
 type ociImageSource struct {
@@ -170,19 +170,19 @@ func (s *ociImageSource) getExternalBlob(ctx context.Context, urls []string) (io
 		hasSupportedURL = true
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 		if err != nil {
-			errWrap = perrors.Wrapf(errWrap, "fetching %s failed %s", u, err.Error())
+			errWrap = fmt.Errorf("fetching %s failed %s: %w", u, err.Error(), errWrap)
 			continue
 		}
 
 		resp, err := s.client.Do(req)
 		if err != nil {
-			errWrap = perrors.Wrapf(errWrap, "fetching %s failed %s", u, err.Error())
+			errWrap = fmt.Errorf("fetching %s failed %s: %w", u, err.Error(), errWrap)
 			continue
 		}
 
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
-			errWrap = perrors.Wrapf(errWrap, "fetching %s failed, response code not 200", u)
+			errWrap = fmt.Errorf("fetching %s failed, response code not 200: %w", u, errWrap)
 			continue
 		}
 

--- a/vendor/github.com/containers/image/v5/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/v5/oci/layout/oci_transport.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -251,7 +250,7 @@ func (ref ociReference) indexPath() string {
 // blobPath returns a path for a blob within a directory using OCI image-layout conventions.
 func (ref ociReference) blobPath(digest digest.Digest, sharedBlobDir string) (string, error) {
 	if err := digest.Validate(); err != nil {
-		return "", perrors.Wrapf(err, "unexpected digest reference %s", digest)
+		return "", fmt.Errorf("unexpected digest reference %s: %w", digest, err)
 	}
 	blobDir := filepath.Join(ref.dir, "blobs")
 	if sharedBlobDir != "" {

--- a/vendor/github.com/containers/image/v5/openshift/openshift-copies.go
+++ b/vendor/github.com/containers/image/v5/openshift/openshift-copies.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 )
@@ -579,7 +578,7 @@ func (rules *clientConfigLoadingRules) Load() (*clientcmdConfig, error) {
 			continue
 		}
 		if err != nil {
-			errlist = append(errlist, perrors.Wrapf(err, "loading config file \"%s\"", filename))
+			errlist = append(errlist, fmt.Errorf("loading config file \"%s\": %w", filename, err))
 			continue
 		}
 
@@ -692,7 +691,7 @@ func resolveLocalPaths(config *clientcmdConfig) error {
 		}
 		base, err := filepath.Abs(filepath.Dir(cluster.LocationOfOrigin))
 		if err != nil {
-			return perrors.Wrapf(err, "Could not determine the absolute path of config file %s", cluster.LocationOfOrigin)
+			return fmt.Errorf("Could not determine the absolute path of config file %s: %w", cluster.LocationOfOrigin, err)
 		}
 
 		if err := resolvePaths(getClusterFileReferences(cluster), base); err != nil {
@@ -705,7 +704,7 @@ func resolveLocalPaths(config *clientcmdConfig) error {
 		}
 		base, err := filepath.Abs(filepath.Dir(authInfo.LocationOfOrigin))
 		if err != nil {
-			return perrors.Wrapf(err, "Could not determine the absolute path of config file %s", authInfo.LocationOfOrigin)
+			return fmt.Errorf("Could not determine the absolute path of config file %s: %w", authInfo.LocationOfOrigin, err)
 		}
 
 		if err := resolvePaths(getAuthInfoFileReferences(authInfo), base); err != nil {

--- a/vendor/github.com/containers/image/v5/openshift/openshift_dest.go
+++ b/vendor/github.com/containers/image/v5/openshift/openshift_dest.go
@@ -21,7 +21,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 )
 
 type openshiftImageDestination struct {
@@ -206,7 +205,7 @@ sigExists:
 			randBytes := make([]byte, 16)
 			n, err := rand.Read(randBytes)
 			if err != nil || n != 16 {
-				return perrors.Wrapf(err, "generating random signature len %d", n)
+				return fmt.Errorf("generating random signature len %d: %w", n, err)
 			}
 			signatureName = fmt.Sprintf("%s@%032x", imageStreamImageName, randBytes)
 			if _, ok := existingSigNames[signatureName]; !ok {

--- a/vendor/github.com/containers/image/v5/openshift/openshift_transport.go
+++ b/vendor/github.com/containers/image/v5/openshift/openshift_transport.go
@@ -12,7 +12,6 @@ import (
 	genericImage "github.com/containers/image/v5/internal/image"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -60,7 +59,7 @@ type openshiftReference struct {
 func ParseReference(ref string) (types.ImageReference, error) {
 	r, err := reference.ParseNormalizedNamed(ref)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "failed to parse image reference %q", ref)
+		return nil, fmt.Errorf("failed to parse image reference %q: %w", ref, err)
 	}
 	tagged, ok := r.(reference.NamedTagged)
 	if !ok {

--- a/vendor/github.com/containers/image/v5/pkg/compression/compression.go
+++ b/vendor/github.com/containers/image/v5/pkg/compression/compression.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/image/v5/pkg/compression/types"
 	"github.com/containers/storage/pkg/chunked/compressor"
 	"github.com/klauspost/pgzip"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/ulikunitz/xz"
 )
@@ -151,13 +150,13 @@ func DetectCompression(input io.Reader) (DecompressorFunc, io.Reader, error) {
 func AutoDecompress(stream io.Reader) (io.ReadCloser, bool, error) {
 	decompressor, stream, err := DetectCompression(stream)
 	if err != nil {
-		return nil, false, perrors.Wrapf(err, "detecting compression")
+		return nil, false, fmt.Errorf("detecting compression: %w", err)
 	}
 	var res io.ReadCloser
 	if decompressor != nil {
 		res, err = decompressor(stream)
 		if err != nil {
-			return nil, false, perrors.Wrapf(err, "initializing decompression")
+			return nil, false, fmt.Errorf("initializing decompression: %w", err)
 		}
 	} else {
 		res = io.NopCloser(stream)

--- a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/system_registries_v2.go
+++ b/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/system_registries_v2.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/homedir"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -103,7 +102,7 @@ func (e *Endpoint) rewriteReference(ref reference.Named, prefix string) (referen
 	newNamedRef = e.Location + refString[prefixLen:]
 	newParsedRef, err := reference.ParseNamed(newNamedRef)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "rewriting reference")
+		return nil, fmt.Errorf("rewriting reference: %w", err)
 	}
 
 	return newParsedRef, nil
@@ -666,7 +665,7 @@ func dropInConfigs(wrapper configWrapper) ([]string, error) {
 		if err != nil && !os.IsNotExist(err) {
 			// Ignore IsNotExist errors: most systems won't have a registries.conf.d
 			// directory.
-			return nil, perrors.Wrapf(err, "reading registries.conf.d")
+			return nil, fmt.Errorf("reading registries.conf.d: %w", err)
 		}
 	}
 
@@ -708,7 +707,7 @@ func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*parsedC
 				return nil, err // Should never happen
 			}
 		} else {
-			return nil, perrors.Wrapf(err, "loading registries configuration %q", wrapper.configPath)
+			return nil, fmt.Errorf("loading registries configuration %q: %w", wrapper.configPath, err)
 		}
 	}
 
@@ -721,7 +720,7 @@ func tryUpdatingCache(ctx *types.SystemContext, wrapper configWrapper) (*parsedC
 		// Enforce v2 format for drop-in-configs.
 		dropIn, err := loadConfigFile(path, true)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "loading drop-in registries configuration %q", path)
+			return nil, fmt.Errorf("loading drop-in registries configuration %q: %w", path, err)
 		}
 		config.updateWithConfigurationFrom(dropIn)
 	}
@@ -975,7 +974,7 @@ func loadConfigFile(path string, forceV2 bool) (*parsedConfig, error) {
 	// Parse and validate short-name aliases.
 	cache, err := newShortNameAliasCache(path, &res.partialV2.shortNameAliasConf)
 	if err != nil {
-		return nil, perrors.Wrap(err, "validating short-name aliases")
+		return nil, fmt.Errorf("validating short-name aliases: %w", err)
 	}
 	res.aliasCache = cache
 	// Clear conf.partialV2.shortNameAliasConf to make it available for garbage collection and

--- a/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
+++ b/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,7 +49,7 @@ func SetupCertificates(dir string, tlsc *tls.Config) error {
 			if tlsc.RootCAs == nil {
 				systemPool, err := tlsconfig.SystemCertPool()
 				if err != nil {
-					return perrors.Wrap(err, "unable to get system cert pool")
+					return fmt.Errorf("unable to get system cert pool: %w", err)
 				}
 				tlsc.RootCAs = systemPool
 			}

--- a/vendor/github.com/containers/image/v5/signature/mechanism.go
+++ b/vendor/github.com/containers/image/v5/signature/mechanism.go
@@ -65,7 +65,7 @@ func NewGPGSigningMechanism() (SigningMechanism, error) {
 // of these keys.
 // The caller must call .Close() on the returned SigningMechanism.
 func NewEphemeralGPGSigningMechanism(blob []byte) (SigningMechanism, []string, error) {
-	return newEphemeralGPGSigningMechanism(blob)
+	return newEphemeralGPGSigningMechanism([][]byte{blob})
 }
 
 // gpgUntrustedSignatureContents returns UNTRUSTED contents of the signature WITHOUT ANY VERIFICATION,

--- a/vendor/github.com/containers/image/v5/signature/mechanism_gpgme.go
+++ b/vendor/github.com/containers/image/v5/signature/mechanism_gpgme.go
@@ -33,10 +33,10 @@ func newGPGSigningMechanismInDirectory(optionalDir string) (signingMechanismWith
 }
 
 // newEphemeralGPGSigningMechanism returns a new GPG/OpenPGP signing mechanism which
-// recognizes _only_ public keys from the supplied blob, and returns the identities
+// recognizes _only_ public keys from the supplied blobs, and returns the identities
 // of these keys.
 // The caller must call .Close() on the returned SigningMechanism.
-func newEphemeralGPGSigningMechanism(blob []byte) (signingMechanismWithPassphrase, []string, error) {
+func newEphemeralGPGSigningMechanism(blobs [][]byte) (signingMechanismWithPassphrase, []string, error) {
 	dir, err := os.MkdirTemp("", "containers-ephemeral-gpg-")
 	if err != nil {
 		return nil, nil, err
@@ -55,9 +55,13 @@ func newEphemeralGPGSigningMechanism(blob []byte) (signingMechanismWithPassphras
 		ctx:          ctx,
 		ephemeralDir: dir,
 	}
-	keyIdentities, err := mech.importKeysFromBytes(blob)
-	if err != nil {
-		return nil, nil, err
+	keyIdentities := []string{}
+	for _, blob := range blobs {
+		ki, err := mech.importKeysFromBytes(blob)
+		if err != nil {
+			return nil, nil, err
+		}
+		keyIdentities = append(keyIdentities, ki...)
 	}
 
 	removeDir = false

--- a/vendor/github.com/containers/image/v5/signature/mechanism_openpgp.go
+++ b/vendor/github.com/containers/image/v5/signature/mechanism_openpgp.go
@@ -63,14 +63,19 @@ func newGPGSigningMechanismInDirectory(optionalDir string) (signingMechanismWith
 // recognizes _only_ public keys from the supplied blob, and returns the identities
 // of these keys.
 // The caller must call .Close() on the returned SigningMechanism.
-func newEphemeralGPGSigningMechanism(blob []byte) (signingMechanismWithPassphrase, []string, error) {
+func newEphemeralGPGSigningMechanism(blobs [][]byte) (signingMechanismWithPassphrase, []string, error) {
 	m := &openpgpSigningMechanism{
 		keyring: openpgp.EntityList{},
 	}
-	keyIdentities, err := m.importKeysFromBytes(blob)
-	if err != nil {
-		return nil, nil, err
+	keyIdentities := []string{}
+	for _, blob := range blobs {
+		ki, err := m.importKeysFromBytes(blob)
+		if err != nil {
+			return nil, nil, err
+		}
+		keyIdentities = append(keyIdentities, ki...)
 	}
+
 	return m, keyIdentities, nil
 }
 

--- a/vendor/github.com/containers/image/v5/signature/policy_config.go
+++ b/vendor/github.com/containers/image/v5/signature/policy_config.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/homedir"
-	perrors "github.com/pkg/errors"
 )
 
 // systemDefaultPolicyPath is the policy path used for DefaultPolicy().
@@ -83,7 +82,7 @@ func NewPolicyFromFile(fileName string) (*Policy, error) {
 	}
 	policy, err := NewPolicyFromBytes(contents)
 	if err != nil {
-		return nil, perrors.Wrapf(err, "invalid policy in %q", fileName)
+		return nil, fmt.Errorf("invalid policy in %q: %w", fileName, err)
 	}
 	return policy, nil
 }
@@ -316,12 +315,22 @@ func (pr *prReject) UnmarshalJSON(data []byte) error {
 }
 
 // newPRSignedBy returns a new prSignedBy if parameters are valid.
-func newPRSignedBy(keyType sbKeyType, keyPath string, keyData []byte, signedIdentity PolicyReferenceMatch) (*prSignedBy, error) {
+func newPRSignedBy(keyType sbKeyType, keyPath string, keyPaths []string, keyData []byte, signedIdentity PolicyReferenceMatch) (*prSignedBy, error) {
 	if !keyType.IsValid() {
 		return nil, InvalidPolicyFormatError(fmt.Sprintf("invalid keyType \"%s\"", keyType))
 	}
-	if len(keyPath) > 0 && len(keyData) > 0 {
-		return nil, InvalidPolicyFormatError("keyType and keyData cannot be used simultaneously")
+	keySources := 0
+	if keyPath != "" {
+		keySources++
+	}
+	if keyPaths != nil {
+		keySources++
+	}
+	if keyData != nil {
+		keySources++
+	}
+	if keySources != 1 {
+		return nil, InvalidPolicyFormatError("exactly one of keyPath, keyPaths and keyData must be specified")
 	}
 	if signedIdentity == nil {
 		return nil, InvalidPolicyFormatError("signedIdentity not specified")
@@ -330,6 +339,7 @@ func newPRSignedBy(keyType sbKeyType, keyPath string, keyData []byte, signedIden
 		prCommon:       prCommon{Type: prTypeSignedBy},
 		KeyType:        keyType,
 		KeyPath:        keyPath,
+		KeyPaths:       keyPaths,
 		KeyData:        keyData,
 		SignedIdentity: signedIdentity,
 	}, nil
@@ -337,7 +347,7 @@ func newPRSignedBy(keyType sbKeyType, keyPath string, keyData []byte, signedIden
 
 // newPRSignedByKeyPath is NewPRSignedByKeyPath, except it returns the private type.
 func newPRSignedByKeyPath(keyType sbKeyType, keyPath string, signedIdentity PolicyReferenceMatch) (*prSignedBy, error) {
-	return newPRSignedBy(keyType, keyPath, nil, signedIdentity)
+	return newPRSignedBy(keyType, keyPath, nil, nil, signedIdentity)
 }
 
 // NewPRSignedByKeyPath returns a new "signedBy" PolicyRequirement using a KeyPath
@@ -345,9 +355,19 @@ func NewPRSignedByKeyPath(keyType sbKeyType, keyPath string, signedIdentity Poli
 	return newPRSignedByKeyPath(keyType, keyPath, signedIdentity)
 }
 
+// newPRSignedByKeyPaths is NewPRSignedByKeyPaths, except it returns the private type.
+func newPRSignedByKeyPaths(keyType sbKeyType, keyPaths []string, signedIdentity PolicyReferenceMatch) (*prSignedBy, error) {
+	return newPRSignedBy(keyType, "", keyPaths, nil, signedIdentity)
+}
+
+// NewPRSignedByKeyPaths returns a new "signedBy" PolicyRequirement using KeyPaths
+func NewPRSignedByKeyPaths(keyType sbKeyType, keyPaths []string, signedIdentity PolicyReferenceMatch) (PolicyRequirement, error) {
+	return newPRSignedByKeyPaths(keyType, keyPaths, signedIdentity)
+}
+
 // newPRSignedByKeyData is NewPRSignedByKeyData, except it returns the private type.
 func newPRSignedByKeyData(keyType sbKeyType, keyData []byte, signedIdentity PolicyReferenceMatch) (*prSignedBy, error) {
-	return newPRSignedBy(keyType, "", keyData, signedIdentity)
+	return newPRSignedBy(keyType, "", nil, keyData, signedIdentity)
 }
 
 // NewPRSignedByKeyData returns a new "signedBy" PolicyRequirement using a KeyData
@@ -362,7 +382,7 @@ var _ json.Unmarshaler = (*prSignedBy)(nil)
 func (pr *prSignedBy) UnmarshalJSON(data []byte) error {
 	*pr = prSignedBy{}
 	var tmp prSignedBy
-	var gotKeyPath, gotKeyData = false, false
+	var gotKeyPath, gotKeyPaths, gotKeyData = false, false, false
 	var signedIdentity json.RawMessage
 	if err := internal.ParanoidUnmarshalJSONObject(data, func(key string) interface{} {
 		switch key {
@@ -373,6 +393,9 @@ func (pr *prSignedBy) UnmarshalJSON(data []byte) error {
 		case "keyPath":
 			gotKeyPath = true
 			return &tmp.KeyPath
+		case "keyPaths":
+			gotKeyPaths = true
+			return &tmp.KeyPaths
 		case "keyData":
 			gotKeyData = true
 			return &tmp.KeyData
@@ -401,16 +424,16 @@ func (pr *prSignedBy) UnmarshalJSON(data []byte) error {
 	var res *prSignedBy
 	var err error
 	switch {
-	case gotKeyPath && gotKeyData:
-		return InvalidPolicyFormatError("keyPath and keyData cannot be used simultaneously")
-	case gotKeyPath && !gotKeyData:
+	case gotKeyPath && !gotKeyPaths && !gotKeyData:
 		res, err = newPRSignedByKeyPath(tmp.KeyType, tmp.KeyPath, tmp.SignedIdentity)
-	case !gotKeyPath && gotKeyData:
+	case !gotKeyPath && gotKeyPaths && !gotKeyData:
+		res, err = newPRSignedByKeyPaths(tmp.KeyType, tmp.KeyPaths, tmp.SignedIdentity)
+	case !gotKeyPath && !gotKeyPaths && gotKeyData:
 		res, err = newPRSignedByKeyData(tmp.KeyType, tmp.KeyData, tmp.SignedIdentity)
-	case !gotKeyPath && !gotKeyData:
-		return InvalidPolicyFormatError("At least one of keyPath and keyData mus be specified")
-	default: // Coverage: This should never happen
-		return fmt.Errorf("Impossible keyPath/keyData presence combination!?")
+	case !gotKeyPath && !gotKeyPaths && !gotKeyData:
+		return InvalidPolicyFormatError("Exactly one of keyPath, keyPaths and keyData must be specified, none of them present")
+	default:
+		return fmt.Errorf("Exactly one of keyPath, keyPaths and keyData must be specified, more than one present")
 	}
 	if err != nil {
 		return err
@@ -582,7 +605,7 @@ func (pr *prSigstoreSigned) UnmarshalJSON(data []byte) error {
 	case !gotKeyPath && gotKeyData:
 		res, err = newPRSigstoreSignedKeyData(tmp.KeyData, tmp.SignedIdentity)
 	case !gotKeyPath && !gotKeyData:
-		return InvalidPolicyFormatError("At least one of keyPath and keyData mus be specified")
+		return InvalidPolicyFormatError("At least one of keyPath and keyData must be specified")
 	default: // Coverage: This should never happen
 		return fmt.Errorf("Impossible keyPath/keyData presence combination!?")
 	}

--- a/vendor/github.com/containers/image/v5/signature/policy_types.go
+++ b/vendor/github.com/containers/image/v5/signature/policy_types.go
@@ -67,14 +67,16 @@ type prReject struct {
 type prSignedBy struct {
 	prCommon
 
-	// KeyType specifies what kind of key reference KeyPath/KeyData is.
+	// KeyType specifies what kind of key reference KeyPath/KeyPaths/KeyData is.
 	// Acceptable values are “GPGKeys” | “signedByGPGKeys” “X.509Certificates” | “signedByX.509CAs”
 	// FIXME: eventually also support GPGTOFU, X.509TOFU, with KeyPath only
 	KeyType sbKeyType `json:"keyType"`
 
-	// KeyPath is a pathname to a local file containing the trusted key(s). Exactly one of KeyPath and KeyData must be specified.
+	// KeyPath is a pathname to a local file containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyPath string `json:"keyPath,omitempty"`
-	// KeyData contains the trusted key(s), base64-encoded. Exactly one of KeyPath and KeyData must be specified.
+	// KeyPaths if a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
+	KeyPaths []string `json:"keyPaths,omitempty"`
+	// KeyData contains the trusted key(s), base64-encoded. Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyData []byte `json:"keyData,omitempty"`
 
 	// SignedIdentity specifies what image identity the signature must be claiming about the image.

--- a/vendor/github.com/containers/image/v5/storage/storage_reference.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_reference.go
@@ -5,6 +5,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	digest "github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,11 +31,11 @@ func newReference(transport storageTransport, named reference.Named, id string) 
 		return nil, ErrInvalidReference
 	}
 	if named != nil && reference.IsNameOnly(named) {
-		return nil, perrors.Wrapf(ErrInvalidReference, "reference %s has neither a tag nor a digest", named.String())
+		return nil, fmt.Errorf("reference %s has neither a tag nor a digest: %w", named.String(), ErrInvalidReference)
 	}
 	if id != "" {
 		if err := validateImageID(id); err != nil {
-			return nil, perrors.Wrapf(ErrInvalidReference, "invalid ID value %q: %v", id, err)
+			return nil, fmt.Errorf("invalid ID value %q: %v: %w", id, err, ErrInvalidReference)
 		}
 	}
 	// We take a copy of the transport, which contains a pointer to the
@@ -145,12 +145,12 @@ func (s *storageReference) resolveImage(sys *types.SystemContext) (*storage.Imag
 	}
 	if s.id == "" {
 		logrus.Debugf("reference %q does not resolve to an image ID", s.StringWithinTransport())
-		return nil, perrors.Wrapf(ErrNoSuchImage, "reference %q does not resolve to an image ID", s.StringWithinTransport())
+		return nil, fmt.Errorf("reference %q does not resolve to an image ID: %w", s.StringWithinTransport(), ErrNoSuchImage)
 	}
 	if loadedImage == nil {
 		img, err := s.transport.store.Image(s.id)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "reading image %q", s.id)
+			return nil, fmt.Errorf("reading image %q: %w", s.id, err)
 		}
 		loadedImage = img
 	}

--- a/vendor/github.com/containers/image/v5/storage/storage_transport.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_transport.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	digest "github.com/opencontainers/go-digest"
-	perrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -118,13 +117,13 @@ func (s *storageTransport) DefaultGIDMap() []idtools.IDMap {
 // relative to the given store, and returns it in a reference object.
 func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (*storageReference, error) {
 	if ref == "" {
-		return nil, perrors.Wrapf(ErrInvalidReference, "%q is an empty reference", ref)
+		return nil, fmt.Errorf("%q is an empty reference: %w", ref, ErrInvalidReference)
 	}
 	if ref[0] == '[' {
 		// Ignore the store specifier.
 		closeIndex := strings.IndexRune(ref, ']')
 		if closeIndex < 1 {
-			return nil, perrors.Wrapf(ErrInvalidReference, "store specifier in %q did not end", ref)
+			return nil, fmt.Errorf("store specifier in %q did not end: %w", ref, ErrInvalidReference)
 		}
 		ref = ref[closeIndex+1:]
 	}
@@ -136,7 +135,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 	if split != -1 {
 		possibleID := ref[split+1:]
 		if possibleID == "" {
-			return nil, perrors.Wrapf(ErrInvalidReference, "empty trailing digest or ID in %q", ref)
+			return nil, fmt.Errorf("empty trailing digest or ID in %q: %w", ref, ErrInvalidReference)
 		}
 		// If it looks like a digest, leave it alone for now.
 		if _, err := digest.Parse(possibleID); err != nil {
@@ -148,7 +147,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 				// so we might as well use the expanded value.
 				id = img.ID
 			} else {
-				return nil, perrors.Wrapf(ErrInvalidReference, "%q does not look like an image ID or digest", possibleID)
+				return nil, fmt.Errorf("%q does not look like an image ID or digest: %w", possibleID, ErrInvalidReference)
 			}
 			// We have recognized an image ID; peel it off.
 			ref = ref[:split]
@@ -174,7 +173,7 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		var err error
 		named, err = reference.ParseNormalizedNamed(ref)
 		if err != nil {
-			return nil, perrors.Wrapf(err, "parsing named reference %q", ref)
+			return nil, fmt.Errorf("parsing named reference %q: %w", ref, err)
 		}
 		named = reference.TagNameOnly(named)
 	}

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 21
+	VersionMinor = 22
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/containers/common/pkg/flag
 github.com/containers/common/pkg/report
 github.com/containers/common/pkg/report/camelcase
 github.com/containers/common/pkg/retry
-# github.com/containers/image/v5 v5.21.2-0.20220712113758-29aec5f7bbbf
+# github.com/containers/image/v5 v5.22.0
 ## explicit; go 1.17
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory
@@ -436,8 +436,8 @@ github.com/syndtr/gocapability/capability
 # github.com/tchap/go-patricia v2.3.0+incompatible
 ## explicit
 github.com/tchap/go-patricia/patricia
-# github.com/theupdateframework/go-tuf v0.3.0
-## explicit; go 1.16
+# github.com/theupdateframework/go-tuf v0.3.1
+## explicit; go 1.18
 github.com/theupdateframework/go-tuf/encrypted
 # github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
 ## explicit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -52,8 +52,8 @@ github.com/containerd/cgroups/stats/v1
 ## explicit; go 1.16
 github.com/containerd/stargz-snapshotter/estargz
 github.com/containerd/stargz-snapshotter/estargz/errorutil
-# github.com/containers/common v0.48.0
-## explicit; go 1.16
+# github.com/containers/common v0.49.0
+## explicit; go 1.17
 github.com/containers/common/pkg/auth
 github.com/containers/common/pkg/capabilities
 github.com/containers/common/pkg/completion
@@ -481,6 +481,8 @@ go.opencensus.io/internal
 go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
+# go.opentelemetry.io/otel/trace v1.3.0
+## explicit; go 1.16
 # golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838
 ## explicit; go 1.17
 golang.org/x/crypto/cast5


### PR DESCRIPTION
… and update for c/common/pkg/retry API migration.

(Introduces `policy.json` `signedBy.keyPaths`.)

@rhatdan PTAL. A separate release-tagging PR to follow.