### PR TITLE
Don't include git commit from a parent directory in the --version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ endif
 CONTAINER_GOSRC = /src/github.com/containers/skopeo
 CONTAINER_RUN ?= $(CONTAINER_CMD) --security-opt label=disable -v $(CURDIR):$(CONTAINER_GOSRC) -w $(CONTAINER_GOSRC) $(SKOPEO_CIDEV_CONTAINER_FQIN)
 
-GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || true)
+GIT_COMMIT := $(shell GIT_CEILING_DIRECTORIES=$$(cd ..; pwd) git rev-parse HEAD 2> /dev/null || true)
 
 EXTRA_LDFLAGS ?=
 SKOPEO_LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} $(EXTRA_LDFLAGS)'

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,6 @@ ifeq ($(GOOS), linux)
   endif
 endif
 
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-
 # If $TESTFLAGS is set, it is passed as extra arguments to 'go test'.
 # You can increase test output verbosity with the option '-test.vv'.
 # You can select certain tests to run, with `-test.run <regex>` for example:


### PR DESCRIPTION
Fixes #1707.

See individual commit messages for details.