### PR TITLE
[release-1.13] Bump to v1.13.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.13.1"
+const Version = "1.13.2-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.13.1-dev"
+const Version = "1.13.1"


### PR DESCRIPTION
In preparation for functional freeze for RHEL 8.9/9.3, create Skopeo v1.31.1 and then bump it to 1.13.2-dev in this branch.

I'll tag and spin a release after this merges for Jindrich.

[NO NEW TESTS NEEDED]