### PR TITLE
feat: add `--image-parallel-copies` flag

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -44,6 +44,7 @@ type copyOptions struct {
 	encryptLayer             []int                     // The list of layers to encrypt
 	encryptionKeys           []string                  // Keys needed to encrypt the image
 	decryptionKeys           []string                  // Keys needed to decrypt the image
+	imageParallelCopies      uint                      // Maximum number of parallel requests when copying images
 }
 
 func copyCmd(global *globalOptions) *cobra.Command {
@@ -95,6 +96,7 @@ See skopeo(1) section "IMAGE NAMES" for the expected format
 	flags.StringSliceVar(&opts.encryptionKeys, "encryption-key", []string{}, "*Experimental* key with the encryption protocol to use needed to encrypt the image (e.g. jwe:/path/to/key.pem)")
 	flags.IntSliceVar(&opts.encryptLayer, "encrypt-layer", []int{}, "*Experimental* the 0-indexed layer indices, with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer)")
 	flags.StringSliceVar(&opts.decryptionKeys, "decryption-key", []string{}, "*Experimental* key needed to decrypt the image")
+	flags.UintVar(&opts.imageParallelCopies, "image-parallel-copies", 0, "Maximum number of image layers to be copied (pulled/pushed) simultaneously. Not setting this field will fall back to containers/image defaults.")
 	return cmd
 }
 
@@ -300,6 +302,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 			OciDecryptConfig:                 decConfig,
 			OciEncryptLayers:                 encLayers,
 			OciEncryptConfig:                 encConfig,
+			MaxParallelDownloads:             opts.imageParallelCopies,
 		})
 		if err != nil {
 			return err

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -220,6 +220,10 @@ The username to access the destination registry.
 
 The password to access the destination registry.
 
+**--image-parallel-copies** _n_
+
+Maximum number of image layers to be copied (pulled/pushed) simultaneously. Not setting this field will fall back to containers/image defaults.
+
 ## EXAMPLES
 
 To just copy an image from one registry to another:


### PR DESCRIPTION
It would be useful when there are many layers while most of layers are unchanged between versions.

See discussion at https://github.com/nlewo/nix2container/pull/125