### PR TITLE
Use common library reporter

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -51,8 +51,8 @@ See skopeo(1) section "IMAGE NAMES" for the expected format
 `, strings.Join(transports.ListNames(), ", ")),
 		RunE: commandAction(opts.run),
 		Example: `skopeo inspect docker://registry.fedoraproject.org/fedora
-  skopeo inspect --config docker://docker.io/alpine
-  skopeo inspect  --format "Name: {{.Name}} Digest: {{.Digest}}" docker://registry.access.redhat.com/ubi8`,
+skopeo inspect --config docker://docker.io/alpine
+skopeo inspect --format "Name: {{.Name}} Digest: {{.Digest}}" docker://registry.access.redhat.com/ubi8`,
 		ValidArgsFunction: autocompleteSupportedTransports,
 	}
 	adjustUsage(cmd)

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -42,6 +42,7 @@ Use docker daemon host at _host_ (`docker-daemon:` transport only)
 
 Format the output using the given Go template.
 The keys of the returned JSON can be used as the values for the --format flag (see examples below).
+Supports the Go templating functions available at https://pkg.go.dev/github.com/containers/common/pkg/report#hdr-Template_Functions
 
 **--help**, **-h**
 


### PR DESCRIPTION
This uses the common library reporter template generation, so that we can use the DefaultFuncs in format output: https://github.com/containers/common/blob/main/pkg/report/template.go#L37