### PR TITLE
Packit: update packit targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,40 +20,5 @@ jobs:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
     targets:
-      - fedora-all-x86_64
-      - fedora-all-aarch64
-      - fedora-eln-x86_64
-      - fedora-eln-aarch64
-      - centos-stream+epel-next-8-x86_64
-      - centos-stream+epel-next-8-aarch64
-      - centos-stream+epel-next-9-x86_64
-      - centos-stream+epel-next-9-aarch64
-    additional_repos:
-      - "copr://rhcontainerbot/podman-next"
-
-  # Run on commit to main branch
-  - job: copr_build
-    trigger: commit
-    notifications:
-      failure_comment:
-        message: "podman-next COPR build failed. @containers/packit-build please check."
-    branch: main
-    owner: rhcontainerbot
-    project: podman-next
-    enable_net: true
-
-  - job: propose_downstream
-    trigger: release
-    update_release: false
-    dist_git_branches:
-      - fedora-all
-
-  - job: koji_build
-    trigger: commit
-    dist_git_branches:
-      - fedora-all
-
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically
+      - epel-9-x86_64
+      - epel-9-aarch64


### PR DESCRIPTION
We only care about buildability on epel 9 (RHEL). It won't be shipped to centos stream or to fedora.
