### PR TITLE
Cirrus: Add reverse-deps. test to verify proxy with ostree-rs-ext

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,6 +119,49 @@ cross_task:
         "${GOSRC}/${SCRIPT_BASE}/runner.sh" cross
 
 
+ostree-rs-ext_task:
+    alias: proxy_ostree_ext
+    # Don't run for docs-only or multi-arch image builds.
+    # Also don't run on release-branches or their PRs,
+    # since base container-image is not version-constrained.
+    only_if: &not_docs_or_release_branch >-
+        ($CIRRUS_BASE_BRANCH == $CIRRUS_DEFAULT_BRANCH ||
+         $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH ) &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CRON != 'multiarch'
+    # WARNING: This task potentially performs a container image
+    # build (on change) with runtime package installs.  Therefore,
+    # its behavior can be unpredictable and potentially flake-prone.
+    # In case of emergency, uncomment the next statement to bypass.
+    #
+    # skip: $CI == "true"
+    #
+    depends_on:
+        - validate
+    # Ref: https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
+    container:
+        # The runtime image will be rebuilt on change
+        dockerfile: contrib/cirrus/ostree_ext.dockerfile
+        docker_arguments:  # required build-args
+            BASE_FQIN: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+            CIRRUS_IMAGE_VERSION: 1
+    env:
+        EXT_REPO_NAME: ostree-rs-ext
+        EXT_REPO_HOME: $CIRRUS_WORKING_DIR/../$EXT_REPO_NAME
+        EXT_REPO: https://github.com/ostreedev/${EXT_REPO_NAME}.git
+    skopeo_build_script:
+        - dnf builddep -y skopeo
+        - make
+        - make install
+    proxy_ostree_ext_build_script:
+        - git clone --depth 1 $EXT_REPO $EXT_REPO_HOME
+        - cd $EXT_REPO_HOME
+        - cargo test --no-run
+    proxy_ostree_ext_test_script:
+        - cd $EXT_REPO_HOME
+        - cargo test -- --nocapture --quiet
+
+
 #####
 ##### NOTE: This task is subtantially duplicated in the containers/image
 ##### repository's `.cirrus.yml`.  Changes made here should be fully merged
@@ -242,6 +285,7 @@ success_task:
         - doccheck
         - osx
         - cross
+        - proxy_ostree_ext
         - test_skopeo
         - image_build
         - meta

--- a/contrib/cirrus/ostree_ext.dockerfile
+++ b/contrib/cirrus/ostree_ext.dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_FQIN=quay.io/coreos-assembler/fcos-buildroot:testing-devel
+FROM $BASE_FQIN
+
+# See 'Danger of using COPY and ADD instructions'
+# at https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
+# Provide easy way to force-invalidate image cache by .cirrus.yml change
+ARG CIRRUS_IMAGE_VERSION
+ENV CIRRUS_IMAGE_VERSION=$CIRRUS_IMAGE_VERSION
+ADD https://sh.rustup.rs /var/tmp/rustup_installer.sh
+
+RUN dnf erase -y rust && \
+    chmod +x /var/tmp/rustup_installer.sh && \
+    /var/tmp/rustup_installer.sh -y --default-toolchain stable --profile minimal
+
+ENV PATH=/root/.cargo/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
This does reverse-dependency testing, verifying `proxy.go` using the ostree-rs-ext Rust code's unit tests.

Based on #1781 by @cgwalters

Signed-off-by: Chris Evich <cevich@redhat.com>