### PR TITLE
[skip-ci] RPM: spec file cleanup

### DIFF
--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -164,12 +164,4 @@ cp -pav systemtest/* %{buildroot}/%{_datadir}/%{name}/test/system/
 %{_datadir}/%{name}/test
 
 %changelog
-%if %{defined autochangelog}
 %autochangelog
-%else
-# NOTE: This changelog will be visible on CentOS 8 Stream builds
-# Other envs are capable of handling autochangelog
-* Tue Jun 13 2023 RH Container Bot <rhcontainerbot@fedoraproject.org>
-- Placeholder changelog for envs that are not autochangelog-ready.
-- Contact upstream if you need to report an issue with the build.
-%endif


### PR DESCRIPTION
All our supported distros except CentOS Stream 9 support autochangelog and we currently build rpms for CentOS Stream 9 only on the podman-next copr, where we don't really care much about changelog.

So, there's no need for this conditional to exist.

Podman Ref: https://github.com/containers/podman/pull/23110