### PR TITLE
Add --check-policy option to skopeo inspect

### DIFF
--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -28,6 +28,10 @@ If the authorization state is not found there, $HOME/.docker/config.json is chec
 
 Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry.
 
+**--check-policy**
+
+Verify that the image pass the policy check.
+
 **--config**
 
 Output configuration in OCI format, default is to format in JSON format.


### PR DESCRIPTION
When handling images with skopeo it can be useful to be able to check that the image is valid before processing any of its metadata. With the new `--check-policy` flag `skopeo inspect` will error out if the image doesn't pass the policy check.