### PR TITLE
[release-1.13 backport] [CI:BUILD] Packit: install golist before updating downstream spec

### DIFF
--- a/rpm/update-spec-provides.sh
+++ b/rpm/update-spec-provides.sh
@@ -5,13 +5,30 @@
 # The goimports don't need to be present upstream.
 
 set -eo pipefail
+set -x
 
 PACKAGE=skopeo
 # script is run from git root directory
 SPEC_FILE=rpm/$PACKAGE.spec
 
+# Needed for golist to work
+# This is run in the packit sandbox environment for downstream tasks and
+# doesn't affect upstream repo and CI.
+export GOPATH=~/go
+GOPATHDIR=$GOPATH/src/github.com/containers/
+mkdir -p $GOPATHDIR
+ln -sf $(pwd) $GOPATHDIR/.
+
+# Packit sandbox doesn't allow root
+# Install golist by downloading and extracting rpm
+# We could handle this in packit `sandcastle` upstream itself
+# but that depends on golist existing in epel
+# https://github.com/packit/sandcastle/pull/186
+dnf download golist
+rpm2cpio golist-*.rpm | cpio -idmv
+
 sed -i '/Provides: bundled(golang.*/d' $SPEC_FILE
 
-GO_IMPORTS=$(golist --imported --package-path github.com/containers/$PACKAGE --skip-self | sort -u | xargs "-I{}" echo "Provides: bundled(golang({}))")
+GO_IMPORTS=$(./usr/bin/golist --imported --package-path github.com/containers/$PACKAGE --skip-self | sort -u | xargs "-I{}" echo "Provides: bundled(golang({}))")
 
 awk -v r="$GO_IMPORTS" '/^# vendored libraries/ {print; print r; next} 1' $SPEC_FILE > temp && mv temp $SPEC_FILE


### PR DESCRIPTION
The default Packit sandbox environment that runs Packit tasks for downstream Fedora does not have golist installed by default and can't run superuser tasks.

This commit will download and extract the golist binary from the Fedora rpm and use it to provide golist.

The GOPATH mention in `rpm/update-spec-provides.sh` is only required for golist to generate the gopaths and doesn't affect upstream or the rpm spec.

Currently, the only way to reliably test this is on an open github issue by running `/packit propose-downstream`. This can't be run on an open PR. The job-specific packit actions can only be tested via the packit service and not via packit cli.


(cherry picked from commit a39972ca35e334b0f04ac999f57faf1ec32cdc79)