### PR TITLE
[Makefile] Don't compile during install

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,7 +92,7 @@ osx_task:
         export PATH=$GOPATH/bin:$PATH
         go version
         go env
-        make validate-local test-unit-local bin/skopeo
+        make validate-local test-unit-local bin/skopeo docs completions
         sudo make install
         /usr/local/bin/skopeo -v
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ endif
 #     Note: Uses the -N -l go compiler options to disable compiler optimizations
 #           and inlining. Using these build options allows you to subsequently
 #           use source debugging tools like delve.
-all: bin/skopeo docs
+all: bin/skopeo docs completions
 
 codespell:
 	codespell -S Makefile,build,buildah,buildah.spec,imgtype,copy,AUTHORS,bin,vendor,.git,go.sum,CHANGELOG.md,changelog.txt,seccomp.json,.cirrus.yml,"*.xz,*.gz,*.tar,*.tgz,*ico,*.png,*.1,*.5,*.orig,*.rej" -L fpr,uint,iff,od,ERRO -w
@@ -148,7 +148,7 @@ docs-in-container:
 	${CONTAINER_RUN} $(MAKE) docs $(if $(DEBUG),DEBUG=$(DEBUG))
 
 .PHONY: completions
-completions: bin/skopeo
+completions:
 	install -d -m 755 completions/bash completions/zsh completions/fish completions/powershell
 	./bin/skopeo completion bash >| completions/bash/skopeo
 	./bin/skopeo completion zsh >| completions/zsh/_skopeo
@@ -165,17 +165,17 @@ install: install-binary install-docs install-completions
 	install -d -m 755 ${DESTDIR}${REGISTRIESDDIR}
 	install -m 644 default.yaml ${DESTDIR}${REGISTRIESDDIR}/default.yaml
 
-install-binary: bin/skopeo
+install-binary:
 	install -d -m 755 ${DESTDIR}${BINDIR}
 	install -m 755 bin/skopeo ${DESTDIR}${BINDIR}/skopeo
 
-install-docs: docs
+install-docs:
 ifneq ($(DISABLE_DOCS), 1)
 	install -d -m 755 ${DESTDIR}${MANDIR}/man1
 	install -m 644 docs/*.1 ${DESTDIR}${MANDIR}/man1
 endif
 
-install-completions: completions
+install-completions:
 	install -d -m 755 ${DESTDIR}${BASHINSTALLDIR}
 	install -m 644 completions/bash/skopeo ${DESTDIR}${BASHINSTALLDIR}
 	install -d -m 755 ${DESTDIR}${ZSHINSTALLDIR}

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -96,7 +96,7 @@ _run_vendor() {
 }
 
 _run_build() {
-    make bin/skopeo BUILDTAGS="$BUILDTAGS"
+    make bin/skopeo docs completions BUILDTAGS="$BUILDTAGS"
     make install PREFIX=/usr/local
 }
 

--- a/install.md
+++ b/install.md
@@ -187,7 +187,7 @@ git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containers
 cd $GOPATH/src/github.com/containers/skopeo && make bin/skopeo
 ```
 
-By default the `make` command (make all) will build bin/skopeo and the documentation locally.
+By default the `make` command (make all) will build bin/skopeo with completions and the documentation locally.
 
 Building of documentation requires `go-md2man`. On systems that do not have this tool, the
 document generation can be skipped by passing `DISABLE_DOCS=1`:

--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -100,11 +100,6 @@ This package contains system tests for %{name}
 
 %prep
 %autosetup -Sgit %{name}-%{version}
-# The %%install stage should not rebuild anything but only install what's
-# built in the %%build stage. So, remove any dependency on build targets.
-sed -i 's/^install-binary: bin\/%{name}.*/install-binary:/' Makefile
-sed -i 's/^completions: bin\/%{name}.*/completions:/' Makefile
-sed -i 's/^install-docs: docs.*/install-docs:/' Makefile
 
 %build
 %set_build_flags
@@ -130,7 +125,7 @@ export BUILDTAGS="$BASEBUILDTAGS btrfs_noversion exclude_graphdriver_btrfs"
 LDFLAGS=''
 
 %gobuild -o bin/%{name} ./cmd/%{name}
-%{__make} docs
+%{__make} docs completions
 
 %install
 make \


### PR DESCRIPTION
Usually while building from source, `make` and `make install` is a common phenomenon. Former only compiles and latter only installs.

Standard procedure of `make && make install` compiles same package twice wasting CPU cycles and producing heat which causes climate change. So trying to fix that. #MakeEarthGreenAgain