### PR TITLE
[CI:BUILD] Packit: trigger builds on commit to main branch

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,8 @@
 specfile_path: skopeo.spec
 
 jobs:
-  - job: copr_build
+  - &copr
+    job: copr_build
     trigger: pull_request
     owner: rhcontainerbot
     project: packit-builds
@@ -25,3 +26,9 @@ jobs:
         - "rpkg spec --outdir ./"
       fix-spec-file:
         - "bash .packit.sh"
+
+  - <<: *copr
+    # Run on commit to main branch
+    trigger: commit
+    branch: main
+    project: podman-next


### PR DESCRIPTION
This commit lets packit trigger builds on
`rhcontainerbot/podman-next` copr after a commit to the main branch instead of the current github webhook trigger.

The builds triggered via packit also provide more information in their `version-release`:

Current webhook triggered build:
`101:0.0.git.2460.cfd6f20f-1`
Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/package/skopeo/

Packit triggered build for another package (netavark) on podman-next:
`101:1.6.0~dev-1.20230321121647013339.main.61.gd6f0352`
Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/package/netavark/

The packit triggered build correctly shows the upstream branch name, commit id, timestamp as well as the upstream version.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

EDIT: Update commit message, PR# is not actually seen in builds triggered after commit to branch using `trigger: commit`. It's only seen in pre-merge builds using `trigger: pull_request`.