### PR TITLE
Bump to v1.14.1, and then to v1.15.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.14.1-dev"
+const Version = "1.14.1"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.14.1"
+const Version = "1.15.0-dev"


### PR DESCRIPTION
As the title says.

Skopeo v1.14.1 is headed for RHEL 8.10/9.4.  Once this first commit below merges, I'll create a release and a release branch (release-1.14) from it.  We'll then continue working on Skopeo v1.15.0-dev in main, and will target 1.15 or another Y version towards RHEL 9.5/10.0 beta sometime in the fall of 2024.

[NO NEW TESTS NEEDED]