### PR TITLE
Remove unused environment variables in Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,11 +20,6 @@ env:
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
 
-    ####
-    #### Cache-image names to test with (double-quotes around names are critical)
-    ####
-    FEDORA_NAME: "fedora-38"
-
     # Google-cloud VM Images
     IMAGE_SUFFIX: "c20231004t194547z-f39f38d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"


### PR DESCRIPTION
Some other containers/* repos use these values in test names; we don't, so remove them so that we don't have to worry about keeping them up to date.

Previously #2131. Cc: @cevich 