### PR TITLE
Bump to Skopeo v1.16.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.16.0"
+const Version = "1.17.0-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.16.0-dev"
+const Version = "1.16.0"


### PR DESCRIPTION
Bump c/storage to v1.55.0, c/image to v5.32.0, and c/common to v0.60.0.  

Then bump to Skopeo v1.16.0, then back to the v1.17.0-dev version in the main branch.

This to coincide with the Podman v5.2 release and to ready for the RHEL
9.5/10.0 Beta release