### PR TITLE
Fix error handling of signature.NewEphemeralGPGSigningMechanism

### DIFF
--- a/cmd/skopeo/signing.go
+++ b/cmd/skopeo/signing.go
@@ -116,11 +116,15 @@ func (opts *standaloneVerifyOptions) run(args []string, stdout io.Writer) error 
 			return fmt.Errorf("Error reading public keys from %s: %w", opts.publicKeyFile, err)
 		}
 		mech, publicKeyfingerprints, err = signature.NewEphemeralGPGSigningMechanism(publicKeys)
+		if err != nil {
+			return fmt.Errorf("Error initializing GPG: %w", err)
+
+		}
 	} else {
 		mech, err = signature.NewGPGSigningMechanism()
-	}
-	if err != nil {
-		return fmt.Errorf("Error initializing GPG: %w", err)
+		if err != nil {
+			return fmt.Errorf("Error initializing GPG: %w", err)
+		}
 	}
 	defer mech.Close()
 


### PR DESCRIPTION
`signature.NewEphemeralGPGSigningMechanism is called` in an `if` branch where the previous `err :=` introduces a "new" `err` variable, which means the failure isn't visible after the `if`.

So, do the dumb thing and just check on both branches explicitly. (We still need to worry about correctly setting `mech` and `publicKeyfingerprints` to persist after the `if`.)

How I hate Go sometimes. And this shows we really should update the linter.