### PR TITLE
Add Gosec GitHub Action

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,25 @@
+name: Run Gosec
+on:
+  push:
+jobs:
+  gosec:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@3a6fd99e54aca25365f6873883ede35d4c00d917 # master
+        with:
+          # we let the report trigger content trigger a failure using the GitHub Security features.
+          args: '-no-fail -fmt sarif -out results.sarif ./...'
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@46ed16ded91731b2df79a2893d3aea8e9f03b5c4 # v2
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: results.sarif


### PR DESCRIPTION
GoSec inspects source code for security problems by scanning the Go AST.

Currently, gosec reports a number of findings that skopeo may want to address. At least with gosec as part of GitHub Actions, the skopeo project can be aware of the current state of skopeo as well the impact changes make upon it.

See: https://github.com/securego/gosec