### PR TITLE
Packit: easier to read distro conditionals

### DIFF
--- a/rpm/update-spec-provides.sh
+++ b/rpm/update-spec-provides.sh
@@ -4,9 +4,9 @@
 # packaging, via the `propose-downstream` packit action.
 # The goimports don't need to be present upstream.
 
-set -e
+set -eo pipefail
 
-PACKAGE=$(basename $(git rev-parse --show-toplevel))
+PACKAGE=skopeo
 # script is run from git root directory
 SPEC_FILE=rpm/$PACKAGE.spec
 


### PR DESCRIPTION
Distro conditionals have been rewritten in a cleaner
and easier to read way.
    
All `bcond` macros have been replaced with friendlier alternatives.
    
Also removed macros related to `import_path` as they are no longer
necessary.
