### PR TITLE
Packit: disable PR merge attempts in builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,6 +8,9 @@
 
 specfile_path: rpm/skopeo.spec
 upstream_tag_template: v{version}
+# disable PR merge attempt in packit builds
+# https://packit.dev/docs/configuration#merge_pr_in_ci
+merge_pr_in_ci: false
 
 srpm_build_deps:
   - make


### PR DESCRIPTION
Packit jobs failed on https://github.com/containers/skopeo/pull/2285 as the PR target branch was `release-1.13` but Packit was trying to merge the commit into `main`.

This commit will disable the PR merge attempt. Mergeability can be handled elsewhere.

Ref: https://packit.dev/docs/configuration#merge_pr_in_ci

Signed-off-by: Lokesh Mandvekar <lsm5@redhat.com>
(cherry picked from commit bb333d77f6c011d969e64b2a86318bc33521f6ea)