### PR TITLE
[release-1.3] Cirrus: Add CI self-destruct condition on EOL date

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -6,6 +6,17 @@
 
 set -e
 
+_EOL=20250501
+if [[ $(date +%Y%m%d) -ge $_EOL ]]; then
+    die "As of $_EOL this branch is probably
+no longer supported in RHEL 8.4, please
+confirm this with RHEL Program Management.  If so:
+It should be removed from Cirrus-Cron,
+the .cirrus.yml file removed, and
+the VM images (manually) unmarked
+'permanent=true'"
+fi
+
 if [[ -r "/etc/automation_environment" ]]; then
     source /etc/automation_environment
     source $AUTOMATION_LIB_PATH/common_lib.sh


### PR DESCRIPTION
This branch will never receive any security-backports when the associated RHEL release reaches EOL.  Add a condition to force CI to break with a helpful message, after this RHEL EOL date.