### PR TITLE
Close a HTTP response body

### DIFF
--- a/integration/registry.go
+++ b/integration/registry.go
@@ -116,6 +116,7 @@ func (t *testRegistryV2) Ping() error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
 		return fmt.Errorf("registry ping replied with an unexpected status code %d", resp.StatusCode)
 	}


### PR DESCRIPTION
Fix a bug found by `golangci-lint run --enable-all ./...`