### PR TITLE
Fix ENTRYPOINT documentation, drop others.

### DIFF
--- a/contrib/skopeoimage/README.md
+++ b/contrib/skopeoimage/README.md
@@ -25,9 +25,7 @@ the images live are public and can be pulled without credentials.  These contain
 resulting containers can run safely with privileges within the container.
 
 The container images are built using the latest Fedora and then Skopeo is installed into them.
-The PATH in the container images is set to the default PATH provided by Fedora.  Also, the
-ENTRYPOINT and the WORKDIR variables are not set within these container images, as such they
-default to `/`.
+The ENTRYPOINT of the container is set to execute the `skopeo` binary.
 
 The container images are:
 


### PR DESCRIPTION
`ENTRYPOINT` was incorrectly documented to be set to `/` (which doesn't even make sense).

Stop mentioning `PATH` and `WORKDIR` in the top-level `README`, typical users of the container shouldn't need to care, and it's already somewhat implied by "built using the latest Fedora".

Fixes #2134.

We should also update the READMEs in some https://quay.io/organization/skopeo repos and https://quay.io/repository/containers/skopeo ; @TomSweeneyRedHat do you know who has write access to that?