### PR TITLE
Talk about "registry repositories" in (skopeo sync) documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Please read the [contribution guide](CONTRIBUTING.md) if you want to collaborate
 | [skopeo-manifest-digest(1)](/docs/skopeo-manifest-digest.1.md)    | Compute a manifest digest for a manifest-file and write it to standard output.   |
 | [skopeo-standalone-sign(1)](/docs/skopeo-standalone-sign.1.md)    | Debugging tool - Publish and sign an image in one step.                                                         |
 | [skopeo-standalone-verify(1)](/docs/skopeo-standalone-verify.1.md)| Verify an image signature.                                                    |
-| [skopeo-sync(1)](/docs/skopeo-sync.1.md)           | Synchronize images between container registries and local directories.                       |
+| [skopeo-sync(1)](/docs/skopeo-sync.1.md)           | Synchronize images between registry repositories and local directories.                      |
 
 License
 -

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -1,14 +1,14 @@
 % skopeo-sync(1)
 
 ## NAME
-skopeo\-sync - Synchronize images between container registries and local directories.
+skopeo\-sync - Synchronize images between registry repositories and local directories.
 
 
 ## SYNOPSIS
 **skopeo sync** [*options*] --src _transport_ --dest _transport_ _source_ _destination_
 
 ## DESCRIPTION
-Synchronize images between container registries and local directories.
+Synchronize images between registry repoositories and local directories.
 The synchronization is achieved by copying all the images found at _source_ to _destination_.
 
 Useful to synchronize a local container registry mirror, and to to populate registries running inside of air-gapped environments.

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -108,7 +108,7 @@ Print the version number
 | [skopeo-manifest-digest(1)](skopeo-manifest-digest.1.md)    | Compute a manifest digest for a manifest-file and write it to standard output. |
 | [skopeo-standalone-sign(1)](skopeo-standalone-sign.1.md)    | Debugging tool - Publish and sign an image in one step.      |
 | [skopeo-standalone-verify(1)](skopeo-standalone-verify.1.md)| Verify an image signature.                                   |
-| [skopeo-sync(1)](skopeo-sync.1.md)| Synchronize images between container registries and local directories.                 |
+| [skopeo-sync(1)](skopeo-sync.1.md)| Synchronize images between registry repositories and local directories.                |
 
 ## FILES
   **/etc/containers/policy.json**


### PR DESCRIPTION
- We don't sync complete registries.
- This should still refer to the remote registry servers.

This is a proposed replacement for #1706 .