### PR TITLE
Verify signatures from a list of public keys

### DIFF
--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -133,15 +133,16 @@ func TestStandaloneVerify(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
 
-	// Using any known fingerprint
-	out, err = runSkopeo("standalone-verify", manifestPath,
-		dockerReference, "any", signaturePath)
+	// Using a public key file
+	t.Setenv("GNUPGHOME", "")
+	out, err = runSkopeo("standalone-verify", "--public-key-file", "fixtures/pubring.gpg", manifestPath,
+		dockerReference, fixturesTestKeyFingerprint, signaturePath)
 	assert.NoError(t, err)
 	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
 
-	// Using a trust store
+	// Using a public key file matching any public key
 	t.Setenv("GNUPGHOME", "")
-	out, err = runSkopeo("standalone-verify", "--truststore", "fixtures/pubring.gpg", manifestPath,
+	out, err = runSkopeo("standalone-verify", "--public-key-file", "fixtures/pubring.gpg", manifestPath,
 		dockerReference, "any", signaturePath)
 	assert.NoError(t, err)
 	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)

--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -127,6 +127,11 @@ func TestStandaloneVerify(t *testing.T) {
 		dockerReference, fixturesTestKeyFingerprint, "fixtures/corrupt.signature")
 	assertTestFailed(t, out, err, "Error verifying signature")
 
+	// Error using any without a public key file
+	out, err = runSkopeo("standalone-verify", manifestPath,
+		dockerReference, "any", signaturePath)
+	assertTestFailed(t, out, err, "Cannot use any fingerprint without a public key file")
+
 	// Success
 	out, err = runSkopeo("standalone-verify", manifestPath,
 		dockerReference, fixturesTestKeyFingerprint, signaturePath)

--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -131,7 +131,20 @@ func TestStandaloneVerify(t *testing.T) {
 	out, err = runSkopeo("standalone-verify", manifestPath,
 		dockerReference, fixturesTestKeyFingerprint, signaturePath)
 	assert.NoError(t, err)
-	assert.Equal(t, "Signature verified, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
+	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
+
+	// Using any known fingerprint
+	out, err = runSkopeo("standalone-verify", manifestPath,
+		dockerReference, "any", signaturePath)
+	assert.NoError(t, err)
+	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
+
+	// Using a trust store
+	t.Setenv("GNUPGHOME", "")
+	out, err = runSkopeo("standalone-verify", "--truststore", "fixtures/pubring.gpg", manifestPath,
+		dockerReference, "any", signaturePath)
+	assert.NoError(t, err)
+	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
 }
 
 func TestUntrustedSignatureDump(t *testing.T) {

--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -136,21 +136,27 @@ func TestStandaloneVerify(t *testing.T) {
 	out, err = runSkopeo("standalone-verify", manifestPath,
 		dockerReference, fixturesTestKeyFingerprint, signaturePath)
 	assert.NoError(t, err)
-	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
+	assert.Equal(t, "Signature verified using fingerprint "+fixturesTestKeyFingerprint+", digest "+fixturesTestImageManifestDigest.String()+"\n", out)
+
+	// Using multiple fingerprints
+	out, err = runSkopeo("standalone-verify", manifestPath,
+		dockerReference, "0123456789ABCDEF0123456789ABCDEF01234567,"+fixturesTestKeyFingerprint+",DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF", signaturePath)
+	assert.NoError(t, err)
+	assert.Equal(t, "Signature verified using fingerprint "+fixturesTestKeyFingerprint+", digest "+fixturesTestImageManifestDigest.String()+"\n", out)
 
 	// Using a public key file
 	t.Setenv("GNUPGHOME", "")
 	out, err = runSkopeo("standalone-verify", "--public-key-file", "fixtures/pubring.gpg", manifestPath,
 		dockerReference, fixturesTestKeyFingerprint, signaturePath)
 	assert.NoError(t, err)
-	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
+	assert.Equal(t, "Signature verified using fingerprint "+fixturesTestKeyFingerprint+", digest "+fixturesTestImageManifestDigest.String()+"\n", out)
 
 	// Using a public key file matching any public key
 	t.Setenv("GNUPGHOME", "")
 	out, err = runSkopeo("standalone-verify", "--public-key-file", "fixtures/pubring.gpg", manifestPath,
 		dockerReference, "any", signaturePath)
 	assert.NoError(t, err)
-	assert.Equal(t, "Signature verified using fingerprint 1D8230F6CDB6A06716E414C1DB72F2188BB46CC8, digest "+fixturesTestImageManifestDigest.String()+"\n", out)
+	assert.Equal(t, "Signature verified using fingerprint "+fixturesTestKeyFingerprint+", digest "+fixturesTestImageManifestDigest.String()+"\n", out)
 }
 
 func TestUntrustedSignatureDump(t *testing.T) {

--- a/docs/skopeo-standalone-verify.1.md
+++ b/docs/skopeo-standalone-verify.1.md
@@ -16,7 +16,7 @@ as per containers-policy.json(5).
 
   _docker-reference_ A docker reference expected to identify the image in the signature
 
-  _key-fingerprint_ Expected identity of the signing key, or "any" to trust any known key
+  _key-fingerprint_ Expected identity of the signing key, or "any" to trust any known key when using a public key file
 
   _signature_ Path to signature file
 
@@ -28,9 +28,9 @@ as per containers-policy.json(5).
 
 Print usage statement
 
-**--truststore** _truststore_
+**--public-key-file** _public key file_
 
-Trust store of public keys to use when verifying signatures. If this is not specified, keys from gpg home are used.
+File containing the public keys to use when verifying signatures. If this is not specified, keys from the GPG homedir are used.
 
 ## EXAMPLES
 

--- a/docs/skopeo-standalone-verify.1.md
+++ b/docs/skopeo-standalone-verify.1.md
@@ -16,7 +16,7 @@ as per containers-policy.json(5).
 
   _docker-reference_ A docker reference expected to identify the image in the signature
 
-  _key-fingerprint_ Expected identity of the signing key
+  _key-fingerprint_ Expected identity of the signing key, or "any" to trust any known key
 
   _signature_ Path to signature file
 
@@ -27,6 +27,10 @@ as per containers-policy.json(5).
 **--help**, **-h**
 
 Print usage statement
+
+**--truststore** _truststore_
+
+Trust store of public keys to use when verifying signatures. If this is not specified, keys from gpg home are used.
 
 ## EXAMPLES
 

--- a/docs/skopeo-standalone-verify.1.md
+++ b/docs/skopeo-standalone-verify.1.md
@@ -4,7 +4,7 @@
 skopeo\-standalone\-verify - Verify an image signature.
 
 ## SYNOPSIS
-**skopeo standalone-verify** _manifest_ _docker-reference_ _key-fingerprint_ _signature_
+**skopeo standalone-verify** _manifest_ _docker-reference_ _key-fingerprints_ _signature_
 
 ## DESCRIPTION
 
@@ -16,7 +16,7 @@ as per containers-policy.json(5).
 
   _docker-reference_ A docker reference expected to identify the image in the signature
 
-  _key-fingerprint_ Expected identity of the signing key, or "any" to trust any known key when using a public key file
+  _key-fingerprints_ Identities of trusted signing keys (comma separated), or "any" to trust any known key when using a public key file
 
   _signature_ Path to signature file
 

--- a/integration/signing_test.go
+++ b/integration/signing_test.go
@@ -73,7 +73,7 @@ func (s *signingSuite) TestSignVerifySmoke() {
 	assertSkopeoSucceeds(t, "^$", "standalone-sign", "-o", sigOutput.Name(),
 		manifestPath, dockerReference, s.fingerprint)
 
-	expected := fmt.Sprintf("^Signature verified, digest %s\n$", TestImageManifestDigest)
+	expected := fmt.Sprintf("^Signature verified using fingerprint %s, digest %s\n$", s.fingerprint, TestImageManifestDigest)
 	assertSkopeoSucceeds(t, expected, "standalone-verify", manifestPath,
 		dockerReference, s.fingerprint, sigOutput.Name())
 }

--- a/systemtest/050-signing.bats
+++ b/systemtest/050-signing.bats
@@ -242,7 +242,7 @@ END_TESTS
                $fingerprint \
                $TESTDIR/busybox.signature
     # manifest digest
-    digest=$(echo "$output" | awk '{print $4;}')
+    digest=$(echo "$output" | awk '{print $NF;}')
     run_skopeo manifest-digest $TESTDIR/busybox/manifest.json
     expect_output $digest
 }


### PR DESCRIPTION
Add the ability to use an on-disk trust store to verify signatures. Also allow the user to trust any known fingerprint instead of having to specify one.

The reason here is that we now have a number of different keys we have used to sign our images over time as they have been rotated. Being able to supply someone with a keystore they can use to verify any of our images with is valuable to us.