### PR TITLE
[release-1.6] Stop trying to install sif prerequisite RPMs

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -66,9 +66,6 @@ _run_setup() {
     # VM's come with the distro. skopeo package pre-installed
     dnf erase -y skopeo
 
-    # Required for testing the SIF transport
-    dnf install -y fakeroot squashfs-tools
-
     msg "Removing systemd-resolved from nsswitch.conf"
     # /etc/resolv.conf is already set to bypass systemd-resolvd
     sed -i -r -e 's/^(hosts.+)resolve.+dns/\1dns/' /etc/nsswitch.conf


### PR DESCRIPTION
Fedora 36 repos no longer exist, so these installations always fail: https://cirrus-ci.com/build/5827089207656448 .

The SIF test in systemtest/020-copy.bats is already conditionalized on the presence of the tools, so it should now be skipped.