### PR TITLE
CI: bump VMs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ env:
     SCRIPT_BASE: "./contrib/cirrus"
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c20240411t124913z-f39f38d13"
+    IMAGE_SUFFIX: "c20240529t141726z-f40f39d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
 
     # Container FQIN's


### PR DESCRIPTION
Changes:
  - fix from @mtrmac for go-1.22 panic ("alphabet, duplicate symbols")
  - debian is now cgroupsv2 + crun (does not affect skopeo)
  - many other Red Queen fixes

Built in: https://github.com/containers/automation_images/pull/338