### PR TITLE
fix summaries for `standalone-sign` and `standalone-verify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ Please read the [contribution guide](CONTRIBUTING.md) if you want to collaborate
 | [skopeo-login(1)](/docs/skopeo-login.1.md)         | Login to a container registry.                                                               |
 | [skopeo-logout(1)](/docs/skopeo-logout.1.md)       | Logout of a container registry.                                                              |
 | [skopeo-manifest-digest(1)](/docs/skopeo-manifest-digest.1.md)    | Compute a manifest digest for a manifest-file and write it to standard output.   |
-| [skopeo-standalone-sign(1)](/docs/skopeo-standalone-sign.1.md)    | Debugging tool - Publish and sign an image in one step.                                                         |
-| [skopeo-standalone-verify(1)](/docs/skopeo-standalone-verify.1.md)| Verify an image signature.                                                    |
+| [skopeo-standalone-sign(1)](/docs/skopeo-standalone-sign.1.md)    | Debugging tool - Sign an image locally without uploading.                     |
+| [skopeo-standalone-verify(1)](/docs/skopeo-standalone-verify.1.md)| Debugging tool - Verify an image signature from local files.                  |
 | [skopeo-sync(1)](/docs/skopeo-sync.1.md)           | Synchronize images between registry repositories and local directories.                      |
 
 License

--- a/docs/skopeo-standalone-sign.1.md
+++ b/docs/skopeo-standalone-sign.1.md
@@ -1,7 +1,7 @@
 % skopeo-standalone-sign(1)
 
 ## NAME
-skopeo\-standalone-sign - Debugging tool - Publish and sign an image in one step.
+skopeo\-standalone-sign - Debugging tool - Sign an image locally without uploading.
 
 ## SYNOPSIS
 **skopeo standalone-sign** [*options*] _manifest_ _docker-reference_ _key-fingerprint_ **--output**|**-o** _signature_

--- a/docs/skopeo-standalone-verify.1.md
+++ b/docs/skopeo-standalone-verify.1.md
@@ -1,7 +1,7 @@
 % skopeo-standalone-verify(1)
 
 ## NAME
-skopeo\-standalone\-verify - Verify an image signature.
+skopeo\-standalone\-verify - Debugging tool - Verify an image signature from local files.
 
 ## SYNOPSIS
 **skopeo standalone-verify** _manifest_ _docker-reference_ _key-fingerprints_ _signature_

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -110,8 +110,8 @@ Print the version number
 | [skopeo-login(1)](skopeo-login.1.md)  | Login to a container registry. |
 | [skopeo-logout(1)](skopeo-logout.1.md)  | Logout of a container registry. |
 | [skopeo-manifest-digest(1)](skopeo-manifest-digest.1.md)    | Compute a manifest digest for a manifest-file and write it to standard output. |
-| [skopeo-standalone-sign(1)](skopeo-standalone-sign.1.md)    | Debugging tool - Publish and sign an image in one step.      |
-| [skopeo-standalone-verify(1)](skopeo-standalone-verify.1.md)| Verify an image signature.                                   |
+| [skopeo-standalone-sign(1)](skopeo-standalone-sign.1.md)    | Debugging tool - Sign an image locally without uploading.    |
+| [skopeo-standalone-verify(1)](skopeo-standalone-verify.1.md)| Debugging tool - Verify an image signature from local files. |
 | [skopeo-sync(1)](skopeo-sync.1.md)| Synchronize images between registry repositories and local directories.                |
 
 ## EXIT STATUS


### PR DESCRIPTION
Correct the summary for `standalone-sign`. The old summary appears to be a bad copy-and-paste from `skopeo copy`.

Clarify that both of these tools are debugging tools, only operating on local files.