### PR TITLE
systemtests: Fix 040-local-registry-auth about XDG_RUNTIME_DIR

### DIFF
--- a/systemtest/040-local-registry-auth.bats
+++ b/systemtest/040-local-registry-auth.bats
@@ -17,6 +17,7 @@ function setup() {
     _cred_dir=$TESTDIR/credentials
     # It is important to change XDG_RUNTIME_DIR only after we start the registry, otherwise it affects the path of $XDG_RUNTIME_DIR/netns maintained by Podman,
     # making it impossible to clean up after ourselves.
+    export XDG_RUNTIME_DIR_OLD=$XDG_RUNTIME_DIR
     export XDG_RUNTIME_DIR=$_cred_dir
     mkdir -p $_cred_dir/containers
     # Remove old/stale cred file
@@ -111,6 +112,9 @@ function setup() {
 }
 
 teardown() {
+    # Need to restore XDG_RUNTIME_DIR.
+    XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR_OLD
+
     podman rm -f reg
 
     if [[ -n $_cred_dir ]]; then


### PR DESCRIPTION
Need to restore `XDG_RUNTIME_DIR` when podman removes the registry.

---

The test fails on rootless because it fails to remove the registry container.

<details>
<summary>tests are failed on rootless</summary>

```
ok 1 auth: credentials on command line
not ok 2 auth: credentials via podman login
# (from function `log_and_run' in file systemtest/helpers.bash, line 130,
#  from function `start_registry' in file systemtest/helpers.bash, line 354,
#  from function `setup' in test file systemtest/040-local-registry-auth.bats, line 15)
#   `start_registry --testuser=$testuser --testpassword=$testpassword --enable-delete=true reg' failed with status 125
# grep: /tmp/skopeo_bats.QQTiih/auth/htpasswd: No such file or directory
# $ podman --cgroup-manager=cgroupfs run -d --name reg -v /tmp/skopeo_bats.QQTiih/auth:/auth:Z -p 5000:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true -e REGISTRY_AUTH=htpasswd -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -e REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm quay.io/libpod/registry:2
# Error: creating container storage: the container name "reg" is already in use by d01c4e29dcd83ff882f15098417e456250760cc1db7a969e1d5a06e24b54aedc. You have to remove that container to be able to reuse that name: that name is already in use
# reg
ok 3 auth: copy with --src-creds and --dest-creds
not ok 4 auth: credentials via authfile
# (from function `log_and_run' in file systemtest/helpers.bash, line 130,
#  from function `start_registry' in file systemtest/helpers.bash, line 354,
#  from function `setup' in test file systemtest/040-local-registry-auth.bats, line 15)
#   `start_registry --testuser=$testuser --testpassword=$testpassword --enable-delete=true reg' failed with status 125
# grep: /tmp/skopeo_bats.PDl4IN/auth/htpasswd: No such file or directory
# $ podman --cgroup-manager=cgroupfs run -d --name reg -v /tmp/skopeo_bats.PDl4IN/auth:/auth:Z -p 5000:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true -e REGISTRY_AUTH=htpasswd -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -e REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm quay.io/libpod/registry:2
# Error: creating container storage: the container name "reg" is already in use by 66ec0f8a781d1fbc7f0b36153669f06e4e0aec2c9cffe5a404b9ed2fec836ac7. You have to remove that container to be able to reuse that name: that name is already in use
# reg
```
</details>

<details>
<summary>tests are succeeded on rootless after applying this commit</summary>

```
ok 1 auth: credentials on command line
ok 2 auth: credentials via podman login
ok 3 auth: copy with --src-creds and --dest-creds
ok 4 auth: credentials via authfile
```
</details>