### PR TITLE
[backport release-1.16] Packit: constrain downstream koji job to fedora package

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -106,6 +106,7 @@ jobs:
   # Fedora Koji build
   - job: koji_build
     trigger: commit
+    packages: [skopeo-fedora]
     sidetag_group: podman-releases
     # Dependents are not rpm dependencies, but the package whose bodhi update
     # should include this package.


### PR DESCRIPTION
This constraint helps to avoid duplicate Packit jobs. The effect will only be seen at the time of Fedora koji build and not on upstream. This doesn't affect upstream.


(cherry picked from commit 6ad77a1bc4418ba0976c4f91cae696622248c9aa)