### PR TITLE
Execute cross-build task using PW pool

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,20 +81,33 @@ osx_task:
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
     depends_on:
         - validate
-    macos_instance:
-        image: ghcr.io/cirruslabs/macos-ventura-base:latest
-    setup_script: |
-        export PATH=$GOPATH/bin:$PATH
-        brew update
-        brew install gpgme go go-md2man
-        make tools
-    test_script: |
-        export PATH=$GOPATH/bin:$PATH
-        go version
-        go env
-        make validate-local test-unit-local bin/skopeo
-        sudo make install
-        /usr/local/bin/skopeo -v
+    persistent_worker: &mac_pw
+        labels:
+            os: darwin
+            arch: arm64
+            purpose: prod
+    env:
+        CIRRUS_WORKING_DIR: "$HOME/ci/task-${CIRRUS_TASK_ID}"
+        # Prevent cache-pollution fron one task to the next.
+        GOPATH: "$CIRRUS_WORKING_DIR/.go"
+        GOCACHE: "$CIRRUS_WORKING_DIR/.go/cache"
+        GOENV: "$CIRRUS_WORKING_DIR/.go/support"
+        GOSRC: "$HOME/ci/task-${CIRRUS_TASK_ID}"
+        TMPDIR: "/private/tmp/ci"
+    # This host is/was shared with potentially many other CI tasks.
+    # The previous task may have been canceled or aborted.
+    prep_script: &mac_cleanup "contrib/cirrus/mac_cleanup.sh"
+    test_script:
+        - export PATH=$GOPATH/bin:$PATH
+        - go version
+        - go env
+        - make tools
+        - make validate-local test-unit-local bin/skopeo
+        - bin/skopeo -v
+    # This host is/was shared with potentially many other CI tasks.
+    # Ensure nothing is left running while waiting for the next task.
+    always:
+        task_cleanup_script: *mac_cleanup
 
 
 cross_task:

--- a/contrib/cirrus/mac_cleanup.sh
+++ b/contrib/cirrus/mac_cleanup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script is intended to be called by Cirrus-CI on a Mac M1 persistent worker.
+# It performs a best-effort attempt at cleaning up from one task execution to the next.
+# Since it run both before and after tasks, it must exit cleanly if there was a cleanup
+# failure (i.e. file or directory not found).
+
+# Help anybody debugging side-effects, since failures are ignored (by necessity).
+set +e -x
+
+# These are the main processes which could leak out of testing.
+killall podman vfkit gvproxy make go ginkgo
+
+mkdir -p $TMPDIR
+
+# Golang will leave behind lots of read-only bits, ref:
+# https://go.dev/ref/mod#module-cache
+# However other tools/scripts could also set things read-only.
+# At this point in CI, we really want all this stuff gone-gone,
+# so there's actually zero-chance it can interfere.
+chmod -R u+w $TMPDIR/* $TMPDIR/.??*
+
+# This is defined as $TMPDIR during setup.  Name must be kept
+# "short" as sockets may reside here.  Darwin suffers from
+# the same limited socket-pathname character-length restriction
+# as Linux.
+rm -rf $TMPDIR/* $TMPDIR/.??*
+
+# Don't change or clobber anything under $CIRRUS_WORKING_DIR for
+# the currently running task.  But make sure we have write permission
+# (go get sets dependencies ro) for everything else, before removing it.
+# First make everything writeable - see the "Golang will..." comment above.
+# shellcheck disable=SC2154
+find "$HOME/ci" -mindepth 1 -maxdepth 1 \
+    -not -name "*task-${CIRRUS_TASK_ID}*" -prune -exec chmod -R u+w '{}' +
+find "$HOME/ci" -mindepth 1 -maxdepth 1 \
+    -not -name "*task-${CIRRUS_TASK_ID}*" -prune -exec rm -rf '{}' +
+
+# Bash scripts exit with the status of the last command.
+true


### PR DESCRIPTION
Previously this task ran using the Cirrus-CI compute service, consuming compute credits.  However, since podman is already using a persistent worker pool for CI, it can also be leveraged for use here.  Since Mac resources are relatively expensive, it also makes financial sense to re-use infrastructure where possible.

Notes:
- This change also restricts the cross-build task to only running on the default branch.  This is necessary because the PW Pool environment is always rolling forward and may not match what was in place at the time a release-branch was created.
- This changes the test from an install + run, to just a build + run. This is required because the task is running as a regular user w/o permissions to install anything system-wide, on a host shared with other CI tasks.