### PR TITLE
Pin Go to 1.18

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,12 +87,13 @@ osx_task:
     macos_instance:
         image: catalina-xcode
     setup_script: |
-        export PATH=$GOPATH/bin:$PATH
+        # /usr/local/opt/go@1.18 will be populated by (brew install go@1.18) below
+        export PATH=$GOPATH/bin:/usr/local/opt/go@1.18/bin:$PATH
         brew update
-        brew install gpgme go go-md2man
+        brew install gpgme go@1.18 go-md2man
         go install golang.org/x/lint/golint@latest
     test_script: |
-        export PATH=$GOPATH/bin:$PATH
+        export PATH=$GOPATH/bin:/usr/local/opt/go@1.18/bin:$PATH
         go version
         go env
         make validate-local test-unit-local bin/skopeo


### PR DESCRIPTION
1.19 has changed the expected gofmt format, and we don't want to follow such changes on the stable branch.

`go@1.18` is "keg-only", i.e. not installed by Brew to `/usr/local/bin`, so we need to change `PATH` to point at it (as the installation instructs us to).

---

This is based on commit 1b6d7f79a521bdcf5947f14363211d3d3ca92c99 from the 1.4 branch.