### PR TITLE
Fix some warnings

### DIFF
--- a/cmd/skopeo/list_tags.go
+++ b/cmd/skopeo/list_tags.go
@@ -128,7 +128,7 @@ func listDockerRepoTags(ctx context.Context, sys *types.SystemContext, opts *tag
 }
 
 // return the tagLists from a docker archive file
-func listDockerArchiveTags(ctx context.Context, sys *types.SystemContext, opts *tagsOptions, userInput string) (repositoryName string, tagListing []string, err error) {
+func listDockerArchiveTags(_ context.Context, sys *types.SystemContext, _ *tagsOptions, userInput string) (repositoryName string, tagListing []string, err error) {
 	ref, err := alltransports.ParseImageName(userInput)
 	if err != nil {
 		return

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -55,14 +55,12 @@ func createApp() (*cobra.Command, *globalOptions) {
 	opts := globalOptions{}
 
 	rootCommand := &cobra.Command{
-		Use:  "skopeo",
-		Long: "Various operations with container images and container image registries",
-		RunE: requireSubcommand,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.before(cmd)
-		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:               "skopeo",
+		Long:              "Various operations with container images and container image registries",
+		RunE:              requireSubcommand,
+		PersistentPreRunE: opts.before,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
 		// Hide the completion command which is provided by cobra
 		CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
 		// This is documented to parse "local" (non-PersistentFlags) flags of parent commands before
@@ -115,7 +113,7 @@ func createApp() (*cobra.Command, *globalOptions) {
 }
 
 // before is run by the cli package for any command, before running the command-specific handler.
-func (opts *globalOptions) before(cmd *cobra.Command) error {
+func (opts *globalOptions) before(cmd *cobra.Command, args []string) error {
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -38,14 +38,13 @@ func (s *skopeoSuite) SetupSuite() {
 }
 
 func (s *skopeoSuite) TearDownSuite() {
-	t := s.T()
 	if s.regV2 != nil {
-		s.regV2.tearDown(t)
+		s.regV2.tearDown()
 	}
 	if s.regV2WithAuth != nil {
 		// cmd := exec.Command("docker", "logout", s.regV2WithAuth)
 		// require.Noerror(t, cmd.Run())
-		s.regV2WithAuth.tearDown(t)
+		s.regV2WithAuth.tearDown()
 	}
 }
 

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -90,10 +90,10 @@ func (s *copySuite) SetupSuite() {
 func (s *copySuite) TearDownSuite() {
 	t := s.T()
 	if s.registry != nil {
-		s.registry.tearDown(t)
+		s.registry.tearDown()
 	}
 	if s.s1Registry != nil {
-		s.s1Registry.tearDown(t)
+		s.s1Registry.tearDown()
 	}
 	if s.cluster != nil {
 		s.cluster.tearDown(t)
@@ -187,7 +187,7 @@ func (s *copySuite) TestCopyWithManifestListStorage() {
 	assertSkopeoSucceeds(t, "", "copy", knownListImage, "containers-storage:"+storage+"test")
 	assertSkopeoSucceeds(t, "", "copy", knownListImage, "dir:"+dir1)
 	assertSkopeoSucceeds(t, "", "copy", "containers-storage:"+storage+"test", "dir:"+dir2)
-	runDecompressDirs(t, "", dir1, dir2)
+	runDecompressDirs(t, dir1, dir2)
 	assertDirImagesAreEqual(t, dir1, dir2)
 }
 
@@ -201,7 +201,7 @@ func (s *copySuite) TestCopyWithManifestListStorageMultiple() {
 	assertSkopeoSucceeds(t, "", "--override-arch", "arm64", "copy", knownListImage, "containers-storage:"+storage+"test")
 	assertSkopeoSucceeds(t, "", "--override-arch", "arm64", "copy", knownListImage, "dir:"+dir1)
 	assertSkopeoSucceeds(t, "", "copy", "containers-storage:"+storage+"test", "dir:"+dir2)
-	runDecompressDirs(t, "", dir1, dir2)
+	runDecompressDirs(t, dir1, dir2)
 	assertDirImagesAreEqual(t, dir1, dir2)
 }
 
@@ -248,7 +248,7 @@ func (s *copySuite) TestCopyWithManifestListStorageDigest() {
 	assertSkopeoSucceeds(t, "", "copy", knownListImage+"@"+digest, "containers-storage:"+storage+"test@"+digest)
 	assertSkopeoSucceeds(t, "", "copy", "containers-storage:"+storage+"test@"+digest, "dir:"+dir1)
 	assertSkopeoSucceeds(t, "", "copy", knownListImage+"@"+digest, "dir:"+dir2)
-	runDecompressDirs(t, "", dir1, dir2)
+	runDecompressDirs(t, dir1, dir2)
 	assertDirImagesAreEqual(t, dir1, dir2)
 }
 
@@ -265,7 +265,7 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArches() {
 	assertSkopeoSucceeds(t, "", "copy", knownListImage+"@"+digest, "containers-storage:"+storage+"test@"+digest)
 	assertSkopeoSucceeds(t, "", "copy", "containers-storage:"+storage+"test@"+digest, "dir:"+dir1)
 	assertSkopeoSucceeds(t, "", "copy", knownListImage+"@"+digest, "dir:"+dir2)
-	runDecompressDirs(t, "", dir1, dir2)
+	runDecompressDirs(t, dir1, dir2)
 	assertDirImagesAreEqual(t, dir1, dir2)
 }
 

--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -230,7 +230,7 @@ type byteFetch struct {
 }
 
 func runTestGetManifestAndConfig(p *proxy, img string) error {
-	v, err := p.callNoFd("OpenImage", []any{knownNotManifestListedImageX8664})
+	v, err := p.callNoFd("OpenImage", []any{img})
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func runTestGetManifestAndConfig(p *proxy, img string) error {
 	}
 
 	// Also verify the optional path
-	v, err = p.callNoFd("OpenImageOptional", []any{knownNotManifestListedImageX8664})
+	v, err = p.callNoFd("OpenImageOptional", []any{img})
 	if err != nil {
 		return err
 	}

--- a/integration/registry.go
+++ b/integration/registry.go
@@ -124,7 +124,7 @@ func (r *testRegistryV2) Ping() error {
 	return nil
 }
 
-func (r *testRegistryV2) tearDown(t *testing.T) {
+func (r *testRegistryV2) tearDown() {
 	// It’s undocumented what Kill() returns if the process has terminated,
 	// so we couldn’t check just for that. This is running in a container anyway…
 	_ = r.cmd.Process.Kill()

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -104,7 +104,7 @@ func (s *syncSuite) TearDownSuite() {
 	}
 
 	if s.registry != nil {
-		s.registry.tearDown(t)
+		s.registry.tearDown()
 	}
 	if s.cluster != nil {
 		s.cluster.tearDown(t)

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -188,7 +188,7 @@ func fileFromFixture(t *testing.T, inputPath string, edits map[string]string) st
 
 // runDecompressDirs runs decompress-dirs.sh using exec.Command().CombinedOutput, verifies that the exit status is 0,
 // and optionally that the output matches a multi-line regexp if it is nonempty; or terminates c on failure
-func runDecompressDirs(t *testing.T, regexp string, args ...string) {
+func runDecompressDirs(t *testing.T, args ...string) {
 	t.Logf("Running %s %s", decompressDirsBinary, strings.Join(args, " "))
 	for i, dir := range args {
 		m, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
@@ -204,9 +204,6 @@ func runDecompressDirs(t *testing.T, regexp string, args ...string) {
 		m, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
 		require.NoError(t, err)
 		t.Logf("manifest %d after: %s", i+1, string(m))
-	}
-	if regexp != "" {
-		assert.Regexp(t, "(?s)"+regexp, string(out)) // (?s) : '.' will also match newlines
 	}
 }
 


### PR DESCRIPTION
golangci-lint linter: unparam

This primarily fixes TestProxy to test the correct image.