### PR TITLE
proxy: Add optional flags to `OpenImage`

### DIFF
--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -332,6 +332,23 @@ func runTestOpenImageOptionalNotFound(p *proxy, img string) error {
 	if imgid != 0 {
 		return fmt.Errorf("Unexpected optional image id %v", imgid)
 	}
+
+	// Also verify the optional options
+	opts := []string{"optional"}
+	v, err = p.callNoFd("OpenImage", []interface{}{img, opts})
+	if err != nil {
+		return fmt.Errorf("calling OpenImage with flag optional: %w ", err)
+	}
+
+	imgidv, ok = v.(float64)
+	if !ok {
+		return fmt.Errorf("OpenImage return value is %T", v)
+	}
+	imgid = uint32(imgidv)
+	if imgid != 0 {
+		return fmt.Errorf("Unexpected optional image id %v", imgid)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
See https://github.com/containers/skopeo/issues/1829#issuecomment-1355220066

This is prep for adding another option like `require-signatures`.

Signed-off-by: Colin Walters <walters@verbum.org>