### PR TITLE
Fix libsubid detection

### DIFF
--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -5,11 +5,16 @@ fi
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT
-cc -o "$tmpdir"/libsubid_tag -l subid -x c - > /dev/null 2> /dev/null << EOF
+cc -o "$tmpdir"/libsubid_tag -x c - -l subid > /dev/null 2> /dev/null << EOF
 #include <shadow/subid.h>
+#include <stdlib.h>
 int main() {
 	struct subid_range *ranges = NULL;
+#if SUBID_ABI_MAJOR >= 4
+	subid_get_uid_ranges("root", &ranges);
+#else
 	get_subuid_ranges("root", &ranges);
+#endif
 	free(ranges);
 	return 0;
 }


### PR DESCRIPTION
Currently, `$(hack/libsubid_tag.sh)` produces no buildtag output. This patch fixes it.

1. Library arguments must be positioned after sources when invoking GCC.
2. Use new function name: `subid_get_uid_ranges`.

Refs:
rhbz: https://bugzilla.redhat.com/show_bug.cgi?id=2254902
podman file: https://github.com/containers/podman/blob/main/hack/libsubid_tag.sh

@mtrmac @rhatdan PTAL