### PR TITLE
Update to Go 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/skopeo
 
-go 1.18
+go 1.19
 
 require (
 	github.com/containers/common v0.55.0


### PR DESCRIPTION
We already require it, because docker/credential-helpers uses Go 1.19 os/exec.Cmd.Environ(). So make that official.

> go mod tidy -go=1.19