### PR TITLE
Cirrus: Skip OSX CI on release-branches

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,8 +75,12 @@ doccheck_task:
       "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" doccheck
 
 osx_task:
-    # Run for regular PRs and those with [CI:BUILD] but not [CI:DOCS]
-    only_if: &not_docs_multiarch >-
+    # Don't run for docs-only or multi-arch image builds.
+    # Also don't run on release-branches or their PRs,
+    # since base container-image is not version-constrained.
+    only_if: &not_docs_or_release_branch >-
+        ($CIRRUS_BASE_BRANCH == $CIRRUS_DEFAULT_BRANCH ||
+         $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH ) &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
         $CIRRUS_CRON != 'multiarch'
     depends_on:
@@ -99,7 +103,9 @@ osx_task:
 
 cross_task:
     alias: cross
-    only_if: *not_docs_multiarch
+    only_if: >-
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CRON != 'multiarch'
     depends_on:
         - validate
     gce_instance: &standardvm
@@ -121,14 +127,7 @@ cross_task:
 
 ostree-rs-ext_task:
     alias: proxy_ostree_ext
-    # Don't run for docs-only or multi-arch image builds.
-    # Also don't run on release-branches or their PRs,
-    # since base container-image is not version-constrained.
-    only_if: &not_docs_or_release_branch >-
-        ($CIRRUS_BASE_BRANCH == $CIRRUS_DEFAULT_BRANCH ||
-         $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH ) &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CRON != 'multiarch'
+    only_if: *not_docs_or_release_branch
     # WARNING: This task potentially performs a container image
     # build (on change) with runtime package installs.  Therefore,
     # its behavior can be unpredictable and potentially flake-prone.


### PR DESCRIPTION
This task does not make sense to maintain long-term on release
branches.  Its intent is always/only to test the latest/greatest code
and environment.  After release, it's simply too difficult to maintain
functioning CI with a constantly changing (Cirrus-managed) OSX environment.
Ensure the task only runs for PRs targeted at the default branch, or if
the current branch is the default branch.

See also:
* https://github.com/containers/skopeo/pull/1851
* https://github.com/containers/skopeo/pull/1852