### PR TITLE
Update to Go 1.20

### DIFF
--- a/cmd/skopeo/list_tags.go
+++ b/cmd/skopeo/list_tags.go
@@ -78,16 +78,12 @@ See skopeo-list-tags(1) section "REPOSITORY NAMES" for the expected format
 // Customized version of the alltransports.ParseImageName and docker.ParseReference that does not place a default tag in the reference
 // Would really love to not have this, but needed to enforce tag-less and digest-less names
 func parseDockerRepositoryReference(refString string) (types.ImageReference, error) {
-	if !strings.HasPrefix(refString, docker.Transport.Name()+"://") {
+	dockerRefString, ok := strings.CutPrefix(refString, docker.Transport.Name()+"://")
+	if !ok {
 		return nil, fmt.Errorf("docker: image reference %s does not start with %s://", refString, docker.Transport.Name())
 	}
 
-	_, dockerImageName, hasColon := strings.Cut(refString, ":")
-	if !hasColon {
-		return nil, fmt.Errorf(`Invalid image name "%s", expected colon-separated transport:reference`, refString)
-	}
-
-	ref, err := reference.ParseNormalizedNamed(strings.TrimPrefix(dockerImageName, "//"))
+	ref, err := reference.ParseNormalizedNamed(dockerRefString)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/containers/skopeo
 
 // Minimum required golang version
-go 1.19 // *****  ATTENTION  WARNING  CAUTION  DANGER  ******
+go 1.20 // *****  ATTENTION  WARNING  CAUTION  DANGER  ******
 
 //         Go versions 1.21 and later will AUTO-UPDATE based
 //         on currently running tools and the (new) `toolchain`

--- a/install.md
+++ b/install.md
@@ -139,7 +139,7 @@ located at [https://github.com/containers/image_build/tree/main/skopeo](https://
 
 Otherwise, read on for building and installing it from source:
 
-To build the `skopeo` binary you need at least Go 1.19.
+To build the `skopeo` binary you need at least Go 1.20.
 
 There are two ways to build skopeo: in a container, or locally without a
 container. Choose the one which better matches your needs and environment.

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -268,8 +268,8 @@ func decompressDir(t *testing.T, dir string) {
 		rawLayer["size"] = uncompressedSize
 		var mimeType string
 		getRawMapField(t, rawLayer, "mediaType", &mimeType)
-		if strings.HasSuffix(mimeType, ".gzip") { // This should use CutSuffix with Go ≥1.20
-			rawLayer["mediaType"] = strings.TrimSuffix(mimeType, ".gzip")
+		if uncompressedMIMEType, ok := strings.CutSuffix(mimeType, ".gzip"); ok {
+			rawLayer["mediaType"] = uncompressedMIMEType
 		}
 
 		rawLayers[i] = rawLayer


### PR DESCRIPTION
After https://github.com/containers/image/pull/2337 (notably https://github.com/go-openapi/swag/compare/v0.22.10...v0.23.0 ), c/image will require Go 1.20 to build.

This does not yet update to that version of c/image, but that will happen soon enough.

So, update to Go 1.20, and take advantage of new standard library features.