### PR TITLE
[skip-ci] Packit: Enable sidetags for bodhi updates

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -93,12 +93,14 @@ jobs:
     dist_git_branches:
       - c10s
 
+  # Fedora Koji build
   - job: koji_build
     trigger: commit
+    sidetag_group: podman-releases
+    # Dependents are not rpm dependencies, but the package whose bodhi update
+    # should include this package.
+    # Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages
+    dependents:
+      - podman
     dist_git_branches:
       - fedora-all
-
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,6 +18,8 @@ packages:
     specfile_path: rpm/skopeo.spec
   skopeo-rhel:
     specfile_path: rpm/skopeo.spec
+  skopeo-eln:
+    specfile_path: rpm/skopeo.spec
 
 srpm_build_deps:
   - make
@@ -30,12 +32,21 @@ jobs:
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     targets:
-      fedora-development-x86_64: {}
-      fedora-development-aarch64: {}
-      fedora-latest-x86_64: {}
-      fedora-latest-aarch64: {}
-      fedora-latest-stable-x86_64: {}
-      fedora-latest-stable-aarch64: {}
+      - fedora-development-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-x86_64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
+      - fedora-40-x86_64
+      - fedora-40-aarch64
+    enable_net: true
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [skopeo-eln]
+    notifications: *copr_build_failure_notification
+    targets:
       fedora-eln-x86_64:
         additional_repos:
           - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
@@ -82,7 +93,7 @@ jobs:
     trigger: release
     packages: [skopeo-fedora]
     update_release: false
-    dist_git_branches:
+    dist_git_branches: &fedora_targets
       - fedora-all
 
   # Sync to CentOS Stream
@@ -102,5 +113,4 @@ jobs:
     # Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages
     dependents:
       - podman
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: *fedora_targets


### PR DESCRIPTION
Packit now has sidetag support for adding multiple builds into a single bodhi update.
    
Since we release c/ccommon, skopeo, buildah and podman often almoost simultaneously, we should release them to Fedora in a single bodhi update using sidetags so all builds can be tested together.
