### PR TITLE
Packit: tag @lsm5 on copr build failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,8 +15,10 @@ srpm_build_deps:
 jobs:
   - job: copr_build
     trigger: pull_request
+    notifications:
+      failure_comment:
+        message: "Ephemeral COPR build failed. @lsm5 please check."
     enable_net: true
-    # keep in sync with https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next
     targets:
       - fedora-all-x86_64
       - fedora-all-aarch64
@@ -32,6 +34,9 @@ jobs:
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    notifications:
+      failure_comment:
+        message: "podman-next COPR build failed. @lsm5 please check."
     branch: main
     owner: rhcontainerbot
     project: podman-next


### PR DESCRIPTION
This change will auto-tag @lsm5 in a github comment on every copr build failure.


@mtrmac @vrothberg PTAL