### PR TITLE
[CI:DOCS] Add golang 1.21 update warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,21 @@
 module github.com/containers/skopeo
 
-go 1.19
+// Minimum required golang version
+go 1.19 // *****  ATTENTION  WARNING  CAUTION  DANGER  ******
+
+//         Go versions 1.21 and later will AUTO-UPDATE based
+//         on currently running tools and the (new) `toolchain`
+//         value (when also increasing the `go` value above).
+//         ref: https://go.dev/doc/toolchain  Because several
+//         different distros and distro-versions build from
+//         this code, golang version consistency is
+//         desireable.  After manually updating to 1.21, a
+//         `toolchain` specificication should be added to pin
+//         the version and block auto-updates.  This does not
+//         block any future changes to the `go` value.
+//         Ref: Upstream discussion:
+//         https://github.com/golang/go/issues/65847
+//         *****  ATTENTION  WARNING  CAUTION  DANGER  ******
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
This is needed on the off-chance that some tool or a human suggests updating the minimum version to 1.21 or later. Since doing so would cause Fedora and Debian to start behaving differently WRT builds.

Ref: https://github.com/containers/podman/pull/22073