### PR TITLE
Bump to v1.15.0 and then to v1.16.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.15.0"
+const Version = "1.16.0-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.15.0-dev"
+const Version = "1.15.0"


### PR DESCRIPTION
As the title says.  Given the changes to the c/* projects underneath Skopeo, I thought it would make sense to create a version that is using the same level of the c/* projects as Podman v5.0 and Buildah v1.35.  If this merges, I'll create a release and a release branch.

Setting main to 1.16.0-dev at the end of this.

[NO NEW TESTS NEEDED]