### PR TITLE
Fix `make test-system` when run as an unprivileged user (containerized)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,6 @@ test-integration-local: bin/skopeo
 	hack/make.sh test-integration
 
 # complicated set of options needed to run podman-in-podman
-# TODO: The $(RM) command will likely fail w/o `podman unshare`
 test-system:
 	DTEMP=$(shell mktemp -d --tmpdir=/var/tmp podman-tmp.XXXXXX); \
 	$(CONTAINER_CMD) --privileged \
@@ -214,7 +213,7 @@ test-system:
 		"$(SKOPEO_CIDEV_CONTAINER_FQIN)" \
 			$(MAKE) test-system-local; \
 	rc=$$?; \
-	-$(RM) -rf $$DTEMP; \
+	$(CONTAINER_RUNTIME) unshare rm -rf $$DTEMP; # This probably doesn't work with Docker, oh well, better than nothing... \
 	exit $$rc
 
 # Intended for CI, assumed to already be running in quay.io/libpod/skopeo_cidev container.

--- a/systemtest/040-local-registry-auth.bats
+++ b/systemtest/040-local-registry-auth.bats
@@ -8,17 +8,19 @@ load helpers
 function setup() {
     standard_setup
 
-    # Remove old/stale cred file
-    _cred_dir=$TESTDIR/credentials
-    export XDG_RUNTIME_DIR=$_cred_dir
-    mkdir -p $_cred_dir/containers
-    rm -f $_cred_dir/containers/auth.json
-
     # Start authenticated registry with random password
     testuser=testuser
     testpassword=$(random_string 15)
 
     start_registry --testuser=$testuser --testpassword=$testpassword --enable-delete=true reg
+
+    _cred_dir=$TESTDIR/credentials
+    # It is important to change XDG_RUNTIME_DIR only after we start the registry, otherwise it affects the path of $XDG_RUNTIME_DIR/netns maintained by Podman,
+    # making it imposible to clean up after ourselves.
+    export XDG_RUNTIME_DIR=$_cred_dir
+    mkdir -p $_cred_dir/containers
+    # Remove old/stale cred file
+    rm -f $_cred_dir/containers/auth.json
 }
 
 @test "auth: credentials on command line" {


### PR DESCRIPTION
This, _together with #1864_, allows running `make test-system` as an unprivileged user. (It doesn’t work for me as `root` and I don’t currently think it’s worth spending time on that.)

That makes the “single Linux developer” use case working again… in case anyone cares.