### PR TITLE
Release v1.10.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.9.3-dev"
+const Version = "1.10.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.10.0"
+const Version = "1.10.1-dev"


### PR DESCRIPTION
`skopeo inspect` now provides more information about individual layers.

The default `/etc/containers/registries.d/default.yaml` now has all entries commented-out, to use built-in defaults; that can change the default for `lookaside-staging` to use an unprivileged users’ home directory instead of a path in `/var/`.

-  GHA: Re-use identical workflow from buildah repo
-  Optimize upstream skopeo container image build
-  Fix running tests on macOS
-  Reformat with Go 1.19's gofmt
-  Fix a comment
-  Fix looking for commands with GNU make 4.2.1
-  Talk about "registry repositories" in (skopeo sync) documentation
-  Point at --all in the --preserve-digests option documentation
-  Remove unused GIT_BRANCH definition
-  Don't include git commit from a parent directory in the --version output
-  Update for c/image's update of github.com/gobuffalo/pop
-  Merge pull request https://github.com/containers/skopeo/pull/1737 from mtrmac/pop-v5-override
-  Stop using docker/docker/pkg/homedir in tests
-  add inspect layersData
-  Don't abort sync if the registry returns invalid tags
-  warn users about --dest-compress and --dest-decompress misuse
-  document imageDestOptions.warnAboutIneffectiveOptions()
-  warn about ineffective destination opts in sync cmd
-  default.yaml should have all options commented
-  Fix documentation in the default registries.d content.
-  [CI:DOCS] Add quay-description update reminder
-  Revert addition of -compat=1.17 to (go mod tidy)
-  Update for https://github.com/klauspost/pgzip/pull/50