### PR TITLE
Accept URI for Sigstore Signed Images

### DIFF
--- a/vendor/github.com/containers/image/v5/signature/fulcio_cert.go
+++ b/vendor/github.com/containers/image/v5/signature/fulcio_cert.go
@@ -7,6 +7,7 @@ import (
 	"encoding/asn1"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/containers/image/v5/signature/internal"
@@ -21,14 +22,15 @@ type fulcioTrustRoot struct {
 	caCertificates *x509.CertPool
 	oidcIssuer     string
 	subjectEmail   string
+	URI            string
 }
 
 func (f *fulcioTrustRoot) validate() error {
 	if f.oidcIssuer == "" {
 		return errors.New("Internal inconsistency: Fulcio use set up without OIDC issuer")
 	}
-	if f.subjectEmail == "" {
-		return errors.New("Internal inconsistency: Fulcio use set up without subject email")
+	if f.subjectEmail == "" && f.URI == "" {
+		return errors.New("Internal inconsistency: Fulcio use set up without subject email or URI")
 	}
 	return nil
 }
@@ -174,10 +176,17 @@ func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, 
 	}
 
 	// == Validate the OIDC subject
-	if !slices.Contains(untrustedCertificate.EmailAddresses, f.subjectEmail) {
-		return nil, internal.NewInvalidSignatureError(fmt.Sprintf("Required email %s not found (got %#v)",
-			f.subjectEmail,
-			untrustedCertificate.EmailAddresses))
+	if !slices.Contains(untrustedCertificate.EmailAddresses, f.subjectEmail) && !strings.Contains(untrustedCertificate.URIs[0].String(), f.URI) {
+		if len(untrustedCertificate.EmailAddresses) > 0 {
+			return nil, internal.NewInvalidSignatureError(fmt.Sprintf("Required email %s not found (got %#v)",
+				f.subjectEmail,
+				untrustedCertificate.EmailAddresses))
+		}
+		if len(untrustedCertificate.URIs) > 0 {
+			return nil, internal.NewInvalidSignatureError(fmt.Sprintf("Required URI %s not found (got %#v)",
+				f.URI,
+				untrustedCertificate.URIs))
+		}
 	}
 	// FIXME: Match more subject types? Cosign does:
 	// - .DNSNames (can’t be issued by Fulcio)

--- a/vendor/github.com/containers/image/v5/signature/policy_eval_sigstore.go
+++ b/vendor/github.com/containers/image/v5/signature/policy_eval_sigstore.go
@@ -57,6 +57,7 @@ func (f *prSigstoreSignedFulcio) prepareTrustRoot() (*fulcioTrustRoot, error) {
 		caCertificates: certs,
 		oidcIssuer:     f.OIDCIssuer,
 		subjectEmail:   f.SubjectEmail,
+		URI:            f.URI,
 	}
 	if err := fulcio.validate(); err != nil {
 		return nil, err

--- a/vendor/github.com/containers/image/v5/signature/policy_types.go
+++ b/vendor/github.com/containers/image/v5/signature/policy_types.go
@@ -154,6 +154,8 @@ type prSigstoreSignedFulcio struct {
 	OIDCIssuer string `json:"oidcIssuer,omitempty"`
 	// SubjectEmail specifies the expected email address of the authenticated OIDC identity, recorded by Fulcio into the generated certificates.
 	SubjectEmail string `json:"subjectEmail,omitempty"`
+	// URI specifies the expected URI of the authenticated OIDC identity, recorded by Fulcio into the generated certificates.
+	URI string `json:"URI,omitempty"`
 }
 
 // PolicyReferenceMatch specifies a set of image identities accepted in PolicyRequirement.


### PR DESCRIPTION
Fixes https://github.com/coreos/rpm-ostree/issues/4272#issuecomment-1689160021

Allows for container images signatures with a URI instead of a email
address as the SAN. This is needed in certain cases such as using a github workflow to sign a container using the github actions OIDC token.

The URI field was added to the `fulcioTrustRoot` struct and associated functions were modifed/created. Logic to handle either having a URI or email address as the SAN was also implemented.

**Testing:**
1. Copy and store `fulcio_v1.crt.pem` to `/etc/pki/containers/fulcio.sigstore.dev.pub` and `rekor.pub` to `/etc/pki/containers/rekor.sigstore.dev.pub`, both of which can be found at: https://github.com/sigstore/root-signing/blob/main/README.md

2. Configure `/etc/containers/policy.json`
```
{
  "default": [
    {
      "type": "reject"
    }
  ],
  "transports": {
    "docker": {
      "registry.access.redhat.com": [
        {
          "type": "signedBy",
          "keyType": "GPGKeys",
          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
        }
      ],
      "registry.redhat.io": [
        {
          "type": "signedBy",
          "keyType": "GPGKeys",
          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
        }
      ],
      "ghcr.io/jmpolom": [
        {
          "type": "sigstoreSigned",
          "fulcio": {
            "caPath": "/etc/pki/containers/fulcio.sigstore.dev.pub",
            "oidcIssuer": "https://token.actions.githubusercontent.com",
            "URI": "https://github.com/jmpolom/fedora-ostree-ws-container/.github/workflows/build.yml@refs/heads/main"
          },
          "rekorPublicKeyPath": "/etc/pki/containers/rekor.sigstore.dev.pub",
          "signedIdentity": {
            "type": "matchRepository"
          }
        }
      ]
    },
    "docker-daemon": {
      "": [
        {
          "type": "insecureAcceptAnything"
        }
      ]
    }
  }
}
```

3. Create `/etc/containers/registries.d/ghcr.io.yaml`
```
docker:
     ghcr.io/jmpolom:
         use-sigstore-attachments: true
```

4. Build the skopeo binary and run the following
```
$ ./bin/skopeo copy docker://ghcr.io/jmpolom/fedora-silverblue-ws:38-main dir:/some/local/directory
```