### PR TITLE
[CI:BUILD] RPM: fix ELN builds

### DIFF
--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -52,7 +52,7 @@ Summary: Inspect container images and repositories on registries
 URL: https://github.com/containers/%{name}
 # Tarball fetched from upstream
 Source0: %{url}/archive/v%{version}.tar.gz
-BuildRequires: go-md2man
+BuildRequires: %{_bindir}/go-md2man
 %if %{defined build_with_btrfs}
 BuildRequires: btrfs-progs-devel
 %endif


### PR DESCRIPTION
For Fedora, we need to ensure ELN builds are successful.

The recent skopeo builds have been failing on copr because of /usr/bin/go-md2man being available via different package names. https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/6119200/

This commit changes go-md2man dependency directly on the binary path instead of a pacakge.

ELN scratch builds are now successful:
https://koji.fedoraproject.org/koji/taskinfo?taskID=102706281