### PR TITLE
default.yaml should have all options commented

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -13,7 +13,7 @@
 # This is the default signature write location for docker registries.
 default-docker:
 #  lookaside: file:///var/lib/containers/sigstore
-  lookaside-staging: file:///var/lib/containers/sigstore
+#  lookaside-staging: file:///var/lib/containers/sigstore
 
 # The 'docker' indicator here is the start of the configuration
 # for docker registries.


### PR DESCRIPTION
Rely on the hard coded defaults in libraries rather then overriding in the yaml file.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>