### PR TITLE
Don't abort sync if the registry returns invalid tags

### DIFF
--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -244,7 +244,11 @@ func imagesToCopyFromRepo(sys *types.SystemContext, repoRef reference.Named) ([]
 	for _, tag := range tags {
 		taggedRef, err := reference.WithTag(repoRef, tag)
 		if err != nil {
-			return nil, fmt.Errorf("Error creating a reference for repository %s and tag %q: %w", repoRef.Name(), tag, err)
+			logrus.WithFields(logrus.Fields{
+				"repo": repoRef.Name(),
+				"tag":  tag,
+			}).Errorf("Error creating a tagged reference from registry tag list: %v", err)
+			continue
 		}
 		ref, err := docker.NewReference(taggedRef)
 		if err != nil {


### PR DESCRIPTION
The user is not very likely to be able to do anything about that, and we have no other way to read those images - so just skip them; we already skip image copies in much more directly user-caused situations, including invalid user-provided strings.

Fixes #1740, hopefully (untested).