### PR TITLE
[skip-ci] RPM: bats requirement only on Fedora

### DIFF
--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -81,7 +81,9 @@ registries without the need to pull them
 Summary: Tests for %{name}
 
 Requires: %{name} = %{epoch}:%{version}-%{release}
+%if %{defined fedora}
 Requires: bats
+%endif
 Requires: gnupg
 Requires: jq
 Requires: golang


### PR DESCRIPTION
The bats package is not available on RHEL. It's in Fedora and EPEL.

Having bats as a requirement for the `skopeo-tests` subpackage will cause installibility test failures for RHEL 10 / C10S gating tests.

This commit makes `bats` a requirement only on Fedora. RHEL and CentOS Stream gating will need to fetch bats through separately enabling EPEL or other means.

Podman PR with similar change: https://github.com/containers/podman/pull/22632