### PR TITLE
Bump to v1.13.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.12.1-dev"
+const Version = "1.13.0"


### PR DESCRIPTION
As the title says.  In preparation of RHEL 8.9/9.3

[NO NEW TESTS NEEDED]