### PR TITLE
[CI:BUILD] Cirrus: Migrate OSX task to M1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,7 +82,7 @@ osx_task:
     depends_on:
         - validate
     macos_instance:
-        image: catalina-xcode
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
     setup_script: |
         export PATH=$GOPATH/bin:$PATH
         brew update


### PR DESCRIPTION
Migrate our OSX build to a M1 instance, since Cirrus is sunsetting Intel-based macOS instances.

Signed-off-by: Ashley Cui <acui@redhat.com>