### PR TITLE
Document that zstd:chunked is downgraded to zstd when encrypting

### DIFF
--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -183,6 +183,8 @@ Existing signatures, if any, are preserved as well.
 **--dest-compress-format** _format_
 
 Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.
+`zstd:chunked` is incompatible with encrypting images,
+and will be treated as `zstd` with a warning in that case.
 
 **--dest-compress-level** _format_
 


### PR DESCRIPTION
A part of https://github.com/containers/common/issues/2117 .