### PR TITLE
Adds `--append-suffix` flag to sync command

### DIFF
--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -46,6 +46,7 @@ type syncOptions struct {
 	dryRun                   bool                      // Don't actually copy anything, just output what it would have done
 	preserveDigests          bool                      // Preserve digests during sync
 	keepGoing                bool                      // Whether or not to abort the sync if there are any errors during syncing the images
+	appendSuffix             string                    // Suffix to append to destination image tag
 }
 
 // repoDescriptor contains information of a single repository used as a sync source.
@@ -112,6 +113,7 @@ See skopeo-sync(1) for details.
 	flags.StringVarP(&opts.source, "src", "s", "", "SOURCE transport type")
 	flags.StringVarP(&opts.destination, "dest", "d", "", "DESTINATION transport type")
 	flags.BoolVar(&opts.scoped, "scoped", false, "Images at DESTINATION are prefix using the full source image path as scope")
+	flags.StringVar(&opts.appendSuffix, "append-suffix", "", "String to append to DESTINATION tags")
 	flags.BoolVarP(&opts.all, "all", "a", false, "Copy all images if SOURCE-IMAGE is a list")
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "Run without actually copying data")
 	flags.BoolVar(&opts.preserveDigests, "preserve-digests", false, "Preserve digests of images and lists")
@@ -642,7 +644,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 				destSuffix = path.Base(destSuffix)
 			}
 
-			destRef, err := destinationReference(path.Join(destination, destSuffix), opts.destination)
+			destRef, err := destinationReference(path.Join(destination, destSuffix)+opts.appendSuffix, opts.destination)
 			if err != nil {
 				return err
 			}

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -66,7 +66,7 @@ Print usage statement.
 
 **--scoped** Prefix images with the source image path, so that multiple images with the same name can be stored at _destination_.
 
-**--append-suffix** _tag-suffix_ String to append to destination tags
+**--append-suffix** _tag-suffix_ String to append to destination tags.
 
 **--preserve-digests** Preserve the digests during copying. Fail if the digest cannot be preserved. Consider using `--all` at the same time.
 
@@ -186,6 +186,16 @@ Destination registry content:
 ```
 REPO                              TAGS
 registry.local.lan/repo/busybox   1-glibc, 1-musl, 1-ubuntu, ..., latest
+```
+
+### Synchronizing to a container registry with tag suffix
+```
+skopeo sync --src docker --dest docker --append-suffix '-mirror' registry.example.com/busybox my-registry.local.lan
+```
+Destination registry content:
+```
+REPO                         TAGS
+registry.local.lan/busybox   1-glibc-mirror, 1-musl-mirror, 1-ubuntu-mirror, ..., latest-mirror
 ```
 
 ### YAML file content (used _source_ for `**--src yaml**`)

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -66,6 +66,8 @@ Print usage statement.
 
 **--scoped** Prefix images with the source image path, so that multiple images with the same name can be stored at _destination_.
 
+**--append-suffix** _tag-suffix_ String to append to destination tags
+
 **--preserve-digests** Preserve the digests during copying. Fail if the digest cannot be preserved. Consider using `--all` at the same time.
 
 **--remove-signatures** Do not copy signatures, if any, from _source-image_. This is necessary when copying a signed image to a destination which does not support signatures.


### PR DESCRIPTION
Adds the option to append the sync timestamp to the destination image tag. 

This is useful for syncing source containers which have non-immutable tags to a destination which does have immutable tags, and allows a point-in-time view of the moving source tag.

For example - source `ubuntu:bionic` would be synced to `<host>/ubuntu:bionic-1664722433` with the `--append-timestamp` flag specified.