### PR TITLE
[skip-ci] Fix issue/pr lock workflow

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -1,7 +1,7 @@
 ---
 
 # See also:
-# https://github.com/containers/podman/blob/main/.github/workflows/discussion_lock.yml
+# https://github.com/containers/podman/blob/main/.github/workflows/issue_pr_lock.yml
 
 on:
   schedule:
@@ -12,7 +12,7 @@ on:
 jobs:
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
   closed_issue_discussion_lock:
-    uses: containers/podman/.github/workflows/discussion_lock.yml@main
+    uses: containers/podman/.github/workflows/issue_pr_lock.yml@main
     secrets: inherit
     permissions:
       contents: read


### PR DESCRIPTION
Followup to https://github.com/containers/podman/pull/22304

This will stop the torment of failure-alert e-mails due to the filename change.