### PR TITLE
[skip-ci] rpm: use macro supported vendoring

### DIFF
--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -159,7 +159,7 @@ cp -pav systemtest/* %{buildroot}/%{_datadir}/%{name}/test/system/
 %{_datadir}/zsh/site-functions/_%{name}
 
 %files tests
-%license LICENSE
+%license LICENSE vendor/modules.txt
 %{_datadir}/%{name}/test
 
 %changelog


### PR DESCRIPTION
This removes the need for any `Provides: bundled()` we needed in spec files.

The updated Provides will be visible in the build logs and can also be verified with `rpm -q --provides $RPM_FILE`.