### PR TITLE
feat: Add `--retry-delay` Option

### DIFF
--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	commonFlag "github.com/containers/common/pkg/flag"
 	"github.com/containers/common/pkg/retry"
@@ -184,6 +185,7 @@ func retryFlags() (pflag.FlagSet, *retry.Options) {
 	opts := retry.Options{}
 	fs := pflag.FlagSet{}
 	fs.IntVar(&opts.MaxRetry, "retry-times", 0, "the number of times to possibly retry")
+	fs.DurationVar(&opts.Delay, "retry-delay", 0*time.Second, "Fixed delay between retries. If not set, retry uses an exponential backoff delay.")
 	return fs, &opts
 }
 

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -204,7 +204,11 @@ Precompute digests to ensure layers are not uploaded that already exist on the d
 
 **--retry-times**
 
-The number of times to retry. Retry wait time will be exponentially increased based on the number of failed attempts.
+The number of times to retry.
+
+**--retry-delay**
+
+Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--src-username**
 

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -66,7 +66,11 @@ Bearer token for accessing the registry.
 
 **--retry-times**
 
-The number of times to retry. Retry wait time will be exponentially increased based on the number of failed attempts.
+The number of times to retry.
+
+**--retry-delay**
+
+Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--shared-blob-dir** _directory_
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -65,7 +65,11 @@ Registry token for accessing the registry.
 
 **--retry-times**
 
-The number of times to retry; retry wait time will be exponentially increased based on the number of failed attempts.
+The number of times to retry.
+
+**--retry-delay**
+
+Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--shared-blob-dir** _directory_
 

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -39,7 +39,11 @@ Bearer token for accessing the registry.
 
 **--retry-times**
 
-The number of times to retry. Retry wait time will be exponentially increased based on the number of failed attempts.
+The number of times to retry.
+
+**--retry-delay**
+
+Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--tls-verify**=_bool_
 

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -123,7 +123,13 @@ The passphare to use when signing with `--sign-by` or `--sign-by-sigstore-privat
 
 **--dest-registry-token** _Bearer token_ for accessing the destination registry.
 
-**--retry-times**  the number of times to retry, retry wait time will be exponentially increased based on the number of failed attempts.
+**--retry-times**
+
+The number of times to retry.
+
+**--retry-delay**
+
+Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--keep-going**
 If any errors occur during copying of images, those errors are logged and the process continues syncing rest of the images and finally fails at the end.


### PR DESCRIPTION
- Add option to set a fixed delay between retries.
- Clarify that if delay is unset, skopeo uses an exponential delay for retries.

Fixes #2476