### PR TITLE
Replace egrep with grep -E

### DIFF
--- a/hack/get_fqin.sh
+++ b/hack/get_fqin.sh
@@ -29,6 +29,6 @@ $CONTAINER_RUNTIME run --rm \
     --entrypoint=/usr/share/automation/bin/cirrus-ci_env.py \
     quay.io/libpod/get_ci_vm:latest \
     --envs="Skopeo Test" /src/.cirrus.yml | \
-    egrep -m1 '^SKOPEO_CIDEV_CONTAINER_FQIN' | \
+    grep -E -m1 '^SKOPEO_CIDEV_CONTAINER_FQIN' | \
     awk -F "=" -e '{print $2}' | \
     tr -d \'\"

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -29,7 +29,7 @@ rc=0
 # for a given skopeo-foo.1.md, the NAME should be 'skopeo-foo'
 for md in *.1.md;do
     # Read the first line after '## NAME'
-    name=$(egrep -A1 '^## NAME' $md|tail -1|awk '{print $1}' | tr -d \\\\)
+    name=$(grep -E -A1 '^## NAME' $md|tail -1|awk '{print $1}' | tr -d \\\\)
 
     expect=$(basename $md .1.md)
     if [ "$name" != "$expect" ]; then
@@ -45,7 +45,7 @@ done
 # Make sure the descriptive text in skopeo-foo.1.md matches the one
 # in the table in skopeo.1.md.
 for md in $(ls -1 *-*.1.md);do
-    desc=$(egrep -A1 '^## NAME' $md|tail -1|sed -E -e 's/^skopeo[^[:space:]]+ - //')
+    desc=$(grep -E -A1 '^## NAME' $md|tail -1|sed -E -e 's/^skopeo[^[:space:]]+ - //')
 
     # Find the descriptive text in the main skopeo man page.
     parent=skopeo.1.md
@@ -112,7 +112,7 @@ function compare_usage() {
 #
 # Make sure the SYNOPSIS line in skopeo-foo.1.md reads '**skopeo foo** ...'
 for md in *.1.md;do
-    synopsis=$(egrep -A1 '^#* SYNOPSIS' $md|tail -1)
+    synopsis=$(grep -E -A1 '^#* SYNOPSIS' $md|tail -1)
 
     # Command name must be bracketed by double asterisks; options and
     # arguments are bracketed by single ones.

--- a/systemtest/010-inspect.bats
+++ b/systemtest/010-inspect.bats
@@ -36,7 +36,7 @@ load helpers
     # the output of 'inspect' lists layer digests,
     # but not the digest of the config blob ($config_digest), if any.
     layers=$(jq -r '.Layers' <<<"$inspect_local")
-    for sha in $(find $workdir -type f | xargs -l1 basename | egrep '^[0-9a-f]{64}$'); do
+    for sha in $(find $workdir -type f | xargs -l1 basename | grep -E '^[0-9a-f]{64}$'); do
         if [ "sha256:$sha" != "$config_digest" ]; then
             expect_output --from="$layers" --substring "sha256:$sha" \
                         "Locally-extracted SHA file is present in 'inspect'"

--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -317,7 +317,7 @@ start_registry() {
             die "start_registry() invoked with testuser but no testpassword"
         fi
 
-        if ! egrep -q "^$testuser:" $AUTHDIR/htpasswd; then
+        if ! grep -E -q "^$testuser:" $AUTHDIR/htpasswd; then
             htpasswd -Bbn $testuser $testpassword >> $AUTHDIR/htpasswd
         fi
 


### PR DESCRIPTION
This should silence any `egrep is obsolescent; using grep -E` warnings.