### PR TITLE
Avoid a warning by gopls / VSCode

### DIFF
--- a/cmd/skopeo/unshare.go
+++ b/cmd/skopeo/unshare.go
@@ -3,6 +3,6 @@
 
 package main
 
-func reexecIfNecessaryForImages(inputImageNames ...string) error {
+func reexecIfNecessaryForImages(_ ...string) error {
 	return nil
 }


### PR DESCRIPTION
Should not change behavior.

`gopls` 0.15 newly warns about the unused parameter.