### PR TITLE
Fix building with Go 1.19

### DIFF
--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -30,11 +30,11 @@ type errorShouldDisplayUsage struct {
 // The error for closeErr is annotated with description (which is not a format string)
 // Typical usage:
 //
-// defer func() {
-//     if err := something.Close(); err != nil {
-//         returnedErr = noteCloseFailure(returnedErr, "closing something", err)
-//     }
-// }
+//	defer func() {
+//		if err := something.Close(); err != nil {
+//			returnedErr = noteCloseFailure(returnedErr, "closing something", err)
+//		}
+//	}
 func noteCloseFailure(err error, description string, closeErr error) error {
 	// We don’t accept a Closer() and close it ourselves because signature.PolicyContext has .Destroy(), not .Close().
 	// This also makes it harder for a caller to do

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -34,7 +34,7 @@ if [[ "$SKOPEO_CONTAINER_TESTS" == "0" ]] && [[ "$CI" != "true" ]]; then
     echo "         the Makefile targets WITHOUT the '-local' suffix."
     echo "***************************************************************"
     ) > /dev/stderr
-    sleep 5s
+    sleep 5
 fi
 
 echo

--- a/integration/openshift_shell_test.go
+++ b/integration/openshift_shell_test.go
@@ -15,11 +15,15 @@ TestRunShell is not really a test; it is a convenient way to use the registry se
 in openshift.go and CopySuite to get an interactive environment for experimentation.
 
 To use it, run:
+
 	sudo make shell
+
 to start a container, then within the container:
+
 	SKOPEO_CONTAINER_TESTS=1 PS1='nested> ' go test -tags openshift_shell -timeout=24h ./integration -v -check.v -check.vv -check.f='CopySuite.TestRunShell'
 
 An example of what can be done within the container:
+
 	cd ..; make bin/skopeo PREFIX=/usr install
 	./skopeo --tls-verify=false  copy --sign-by=personal@example.com docker://quay.io/libpod/busybox:latest atomic:localhost:5000/myns/personal:personal
 	oc get istag personal:personal -o json


### PR DESCRIPTION
This is primarily `gofmt` updates (the minimal version, not a full review to benefit from the new syntax).

Let’s see if the current version’s formatters accept the outcome…