### PR TITLE
[release-1.14] Bump c/common to v0.57.4, Skopeo to v1.14.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/containers/skopeo
 go 1.19
 
 require (
-	github.com/containers/common v0.57.3
+	github.com/containers/common v0.57.4
 	github.com/containers/image/v5 v5.29.2
 	github.com/containers/ocicrypt v1.1.9
 	github.com/containers/storage v1.51.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/containerd/containerd v1.7.9 h1:KOhK01szQbM80YfW1H6RZKh85PHGqY/9OcEZ3
 github.com/containerd/containerd v1.7.9/go.mod h1:0/W44LWEYfSHoxBtsHIiNU/duEkgpMokemafHVCpq9Y=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1/go.mod h1:gr2RNwukQ/S9Nv33Lt6UC7xEx58C+LHRdoqbEKjz1Kk=
-github.com/containers/common v0.57.3 h1:g4NqE/4iqunqgp7htfJLPKAFKf1PAXkv2I65a7+lQJI=
-github.com/containers/common v0.57.3/go.mod h1:o3L3CyOI9yr+JC8l4dZgvqTxcjs3qdKmkek00uchgvw=
+github.com/containers/common v0.57.4 h1:kmfBad92kUjP5X44BPpOwMe+eZQqaKETfS+ASeL0g+g=
+github.com/containers/common v0.57.4/go.mod h1:o3L3CyOI9yr+JC8l4dZgvqTxcjs3qdKmkek00uchgvw=
 github.com/containers/image/v5 v5.29.2 h1:b8U0XYWhaQbKucK73IbmSm8WQyKAhKDbAHQc45XlsOw=
 github.com/containers/image/v5 v5.29.2/go.mod h1:kQ7qcDsps424ZAz24thD+x7+dJw1vgur3A9tTDsj97E=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/containerd/containerd/errdefs
 ## explicit; go 1.19
 github.com/containerd/stargz-snapshotter/estargz
 github.com/containerd/stargz-snapshotter/estargz/errorutil
-# github.com/containers/common v0.57.3
+# github.com/containers/common v0.57.4
 ## explicit; go 1.18
 github.com/containers/common/pkg/auth
 github.com/containers/common/pkg/capabilities

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.14.3-dev"
+const Version = "1.14.3"


### PR DESCRIPTION
Bump c/common to v0.57.4, then Skopeo to v1.14.3.

This is in preparation for RHEL 8.10/9.4