### PR TITLE
[skip-ci] GHA: Fix exceeding secondary rate limit

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -5,7 +5,10 @@
 
 on:
   schedule:
-    - cron:  '0 0 * * *'
+    # N/B: This workflow easily encounters GitHub rate-limiting, do not run at the same
+    # time as Podman (00:00) or Buildah (01:10). Ref:
+    # https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+    - cron:  '20 2 * * *'
   # Debug: Allow triggering job manually in github-actions WebUI
   workflow_dispatch: {}
 


### PR DESCRIPTION
The dessant/lock-threads github action intermittantly encounters the error:

```
You have exceeded a secondary rate limit. Please wait a few minutes
before you try again.
```

While it's impossible to determine which documented or undocumented rate limit was exceeded, other users of this action have reported improvements by staggering their use of this action.

Ref: Issue 35 https://github.com/dessant/lock-threads/issues

Note: CI is useless for this PR, it must be manually reviewed and manually merged.  See also https://github.com/containers/buildah/pull/5471