### PR TITLE
[skip-ci] GHA: Closed issue/PR comment-lock

### DIFF
--- a/.github/workflows/discussion_lock.yml
+++ b/.github/workflows/discussion_lock.yml
@@ -1,0 +1,20 @@
+---
+
+# See also:
+# https://github.com/containers/podman/blob/main/.github/workflows/discussion_lock.yml
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+  # Debug: Allow triggering job manually in github-actions WebUI
+  workflow_dispatch: {}
+
+jobs:
+  # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  closed_issue_discussion_lock:
+    uses: containers/podman/.github/workflows/discussion_lock.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
Lock discussions on closed PRs and Issues after 90-days of inactivity.

Ref:
     https://github.com/containers/podman/discussions/19012
and
     https://github.com/containers/podman/pull/19691
and
     https://github.com/containers/podman/pull/19700