### PR TITLE
Fix format string inconsistency causing a build failure

### DIFF
--- a/cmd/skopeo/proxy.go
+++ b/cmd/skopeo/proxy.go
@@ -784,7 +784,7 @@ func (h *proxyHandler) processRequest(readBytes []byte) (rb replyBuf, terminate 
 		err = fmt.Errorf("invalid request: %v", err)
 		return
 	}
-	logrus.Debugf("Executing method %s", req.Method, err)
+	logrus.Debugf("Executing method %s", req.Method)
 
 	// Dispatch on the method
 	switch req.Method {


### PR DESCRIPTION
After a manually-pushed version of #2400 .

Cc: @cgwalters .

(There are some indications the tests are going to fail for an unrelated purpose later; if so, I’ll include a fix for that in this PR.)