### PR TITLE
proxy: Fix leak of blobs from containers-storage

### DIFF
--- a/cmd/skopeo/proxy.go
+++ b/cmd/skopeo/proxy.go
@@ -599,10 +599,12 @@ func (h *proxyHandler) GetBlob(args []interface{}) (replyBuf, error) {
 
 	piper, f, err := h.allocPipe()
 	if err != nil {
+		blobr.Close()
 		return ret, err
 	}
 	go func() {
 		// Signal completion when we return
+		defer blobr.Close()
 		defer f.wg.Done()
 		verifier := d.Verifier()
 		tr := io.TeeReader(blobr, verifier)


### PR DESCRIPTION
Missing `.Close()` on the blob currently leaks a temporary file.  Noticed this when doing repeated pulls.

Signed-off-by: Colin Walters <walters@verbum.org>