### PR TITLE
[CI:DOCS] Format manual page documents

### DIFF
--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -219,12 +219,12 @@ The password to access the destination registry.
 ## EXAMPLES
 
 To just copy an image from one registry to another:
-```sh
+```console
 $ skopeo copy docker://quay.io/skopeo/stable:latest docker://registry.example.com/skopeo:latest
 ```
 
 To copy the layers of the docker.io busybox image to a local directory:
-```sh
+```console
 $ mkdir -p /var/lib/images/busybox
 $ skopeo copy docker://busybox:latest dir:/var/lib/images/busybox
 $ ls /var/lib/images/busybox/*
@@ -234,46 +234,45 @@ $ ls /var/lib/images/busybox/*
 ```
 
 To create an archive consumable by `docker load` (but note that using a registry is almost always more efficient):
-```sh
+```console
 $ skopeo copy docker://busybox:latest docker-archive:archive-file.tar:busybox:latest
 ```
 
 To copy and sign an image:
-
-```sh
-# skopeo copy --sign-by dev@example.com containers-storage:example/busybox:streaming docker://example/busybox:gold
+```console
+$ skopeo copy --sign-by dev@example.com containers-storage:example/busybox:streaming docker://example/busybox:gold
 ```
 
 To encrypt an image:
-```sh
-skopeo copy docker://docker.io/library/nginx:1.17.8 oci:local_nginx:1.17.8
+```console
+$ skopeo copy docker://docker.io/library/nginx:1.17.8 oci:local_nginx:1.17.8
 
-openssl genrsa -out private.key 1024
-openssl rsa -in private.key -pubout > public.key
+$ openssl genrsa -out private.key 1024
+$ openssl rsa -in private.key -pubout > public.key
 
-skopeo  copy --encryption-key jwe:./public.key oci:local_nginx:1.17.8 oci:try-encrypt:encrypted
+$ skopeo copy --encryption-key jwe:./public.key oci:local_nginx:1.17.8 oci:try-encrypt:encrypted
 ```
 
 To decrypt an image:
-```sh
-skopeo copy --decryption-key ./private.key oci:try-encrypt:encrypted oci:try-decrypt:decrypted
+```console
+$ skopeo copy --decryption-key ./private.key oci:try-encrypt:encrypted oci:try-decrypt:decrypted
 ```
 
 To copy encrypted image without decryption:
-```sh
-skopeo copy oci:try-encrypt:encrypted oci:try-encrypt-copy:encrypted
+```console
+$ skopeo copy oci:try-encrypt:encrypted oci:try-encrypt-copy:encrypted
 ```
 
 To decrypt an image that requires more than one key:
-```sh
-skopeo copy --decryption-key ./private1.key --decryption-key ./private2.key --decryption-key ./private3.key oci:try-encrypt:encrypted oci:try-decrypt:decrypted
+```console
+$ skopeo copy --decryption-key ./private1.key --decryption-key ./private2.key --decryption-key ./private3.key oci:try-encrypt:encrypted oci:try-decrypt:decrypted
 ```
 
 Container images can also be partially encrypted by specifying the index of the layer. Layers are 0-indexed indices, with support for negative indexing. i.e. 0 is the first layer, -1 is the last layer.
 
 Let's say out of 3 layers that the image `docker.io/library/nginx:1.17.8` is made up of, we only want to encrypt the 2nd layer,
-```sh
-skopeo  copy --encryption-key jwe:./public.key --encrypt-layer 1 oci:local_nginx:1.17.8 oci:try-encrypt:encrypted
+```console
+$ skopeo copy --encryption-key jwe:./public.key --encrypt-layer 1 oci:local_nginx:1.17.8 oci:try-encrypt:encrypted
 ```
 
 ## SEE ALSO

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -85,7 +85,7 @@ The password to access the registry.
 ## EXAMPLES
 
 Mark image example/pause for deletion from the registry.example.com registry:
-```sh
+```console
 $ skopeo delete docker://registry.example.com/example/pause:latest
 ```
 See above for additional details on using the command **delete**.

--- a/docs/skopeo-generate-sigstore-key.1.md
+++ b/docs/skopeo-generate-sigstore-key.1.md
@@ -35,7 +35,7 @@ Do not use this option if at all avoidable.
 
 ## EXAMPLES
 
-```sh
+```console
 $ skopeo generate-sigstore-key --output-prefix mykey
 ```
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -87,7 +87,7 @@ Do not list the available tags from the repository in the output. When `true`, t
 ## EXAMPLES
 
 To review information for the image fedora from the docker.io registry:
-```sh
+```console
 $ skopeo inspect docker://docker.io/fedora
 
 {
@@ -126,7 +126,7 @@ $ skopeo inspect docker://docker.io/fedora
 ```
 
 To inspect python from the docker.io registry and not show the available tags:
-```sh
+```console
 $ skopeo inspect --no-tags docker://docker.io/library/python
 {
     "Name": "docker.io/library/python",
@@ -165,12 +165,12 @@ $ skopeo inspect --no-tags docker://docker.io/library/python
 }
 ```
 
-```
+```console
 $ /bin/skopeo inspect --config docker://registry.fedoraproject.org/fedora --format "{{ .Architecture }}"
 amd64
 ```
 
-```
+```console
 $ /bin/skopeo inspect --format '{{ .Env }}' docker://registry.access.redhat.com/ubi8
 [PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin container=oci]
 ```

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -79,7 +79,7 @@ This commands refers to repositories using a _transport_`:`_details_ format. The
 
 ### Docker Transport
 To get the list of tags in the "fedora" repository from the docker.io registry (the repository name expands to "library/fedora" per docker transport canonical form):
-```sh
+```console
 $ skopeo list-tags docker://docker.io/fedora
 {
     "Repository": "docker.io/library/fedora",
@@ -110,7 +110,7 @@ $ skopeo list-tags docker://docker.io/fedora
 
 To list the tags in a local host docker/distribution registry on port 5000, in this case for the "fedora" repository:
 
-```sh
+```console
 $ skopeo list-tags docker://localhost:5000/fedora
 {
     "Repository": "localhost:5000/fedora",
@@ -127,7 +127,7 @@ $ skopeo list-tags docker://localhost:5000/fedora
 
 To list the tags in a local docker-archive file:
 
-```sh
+```console
 $ skopeo list-tags docker-archive:/tmp/busybox.tar.gz
 {
     "Tags": [
@@ -138,7 +138,7 @@ $ skopeo list-tags docker-archive:/tmp/busybox.tar.gz
 
 Also supports more than one tags in an archive:
 
-```sh
+```console
 $ skopeo list-tags docker-archive:/tmp/docker-two-images.tar.gz
 {
     "Tags": [
@@ -150,7 +150,7 @@ $ skopeo list-tags docker-archive:/tmp/docker-two-images.tar.gz
 
 Will include a source-index entry for each untagged image:
 
-```sh
+```console
 $ skopeo list-tags docker-archive:/tmp/four-tags-with-an-untag.tar
 {
     "Tags": [

--- a/docs/skopeo-login.1.md
+++ b/docs/skopeo-login.1.md
@@ -57,41 +57,41 @@ Write more detailed information to stdout
 
 ## EXAMPLES
 
-```
+```console
 $ skopeo login docker.io
 Username: testuser
 Password:
 Login Succeeded!
 ```
 
-```
+```console
 $ skopeo login -u testuser -p testpassword localhost:5000
 Login Succeeded!
 ```
 
-```
+```console
 $ skopeo login --authfile authdir/myauths.json docker.io
 Username: testuser
 Password:
 Login Succeeded!
 ```
 
-```
+```console
 $ skopeo login --tls-verify=false -u test -p test localhost:5000
 Login Succeeded!
 ```
 
-```
+```console
 $ skopeo login --cert-dir /etc/containers/certs.d/ -u foo -p bar localhost:5000
 Login Succeeded!
 ```
 
-```
+```console
 $ skopeo login -u testuser  --password-stdin < testpassword.txt docker.io
 Login Succeeded!
 ```
 
-```
+```console
 $ echo $testpassword | skopeo login -u testuser --password-stdin docker.io
 Login Succeeded!
 ```

--- a/docs/skopeo-logout.1.md
+++ b/docs/skopeo-logout.1.md
@@ -35,17 +35,17 @@ Require HTTPS and verify certificates when talking to the container registry or 
 
 ## EXAMPLES
 
-```
+```console
 $ skopeo logout docker.io
 Remove login credentials for docker.io
 ```
 
-```
+```console
 $ skopeo logout --authfile authdir/myauths.json docker.io
 Remove login credentials for docker.io
 ```
 
-```
+```console
 $ skopeo logout --all
 Remove login credentials for all registries
 ```

--- a/docs/skopeo-manifest-digest.1.md
+++ b/docs/skopeo-manifest-digest.1.md
@@ -18,7 +18,7 @@ Print usage statement
 
 ## EXAMPLES
 
-```sh
+```console
 $ skopeo manifest-digest manifest.json
 sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6
 ```

--- a/docs/skopeo-standalone-sign.1.md
+++ b/docs/skopeo-standalone-sign.1.md
@@ -31,7 +31,7 @@ The passphare to use when signing with the key ID from `--sign-by`. Only the fir
 
 ## EXAMPLES
 
-```sh
+```console
 $ skopeo standalone-sign busybox-manifest.json registry.example.com/example/busybox 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8 --output busybox.signature
 $
 ```

--- a/docs/skopeo-standalone-verify.1.md
+++ b/docs/skopeo-standalone-verify.1.md
@@ -30,7 +30,7 @@ Print usage statement
 
 ## EXAMPLES
 
-```sh
+```console
 $ skopeo standalone-verify busybox-manifest.json registry.example.com/example/busybox 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8  busybox.signature
 Signature verified, digest sha256:20bf21ed457b390829cdbeec8795a7bea1626991fda603e0d01b4e7f60427e55
 ```

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -133,7 +133,7 @@ The password to access the destination registry.
 ## EXAMPLES
 
 ### Synchronizing to a local directory
-```
+```console
 $ skopeo sync --src docker --dest dir registry.example.com/busybox /media/usb
 ```
 Images are located at:
@@ -151,7 +151,7 @@ Images are located at:
 /media/usb/busybox:1-glibc
 ```
 Sync run
-```
+```console
 $ skopeo sync --src dir --dest docker /media/usb/busybox:1-glibc my-registry.local.lan/test/
 ```
 Destination registry content:
@@ -161,7 +161,7 @@ my-registry.local.lan/test/busybox   1-glibc
 ```
 
 ### Synchronizing to a local directory, scoped
-```
+```console
 $ skopeo sync --src docker --dest dir --scoped registry.example.com/busybox /media/usb
 ```
 Images are located at:
@@ -174,8 +174,8 @@ Images are located at:
 ```
 
 ### Synchronizing to a container registry
-```
-skopeo sync --src docker --dest docker registry.example.com/busybox my-registry.local.lan
+```console
+$ skopeo sync --src docker --dest docker registry.example.com/busybox my-registry.local.lan
 ```
 Destination registry content:
 ```
@@ -184,8 +184,8 @@ registry.local.lan/busybox   1-glibc, 1-musl, 1-ubuntu, ..., latest
 ```
 
 ### Synchronizing to a container registry keeping the repository
-```
-skopeo sync --src docker --dest docker registry.example.com/repo/busybox my-registry.local.lan/repo
+```console
+$ skopeo sync --src docker --dest docker registry.example.com/repo/busybox my-registry.local.lan/repo
 ```
 Destination registry content:
 ```
@@ -194,8 +194,8 @@ registry.local.lan/repo/busybox   1-glibc, 1-musl, 1-ubuntu, ..., latest
 ```
 
 ### Synchronizing to a container registry with tag suffix
-```
-skopeo sync --src docker --dest docker --append-suffix '-mirror' registry.example.com/busybox my-registry.local.lan
+```console
+$ skopeo sync --src docker --dest docker --append-suffix '-mirror' registry.example.com/busybox my-registry.local.lan
 ```
 Destination registry content:
 ```
@@ -227,8 +227,8 @@ quay.io:
             - latest
 ```
 If the yaml filename is `sync.yml`, sync run:
-```
-skopeo sync --src yaml --dest docker sync.yml my-registry.local.lan/repo/
+```console
+$ skopeo sync --src yaml --dest docker sync.yml my-registry.local.lan/repo/
 ```
 This will copy the following images:
 - Repository `registry.example.com/busybox`: all images, as no tags are specified.


### PR DESCRIPTION
- Add a prompt to the skopeo commands.

- Add a "console" identifier to fenced code blocks which has a prompt, not "sh".

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

If the commands has a prompt, we should use a "console" identifier.