### PR TITLE
install.md: add Windows static build example

### DIFF
--- a/install.md
+++ b/install.md
@@ -245,6 +245,18 @@ docker run -v $PWD:/src -w /src -e CGO_ENABLED=0 golang \
 make BUILDTAGS=containers_image_openpgp GO_DYN_FLAGS=
 ```
 
+On Windows something like this might work (even more unsupported):
+
+```batch
+REM get git ref
+@echo off && for /f "tokens=*" %i in ('git rev-parse --short HEAD') do set skgitref=%i && @echo on
+REM build bin\skopeo.exe
+set CGO_ENABLED=0
+set GOOS=windows
+go build -mod=vendor -buildmode=pie -ldflags "-X main.gitCommit=%skgitref%" -gcflags "" -tags "containers_image_openpgp" -o ./bin/skopeo.exe ./cmd/skopeo
+```
+
+
 Keep in mind that the resulting binary is unsupported and might crash randomly. Only use if you know what you're doing!
 
 For more information, history, and context about static builds, check the following issues:


### PR DESCRIPTION
This adds an example to `install.md` how to build a static `skopeo.exe` on Windows. Remote registry functionality seems to be working fine on Windows.

Examples where this might be useful:
- There aren't many options to run Windows containers, one of the more popular ones is to use Docker Desktop which can either be in Linux or Windows mode. In Windows mode a Skopeo Linux container can't be used.
- when only using a Windows _Docker_ or _containerd_ build (which can only run Windows containers, so again no Skopeo Linux container).