### PR TITLE
systemtest: update quay.io registry image

### DIFF
--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -10,7 +10,7 @@ SKOPEO_BINARY=${SKOPEO_BINARY:-${TEST_SOURCE_DIR}/../bin/skopeo}
 SKOPEO_TIMEOUT=${SKOPEO_TIMEOUT:-300}
 
 # Default image to run as a local registry
-REGISTRY_FQIN=${SKOPEO_TEST_REGISTRY_FQIN:-quay.io/libpod/registry:2}
+REGISTRY_FQIN=${SKOPEO_TEST_REGISTRY_FQIN:-quay.io/libpod/registry:2.8.2}
 
 ###############################################################################
 # BEGIN setup/teardown


### PR DESCRIPTION
The "2" tag is very old and not a multi arch manifest. As such testing on aarch64 failed because it pulled and x86_64 image instead. This was found in downstream RHEL testing.

The "2.8.2" is multi arch and used in podman testing were we successfully run aarch64 based testing.