### PR TITLE
copy: Note support for `zstd:chunked`

### DIFF
--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -182,7 +182,7 @@ Existing signatures, if any, are preserved as well.
 
 **--dest-compress-format** _format_
 
-Specifies the compression format to use.  Supported values are: `gzip` and `zstd`.
+Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.
 
 **--dest-compress-level** _format_
 


### PR DESCRIPTION
Since this comes from the underlying c/image library.