### PR TITLE
[CI:BUILD] Packit: initial enablement

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script handles any custom processing of the spec file generated using the `post-upstream-clone`
+# action and gets used by the fix-spec-file action in .packit.yaml.
+
+set -eo pipefail
+
+# Get Version from HEAD
+VERSION=$(grep '^const Version' version/version.go | cut -d\" -f2 | sed -e 's/-/~/')
+
+# Generate source tarball
+git archive --prefix=skopeo-$VERSION/ -o skopeo-$VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Update Version in spec with Version from Cargo.toml
+sed -i "s/^Version:.*/Version: $VERSION/" skopeo.spec
+
+# Update Release in spec with Packit's release envvar
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" skopeo.spec
+
+# Update Source tarball name in spec
+sed -i "s/^Source:.*.tar.gz/Source: skopeo-$VERSION.tar.gz/" skopeo.spec
+
+# Update setup macro to use the correct build dir
+sed -i "s/^%setup.*/%autosetup -Sgit -n %{name}-$VERSION/" skopeo.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,27 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# NOTE: The Packit copr_build tasks help to check if every commit builds on
+# supported Fedora and CentOS Stream arches.
+# They do not block the current Cirrus-based workflow.
+
+# Build targets can be found at:
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
+
+specfile_path: skopeo.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    owner: rhcontainerbot
+    project: packit-builds
+    enable_net: true
+    srpm_build_deps:
+      - make
+      - rpkg
+    actions:
+      post-upstream-clone:
+        - "rpkg spec --outdir ./"
+      fix-spec-file:
+        - "bash .packit.sh"


### PR DESCRIPTION
This commit will run COPR builds on every PR against all active releases of CentOS Stream and Fedora, thus allowing buildability checks before the PR merges.

Builds are done on a custom COPR project:
`rhcontainerbot/packit-builds`.
Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/

The build targets are set in the copr itself, so we don't need to explicitly mention them in `.packit.yaml`, making upstream configuration a lot simpler.

The `spec.rpkg` file meant for rpm builds post-pr-merge at `rhcontainerbot/podman-next` copr gets reused for packit builds, so the packit jobs are independent of Fedora / CentOS dist-git.

NOTE: The Packit copr_build tasks help to check if every commit builds on
supported Fedora and CentOS Stream arches. They do not block the current
Cirrus-based workflow.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>