### PR TITLE
[release-1.3] Refer to registry.k8s.io instead of k8s.gcr.io

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -528,7 +528,7 @@ func (s *CopySuite) TestCopySimple(c *check.C) {
 
 	// FIXME: It would be nice to use one of the local Docker registries instead of needing an Internet connection.
 	// "pull": docker: → dir:
-	assertSkopeoSucceeds(c, "", "copy", "docker://k8s.gcr.io/pause", "dir:"+dir1)
+	assertSkopeoSucceeds(c, "", "copy", "docker://registry.k8s.io/pause", "dir:"+dir1)
 	// "push": dir: → docker(v2s2):
 	assertSkopeoSucceeds(c, "", "--tls-verify=false", "--debug", "copy", "dir:"+dir1, ourRegistry+"pause:unsigned")
 	// The result of pushing and pulling is an unmodified image.
@@ -542,14 +542,14 @@ func (s *CopySuite) TestCopySimple(c *check.C) {
 	ociDest := "pause-latest-image"
 	ociImgName := "pause"
 	defer os.RemoveAll(ociDest)
-	assertSkopeoSucceeds(c, "", "copy", "docker://k8s.gcr.io/pause:latest", "oci:"+ociDest+":"+ociImgName)
+	assertSkopeoSucceeds(c, "", "copy", "docker://registry.k8s.io/pause:latest", "oci:"+ociDest+":"+ociImgName)
 	_, err = os.Stat(ociDest)
 	c.Assert(err, check.IsNil)
 
 	// docker v2s2 -> OCI image layout without image name
 	ociDest = "pause-latest-noimage"
 	defer os.RemoveAll(ociDest)
-	assertSkopeoSucceeds(c, "", "copy", "docker://k8s.gcr.io/pause:latest", "oci:"+ociDest)
+	assertSkopeoSucceeds(c, "", "copy", "docker://registry.k8s.io/pause:latest", "oci:"+ociDest)
 	_, err = os.Stat(ociDest)
 	c.Assert(err, check.IsNil)
 }

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -24,13 +24,13 @@ const (
 	// manifest lists, and with some tags that don't.
 	pullableRepo = "quay.io/libpod/testimage"
 	// A tagged image in the repository that we can inspect and copy.
-	pullableTaggedImage = "k8s.gcr.io/coredns/coredns:v1.6.6"
+	pullableTaggedImage = "registry.k8s.io/coredns/coredns:v1.6.6"
 	// A tagged manifest list in the repository that we can inspect and copy.
-	pullableTaggedManifestList = "k8s.gcr.io/coredns/coredns:v1.8.0"
+	pullableTaggedManifestList = "registry.k8s.io/coredns/coredns:v1.8.0"
 	// A repository containing multiple tags, some of which are for
 	// manifest lists, and which includes a "latest" tag.  We specify the
 	// name here without a tag.
-	pullableRepoWithLatestTag = "k8s.gcr.io/pause"
+	pullableRepoWithLatestTag = "registry.k8s.io/pause"
 )
 
 func init() {
@@ -309,7 +309,7 @@ func (s *SyncSuite) TestYamlRegex2Dir(c *check.C) {
 	dir1 := path.Join(tmpDir, "dir1")
 
 	yamlConfig := `
-k8s.gcr.io:
+registry.k8s.io:
   images-by-tag-regex:
     pause: ^[12]\.0$  # regex string test
 `
@@ -343,7 +343,7 @@ func (s *SyncSuite) TestYamlDigest2Dir(c *check.C) {
 	dir1 := path.Join(tmpDir, "dir1")
 
 	yamlConfig := `
-k8s.gcr.io:
+registry.k8s.io:
   images:
     pause:
     - sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610
@@ -374,7 +374,7 @@ func (s *SyncSuite) TestYaml2Dir(c *check.C) {
 	dir1 := path.Join(tmpDir, "dir1")
 
 	yamlConfig := `
-k8s.gcr.io:
+registry.k8s.io:
   images:
     coredns/coredns:
       - v1.8.0


### PR DESCRIPTION
... per https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/ .

We are seeing intermittent failures (sufficient to reliably cause a test suite failure) pulling from k8s.gcr.io, let's see if using the newer one improves things.