### PR TITLE
Cross-link the top-level and subcommand option lists

### DIFF
--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -20,6 +20,8 @@ automatically inherit any parts of the source name.
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--additional-tag**=_strings_
 
 Additional tags (supports docker-archive).

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -31,6 +31,8 @@ $ docker exec -it registry /usr/bin/registry garbage-collect /etc/docker-distrib
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--authfile** _path_
 
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `skopeo login`.

--- a/docs/skopeo-generate-sigstore-key.1.md
+++ b/docs/skopeo-generate-sigstore-key.1.md
@@ -17,6 +17,8 @@ The private key is written to _prefix_**.pub** .
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--help**, **-h**
 
 Print usage statement

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -17,6 +17,8 @@ To see values for a different architecture/OS, use the **--override-os** / **--o
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--authfile** _path_
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `skopeo login`.

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -12,6 +12,8 @@ Return a list of tags from _source-image_ in a registry or a local docker-archiv
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--authfile** _path_
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `skopeo login`.

--- a/docs/skopeo-login.1.md
+++ b/docs/skopeo-login.1.md
@@ -15,6 +15,8 @@ flag. The default path used is **${XDG\_RUNTIME\_DIR}/containers/auth.json**.
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--password**, **-p**=*password*
 
 Password for registry

--- a/docs/skopeo-logout.1.md
+++ b/docs/skopeo-logout.1.md
@@ -14,6 +14,8 @@ All the cached credentials can be removed by setting the **all** flag.
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json

--- a/docs/skopeo-standalone-sign.1.md
+++ b/docs/skopeo-standalone-sign.1.md
@@ -17,6 +17,8 @@ This is primarily a debugging tool, useful for special cases, and usually should
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--help**, **-h**
 
 Print usage statement

--- a/docs/skopeo-standalone-verify.1.md
+++ b/docs/skopeo-standalone-verify.1.md
@@ -24,6 +24,8 @@ as per containers-policy.json(5).
 
 ## OPTIONS
 
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--help**, **-h**
 
 Print usage statement

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -29,6 +29,9 @@ When the `--scoped` option is specified, images are prefixed with the source ima
 name can be stored at _destination_.
 
 ## OPTIONS
+
+See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
+
 **--all**, **-a**
 If one of the images in __src__ refers to a list of images, instead of copying just the image which matches the current OS and
 architecture (subject to the use of the global --override-os, --override-arch and --override-variant options), attempt to copy all of

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -51,6 +51,9 @@ See [containers-transports(5)](https://github.com/containers/image/blob/main/doc
 
 ## OPTIONS
 
+These options should be placed before the subcommand name.
+Individual subcommands have their own options.
+
 **--command-timeout** _duration_
 
 Timeout for the command execution.


### PR DESCRIPTION
... primarily to make the top-level options more discoverable.

Should help a bit with #1914 .