### PR TITLE
[release-1.4] [CI:BUILD] Cirrus: Migrate OSX task to M1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -98,7 +98,7 @@ osx_task:
         brew install gpgme go@1.16 go-md2man
         go get -u golang.org/x/lint/golint
     test_script: |
-        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:$PATH
+        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:/opt/homebrew/opt/go@1.16/bin:$PATH
         go version
         go env
         make validate-local test-unit-local bin/skopeo

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -93,12 +93,12 @@ osx_task:
         # /usr/local/opt/go@1.16 will be populated by (brew install go@1.16) below
         # /opt/homebrew is the expected path for anything installed with brew
         # on M1 macs
-        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:/opt/homebrew/opt/go@1.16/bin:$PATH
+        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:/opt/homebrew/opt/go@1.16/bin:/opt/homebrew/bin:$PATH
         brew update
         brew install gpgme go@1.16 go-md2man
         go get -u golang.org/x/lint/golint
     test_script: |
-        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:/opt/homebrew/opt/go@1.16/bin:$PATH
+        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:/opt/homebrew/opt/go@1.16/bin:/opt/homebrew/bin:$PATH
         go version
         go env
         make validate-local test-unit-local bin/skopeo

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,10 +88,12 @@ osx_task:
     depends_on:
         - validate
     macos_instance:
-        image: catalina-xcode
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
     setup_script: |
         # /usr/local/opt/go@1.16 will be populated by (brew install go@1.16) below
-        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:$PATH
+        # /opt/homebrew is the expected path for anything installed with brew
+        # on M1 macs
+        export PATH=$GOPATH/bin:/usr/local/opt/go@1.16/bin:/opt/homebrew/opt/go@1.16/bin:$PATH
         brew update
         brew install gpgme go@1.16 go-md2man
         go get -u golang.org/x/lint/golint


### PR DESCRIPTION
Migrate our OSX build to a M1 instance, since Cirrus is sunsetting Intel-based macOS instances.

Signed-off-by: Ashley Cui <acui@redhat.com>
(cherry picked from commit b5ac534960bd4188f7fd847cec3225f55714abc4)
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>