### PR TITLE
Stop using the exclude_graphdriver_devicemapper build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,10 @@ MANPAGES ?= $(MANPAGES_MD:%.md=%)
 BTRFS_BUILD_TAG = $(shell hack/btrfs_tag.sh) $(shell hack/btrfs_installed_tag.sh)
 LIBSUBID_BUILD_TAG = $(shell hack/libsubid_tag.sh)
 LOCAL_BUILD_TAGS = $(BTRFS_BUILD_TAG) $(LIBSUBID_BUILD_TAG)
-BUILDTAGS += exclude_graphdriver_devicemapper $(LOCAL_BUILD_TAGS)
+BUILDTAGS += $(LOCAL_BUILD_TAGS)
 
 ifeq ($(DISABLE_CGO), 1)
-	override BUILDTAGS = exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp
+	override BUILDTAGS = exclude_graphdriver_btrfs containers_image_openpgp
 endif
 
 #   make all DEBUG=1

--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -120,7 +120,7 @@ CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-an
 export CGO_CFLAGS="$CGO_CFLAGS -m64 -mtune=generic -fcf-protection=full"
 %endif
 
-BASEBUILDTAGS="exclude_graphdriver_devicemapper $(hack/libsubid_tag.sh)"
+BASEBUILDTAGS="$(hack/libsubid_tag.sh)"
 %if %{defined build_with_btrfs}
 export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_tag.sh) $(hack/btrfs_installed_tag.sh)"
 %else


### PR DESCRIPTION
The code has now been completely removed and nothing checks for that tag.