### PR TITLE
bump to v1.11.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.10.1-dev"
+const Version = "1.11.0-dev"


### PR DESCRIPTION
Given there is a release-1.10 branch, we should bump main to the next minor version.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>