### PR TITLE
Avoid use of a deprecated capability.NewPid

### DIFF
--- a/cmd/skopeo/unshare_linux.go
+++ b/cmd/skopeo/unshare_linux.go
@@ -22,9 +22,12 @@ func maybeReexec() error {
 	// With Skopeo we need only the subset of the root capabilities necessary
 	// for pulling an image to the storage.  Do not attempt to create a namespace
 	// if we already have the capabilities we need.
-	capabilities, err := capability.NewPid(0)
+	capabilities, err := capability.NewPid2(0)
 	if err != nil {
 		return fmt.Errorf("error reading the current capabilities sets: %w", err)
+	}
+	if err := capabilities.Load(); err != nil {
+		return fmt.Errorf("error loading the current capabilities sets: %w", err)
 	}
 	if slices.ContainsFunc(neededCapabilities, func(cap capability.Cap) bool {
 		return !capabilities.Get(capability.EFFECTIVE, cap)


### PR DESCRIPTION
This is reported by golangci-lint in #1967 .

(Absolutely untested.)