### PR TITLE
README: Update example to show newly exposed LayerData

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,29 +56,37 @@ Examples:
 $ skopeo inspect docker://registry.fedoraproject.org/fedora:latest
 {
     "Name": "registry.fedoraproject.org/fedora",
-    "Digest": "sha256:655721ff613ee766a4126cb5e0d5ae81598e1b0c3bcf7017c36c4d72cb092fe9",
+    "Digest": "sha256:0f65bee641e821f8118acafb44c2f8fe30c2fc6b9a2b3729c0660376391aa117",
     "RepoTags": [
-        "24",
-        "25",
-        "26-modular",
-	...
+        "34-aarch64",
+        "34",
+        "latest",
+        ...
     ],
-    "Created": "2020-04-29T06:48:16Z",
+    "Created": "2022-11-24T13:54:18Z",
     "DockerVersion": "1.10.1",
     "Labels": {
         "license": "MIT",
         "name": "fedora",
         "vendor": "Fedora Project",
-        "version": "32"
+        "version": "37"
     },
     "Architecture": "amd64",
     "Os": "linux",
     "Layers": [
-        "sha256:3088721d7dbf674fc0be64cd3cf00c25aab921cacf35fa0e7b1578500a3e1653"
+        "sha256:2a0fc6bf62e155737f0ace6142ee686f3c471c1aab4241dc3128904db46288f0"
+    ],
+    "LayersData": [
+        {
+            "MIMEType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "Digest": "sha256:2a0fc6bf62e155737f0ace6142ee686f3c471c1aab4241dc3128904db46288f0",
+            "Size": 71355009,
+            "Annotations": null
+        }
     ],
     "Env": [
-        "DISTTAG=f32container",
-        "FGC=f32",
+        "DISTTAG=f37container",
+        "FGC=f37",
         "container=oci"
     ]
 }

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -89,26 +89,38 @@ Do not list the available tags from the repository in the output. When `true`, t
 To review information for the image fedora from the docker.io registry:
 ```sh
 $ skopeo inspect docker://docker.io/fedora
+
 {
     "Name": "docker.io/library/fedora",
-    "Digest": "sha256:a97914edb6ba15deb5c5acf87bd6bd5b6b0408c96f48a5cbd450b5b04509bb7d",
+    "Digest": "sha256:f99efcddc4dd6736d8a88cc1ab6722098ec1d77dbf7aed9a7a514fc997ca08e0",
     "RepoTags": [
-	"20",
-	"21",
-	"22",
-	"23",
-	"24",
-	"heisenbug",
-	"latest",
-	"rawhide"
+        "20",
+        "21",
+        "..."
     ],
-    "Created": "2016-06-20T19:33:43.220526898Z",
-    "DockerVersion": "1.10.3",
-    "Labels": {},
+    "Created": "2022-11-16T07:26:42.618327645Z",
+    "DockerVersion": "20.10.12",
+    "Labels": {
+        "maintainer": "Clement Verna \u003ccverna@fedoraproject.org\u003e"
+    },
     "Architecture": "amd64",
     "Os": "linux",
     "Layers": [
-	"sha256:7c91a140e7a1025c3bc3aace4c80c0d9933ac4ee24b8630a6b0b5d8b9ce6b9d4"
+        "sha256:cb8b1ed77979b894115a983f391465651aa7eb3edd036be4b508eea47271eb93"
+    ],
+    "LayersData": [
+        {
+            "MIMEType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "Digest": "sha256:cb8b1ed77979b894115a983f391465651aa7eb3edd036be4b508eea47271eb93",
+            "Size": 65990920,
+            "Annotations": null
+        }
+    ],
+    "Env": [
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "DISTTAG=f37container",
+        "FGC=f37",
+        "FBR=f37"
     ]
 }
 ```
@@ -118,33 +130,37 @@ To inspect python from the docker.io registry and not show the available tags:
 $ skopeo inspect --no-tags docker://docker.io/library/python
 {
     "Name": "docker.io/library/python",
-    "Digest": "sha256:5ca194a80ddff913ea49c8154f38da66a41d2b73028c5cf7e46bc3c1d6fda572",
+    "Digest": "sha256:10fc14aa6ae69f69e4c953cffd9b0964843d8c163950491d2138af891377bc1d",
     "RepoTags": [],
-    "Created": "2021-10-05T23:40:54.936108045Z",
-    "DockerVersion": "20.10.7",
+    "Created": "2022-11-16T06:55:28.566254104Z",
+    "DockerVersion": "20.10.12",
     "Labels": null,
     "Architecture": "amd64",
     "Os": "linux",
     "Layers": [
-        "sha256:df5590a8898bedd76f02205dc8caa5cc9863267dbcd8aac038bcd212688c1cc7",
-        "sha256:705bb4cb554eb7751fd21a994f6f32aee582fbe5ea43037db6c43d321763992b",
-        "sha256:519df5fceacdeaadeec563397b1d9f4d7c29c9f6eff879739cab6f0c144f49e1",
-        "sha256:ccc287cbeddc96a0772397ca00ec85482a7b7f9a9fac643bfddd87b932f743db",
-        "sha256:e3f8e6af58ed3a502f0c3c15dce636d9d362a742eb5b67770d0cfcb72f3a9884",
-        "sha256:aebed27b2d86a5a3a2cbe186247911047a7e432b9d17daad8f226597c0ea4276",
-        "sha256:54c32182bdcc3041bf64077428467109a70115888d03f7757dcf614ff6d95ebe",
-        "sha256:cc8b7caedab13af07adf4836e13af2d4e9e54d794129b0fd4c83ece6b1112e86",
-        "sha256:462c3718af1d5cdc050cfba102d06c26f78fe3b738ce2ca2eb248034b1738945"
+        "sha256:a8ca11554fce00d9177da2d76307bdc06df7faeb84529755c648ac4886192ed1",
+        "sha256:e4e46864aba2e62ba7c75965e4aa33ec856ee1b1074dda6b478101c577b63abd",
+        "..."
+    ],
+    "LayersData": [
+        {
+            "MIMEType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "Digest": "sha256:a8ca11554fce00d9177da2d76307bdc06df7faeb84529755c648ac4886192ed1",
+            "Size": 55038615,
+            "Annotations": null
+        },
+        {
+            "MIMEType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "Digest": "sha256:e4e46864aba2e62ba7c75965e4aa33ec856ee1b1074dda6b478101c577b63abd",
+            "Size": 5164893,
+            "Annotations": null
+        },
+        "..."
     ],
     "Env": [
         "PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "LANG=C.UTF-8",
-        "GPG_KEY=A035C8C19219BA821ECEA86B64E628F8D684696D",
-        "PYTHON_VERSION=3.10.0",
-        "PYTHON_PIP_VERSION=21.2.4",
-        "PYTHON_SETUPTOOLS_VERSION=57.5.0",
-        "PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/d781367b97acf0ece7e9e304bf281e99b618bf10/public/get-pip.py",
-        "PYTHON_GET_PIP_SHA256=01249aa3e58ffb3e1686b7141b4e9aac4d398ef4ac3012ed9dff8dd9f685ffe0"
+        "...",
     ]
 }
 ```


### PR DESCRIPTION
I discovered skopeo via [this link](https://docs.gitlab.com/ee/user/packages/container_registry/reduce_container_registry_data_transfer.html#determine-image-size) in the gitlab docs which advertises skopeo for exposing layer sizes. I then got confused by the layer sizes not being exposed in the "skopeo inspect" example of the README. Now I realize this to be a rather new feature, and this PR updates the documentation for it.

Fix:
---
Since d9dfc44 the 'skopeo inspect' command exposes the LayerData which often contains the layer size. This is a very useful feature so we mentioned it in the README now.