### PR TITLE
Add an example for creating a docker-archive file

### DIFF
--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -228,6 +228,11 @@ $ ls /var/lib/images/busybox/*
   /tmp/busybox/8ddc19f16526912237dd8af81971d5e4dd0587907234be2b83e249518d5b673f.tar
 ```
 
+To create an archive consumable by `docker load` (but note that using a registry is almost always more efficient):
+```sh
+$ skopeo copy docker://busybox:latest docker-archive:archive-file.tar:busybox:latest
+```
+
 To copy and sign an image:
 
 ```sh


### PR DESCRIPTION
... with the image correctly tagged.

I also snuck a warning against `docker-archive:` in there.

Fixes #1609 . (I could well see an argument that this is not worth the space in the man page and that #1609 should just be closed.)