### PR TITLE
[CI:BUILD] Optimize upstream skopeo container image build

### DIFF
--- a/contrib/skopeoimage/upstream/Containerfile
+++ b/contrib/skopeoimage/upstream/Containerfile
@@ -16,27 +16,11 @@ FROM registry.fedoraproject.org/fedora:latest
 #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
 RUN dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
-    dnf -y --enablerepo updates-testing --exclude container-selinux install \
-        make \
-        golang \
-        git \
-        go-md2man \
-        fuse-overlayfs \
-        fuse3 \
-        containers-common \
-        gpgme-devel \
-        libassuan-devel \
-        btrfs-progs-devel \
-        device-mapper-devel && \
-    mkdir /root/skopeo && \
-    git clone https://github.com/containers/skopeo \
-        /root/skopeo/src/github.com/containers/skopeo && \
-    export GOPATH=/root/skopeo && \
-    cd /root/skopeo/src/github.com/containers/skopeo && \
-    make bin/skopeo && \
-    make PREFIX=/usr install && \
-    rm -rf /root/skopeo/* && \
-    dnf -y remove git golang go-md2man make && \
+    dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
+    dnf -y copr enable rhcontainerbot/podman-next && \
+    dnf -y install skopeo \
+        --exclude container-selinux \
+        --enablerepo=updates-testing && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 


### PR DESCRIPTION
Running cross-platform compiles using emulation is a painfully
slow process.  Since CI-runtime is limited, improve image build time
by leveraging the automatic RPM builds occurring for the podman-next
COPR repo.  This adds build-time efficiency by offloading the
compilation task.  Note: These RPMs are built any time the 'main'
branch changes, so they'll still be very recent.

https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/