### PR TITLE
hack: Support picking cc and cpp via environment variables.

### DIFF
--- a/hack/btrfs_installed_tag.sh
+++ b/hack/btrfs_installed_tag.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cc -E - > /dev/null 2> /dev/null << EOF
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <btrfs/ioctl.h>
 EOF
 if test $? -ne 0 ; then

--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cc -E - > /dev/null 2> /dev/null << EOF
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <btrfs/version.h>
 EOF
 if test $? -ne 0 ; then

--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -5,7 +5,8 @@ fi
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT
-cc -o "$tmpdir"/libsubid_tag -x c - -l subid > /dev/null 2> /dev/null << EOF
+${CC:-cc} ${CPPFLAGS} ${CFLAGS} -o "$tmpdir"/libsubid_tag -x c - -l subid \
+	  > /dev/null 2> /dev/null << EOF
 #include <shadow/subid.h>
 #include <stdlib.h>
 int main() {


### PR DESCRIPTION
Until now `cc' was hard-coded as the only compiler used.  Supporting selecting the compiler and preprocessor to be used via environment variables makes life easier for distributors, so this commit mimics how podman does it in its hack/* scripts.

Fixes #2278.