### PR TITLE
RPM: define gobuild macro for rhel/centos stream

### DIFF
--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -7,9 +7,12 @@
 %global debug_package %{nil}
 %endif
 
-# RHEL 8's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
-# set it separately here and do not depend on RHEL 8's go-srpm-macros package.
-%if %{defined rhel} && 0%{?rhel} == 8
+# RHEL's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
+# set it separately here and do not depend on RHEL's go-[s]rpm-macros package
+# until that's fixed.
+# c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
+# c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331
+%if %{defined rhel}
 %define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "-linkmode=external -compressdwarf=false ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
 %endif
 


### PR DESCRIPTION
The current gobuild macro doesn't account for build tags on both c9s and c8s. This is currently causing copr build failures for c9s.

Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/6220412/

This commit will define gobuild for all those envs until gobuild is fixed by default.

Refs:
c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331