### PR TITLE
Workaround GNU Make 4.2.1 incorrectly executing shell commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,14 @@ GOBIN := $(GOPATH)/bin
 endif
 
 # Scripts may also use CONTAINER_RUNTIME, so we need to export it.
-# N/B: Need to use 'command -v' here for compatibility with MacOS.
-export CONTAINER_RUNTIME ?= $(if $(shell command -v podman),podman,docker)
-GOMD2MAN ?= $(if $(shell command -v go-md2man),go-md2man,$(GOBIN)/go-md2man)
+# Note possibly non-obvious aspects of this:
+# - We need to use 'command -v' here, not 'which', for compatibility with MacOS.
+# - GNU Make 4.2.1 (included in Ubuntu 20.04) incorrectly tries to avoid invoking
+#   a shell, and fails because there is no /usr/bin/command. The trailing ';' in
+#   $(shell … ;) defeats that heuristic (recommended in
+#   https://savannah.gnu.org/bugs/index.php?57625 ).
+export CONTAINER_RUNTIME ?= $(if $(shell command -v podman ;),podman,docker)
+GOMD2MAN ?= $(if $(shell command -v go-md2man ;),go-md2man,$(GOBIN)/go-md2man)
 
 # Go module support: set `-mod=vendor` to use the vendored sources.
 # See also hack/make.sh.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq ($(GOBIN),)
 GOBIN := $(GOPATH)/bin
 endif
 
-# Multiple scripts are sensitive to this value, make sure it's exported/available
+# Scripts may also use CONTAINER_RUNTIME, so we need to export it.
 # N/B: Need to use 'command -v' here for compatibility with MacOS.
 export CONTAINER_RUNTIME ?= $(if $(shell command -v podman),podman,docker)
 GOMD2MAN ?= $(if $(shell command -v go-md2man),go-md2man,$(GOBIN)/go-md2man)


### PR DESCRIPTION
Fix looking for commands with GNU make 4.2.1
    
Before https://git.savannah.gnu.org/cgit/make.git/commit/job.c?h=4.3&id=1af314465e5dfe3e8baa839a32a72e83c04f26ef , `make` was incorrectly trying to avoid running a shell for `command -v`.  Use the workaround recommended in https://savannah.gnu.org/bugs/index.php?57625 .

Fixes one half of (the reported problems in) #1584.

Compare #1730 .