### PR TITLE
Help Renovate manage the golangci-lint version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,11 +49,4 @@
   /*************************************************
    *** Repository-specific configuration options ***
    *************************************************/
-
-  // Don't leave dep. update. PRs "hanging", assign them to people.
-  "assignees": ["containers/image-maintainers"],  // same for skopeo
-
-  /*************************************************
-   ***** Golang-specific configuration options *****
-   *************************************************/
 }

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ GOBIN := $(shell $(GO) env GOBIN)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
+# N/B: This value is managed by Renovate, manual changes are
+# possible, as long as they don't disturb the formatting
+# (i.e. DO NOT ADD A 'v' prefix!)
+GOLANGCI_LINT_VERSION := 1.53.2
+
 ifeq ($(GOBIN),)
 GOBIN := $(GOPATH)/bin
 endif
@@ -183,7 +188,7 @@ shell:
 
 tools:
 	if [ ! -x "$(GOBIN)/golangci-lint" ]; then \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.52.2 ; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v$(GOLANGCI_LINT_VERSION) ; \
 	fi
 
 check: validate test-unit test-integration test-system


### PR DESCRIPTION
It's a bit cumbersome to manage a tooling version buried deep in a command, let alone one also buried deep in a `Makefile`.  Add a variable to hold the version number so renovate can easily manage it. This happens via a `regex` manager in the shared configuration include `containers/automation//renovate/defaults.json5`.  Also add a helpful note/reminder to humans who may want to manually change the version for some reason.

Depends on: https://github.com/containers/automation/pull/145