### PR TITLE
[skip-ci] Packit: `packages: [skopeo-fedora]` for podman-next jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -63,6 +63,7 @@ jobs:
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    packages: [skopeo-fedora]
     notifications:
       failure_comment:
         message: "podman-next COPR build failed. @containers/packit-build please check."


### PR DESCRIPTION
Without this change, packit will trigger duplicate jobs on podman-next for `skopeo-fedora`, `skopeo-centos` etc, which essentially point to the same spec file.

1 triggered job builds packages for all environments enabled on the COPR, so simply `skopeo-fedora` should suffice.