### PR TITLE
Fix tabelating output in (skopeo inspect --format)

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -246,5 +246,8 @@ func printTmpl(stdout io.Writer, row string, data []any) error {
 		return err
 	}
 	w := tabwriter.NewWriter(stdout, 8, 2, 2, ' ', 0)
-	return t.Execute(w, data)
+	if err := t.Execute(w, data); err != nil {
+		return err
+	}
+	return w.Flush()
 }


### PR DESCRIPTION
`tabwriter` buffers lines that contain `\t` in memory, and only writes them out on a `.Flush()`. So actually call that.

Without this, things like `--format 'name\tdigest\tlabels\n{{.Name}}\t{{.Digest}}\t{{.Labels}}\n'` result in no output at all.