### PR TITLE
copy: add support for `--format zstd`

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/cli"
 	"github.com/containers/image/v5/pkg/cli/sigstore"
+	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/signature/signer"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -159,10 +160,18 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 	}
 
 	var manifestType string
+	var requiredCompression string
 	if opts.format.Present() {
-		manifestType, err = parseManifestFormat(opts.format.Value())
+		manifestType, requiredCompression, err = parseManifestFormat(opts.format.Value())
 		if err != nil {
 			return err
+		}
+		if requiredCompression != "" {
+			cf, err := compression.AlgorithmByName(requiredCompression)
+			if err != nil {
+				return err
+			}
+			destinationCtx.CompressionFormat = &cf
 		}
 	}
 

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -556,7 +556,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 
 	var manifestType string
 	if opts.format.Present() {
-		manifestType, err = parseManifestFormat(opts.format.Value())
+		manifestType, _, err = parseManifestFormat(opts.format.Value())
 		if err != nil {
 			return err
 		}

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -349,16 +349,18 @@ func parseImageSource(ctx context.Context, opts *imageOptions, name string) (typ
 
 // parseManifestFormat parses format parameter for copy and sync command.
 // It returns string value to use as manifest MIME type
-func parseManifestFormat(manifestFormat string) (string, error) {
+func parseManifestFormat(manifestFormat string) (string, string, error) {
 	switch manifestFormat {
+	case "zstd":
+		return imgspecv1.MediaTypeImageManifest, "zstd", nil
 	case "oci":
-		return imgspecv1.MediaTypeImageManifest, nil
+		return imgspecv1.MediaTypeImageManifest, "", nil
 	case "v2s1":
-		return manifest.DockerV2Schema1SignedMediaType, nil
+		return manifest.DockerV2Schema1SignedMediaType, "", nil
 	case "v2s2":
-		return manifest.DockerV2Schema2MediaType, nil
+		return manifest.DockerV2Schema2MediaType, "", nil
 	default:
-		return "", fmt.Errorf("unknown format %q. Choose one of the supported formats: 'oci', 'v2s1', or 'v2s2'", manifestFormat)
+		return "", "", fmt.Errorf("unknown format %q. Choose one of the supported formats: 'oci', 'v2s1', or 'v2s2'", manifestFormat)
 	}
 }
 

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -68,7 +68,7 @@ This option does not change what will be copied; consider using `--all` at the s
 
 **--format**, **-f** _manifest-type_
 
-MANIFEST TYPE (oci, v2s1, or v2s2) to use in the destination (default is manifest type of source, with fallbacks)
+MANIFEST TYPE (zstd, oci, v2s1, or v2s2) to use in the destination (default is manifest type of source, with fallbacks)
 
 **--help**, **-h**
 

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -1138,6 +1138,13 @@ func (s *copySuite) TestCopyManifestConversion() {
 	// convert from v2s1 to v2s2
 	assertSkopeoSucceeds(t, "", "copy", "--format=v2s2", "dir:"+destDir1, "dir:"+destDir2)
 	verifyManifestMIMEType(t, destDir2, manifest.DockerV2Schema2MediaType)
+
+	// convert from v2s2 to oci
+	assertSkopeoSucceeds(t, "", "copy", "--format=oci", "dir:"+srcDir, "dir:"+destDir1)
+	verifyManifestMIMEType(t, destDir1, imgspecv1.MediaTypeImageManifest)
+	// verify oci gzip getting convert to zstd
+	assertSkopeoSucceeds(t, "", "copy", "--format=zstd", "dir:"+destDir1, "dir:"+destDir2)
+	verifyInstanceZstdCompression(t, destDir2, imgspecv1.MediaTypeImageManifest)
 }
 
 func (s *copySuite) TestCopyPreserveDigests() {

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -214,3 +214,22 @@ func verifyManifestMIMEType(t *testing.T, dir string, expectedMIMEType string) {
 	mimeType := manifest.GuessMIMEType(manifestBlob)
 	assert.Equal(t, expectedMIMEType, mimeType)
 }
+
+// Verifies if all instances have been compression with zstd
+func verifyInstanceZstdCompression(t *testing.T, dir string, expectedMIMEType string) {
+	manifestBlob, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	require.NoError(t, err)
+	mimeType := manifest.GuessMIMEType(manifestBlob)
+	assert.Equal(t, expectedMIMEType, mimeType)
+
+	list, err := manifest.ListFromBlob(manifestBlob, mimeType)
+	require.NoError(t, err)
+
+	instances := list.Instances()
+	annotations := map[string]string{"io.github.containers.compression.zstd": "true"}
+	for _, digest := range instances {
+		instance, err := list.Instance(digest)
+		require.NoError(t, err)
+		assert.Equal(t, annotations, instance.ReadOnly.Annotations)
+	}
+}


### PR DESCRIPTION
`skopeo copy --format zstd` copy contents of manifest list from source to destination and verifying the destination is converted to `OCI` manifest list and each image converted and compression with `zstd` compression algorithm.

Needs: https://github.com/containers/image/pull/2047