### PR TITLE
RPM: cleanup gobuild macro for CentOS Stream

### DIFF
--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -145,6 +145,10 @@ cp -pav systemtest/* %{buildroot}/%{_datadir}/%{name}/test/system/
 #define license tag if not already defined
 %{!?_licensedir:%global license %doc}
 
+# Include this to silence rpmlint.
+# Especially annoying if you use syntastic vim plugin.
+%check
+
 %files
 %license LICENSE
 %doc README.md

--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -7,20 +7,15 @@
 %global debug_package %{nil}
 %endif
 
-# RHEL's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
-# set it separately here and do not depend on RHEL's go-[s]rpm-macros package
-# until that's fixed.
-# c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
-# c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331
-%if %{defined rhel}
-%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "-linkmode=external -compressdwarf=false ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
-%endif
-
 %global gomodulesmode GO111MODULE=on
 
 # No btrfs on RHEL
 %if %{defined fedora}
 %define build_with_btrfs 1
+%endif
+
+%if %{defined rhel}
+%define fips 1
 %endif
 
 # Only used in official koji builds
@@ -125,6 +120,10 @@ BASEBUILDTAGS="$(hack/libsubid_tag.sh)"
 export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_tag.sh) $(hack/btrfs_installed_tag.sh)"
 %else
 export BUILDTAGS="$BASEBUILDTAGS btrfs_noversion exclude_graphdriver_btrfs"
+%endif
+
+%if %{defined fips}
+export BUILDTAGS="$BUILDTAGS libtrust_openssl"
 %endif
 
 # unset LDFLAGS earlier set from set_build_flags


### PR DESCRIPTION
The default gobuild macro on CentOS Stream now accounts for `BUILDTAGS`, so we don't need to redefine the macro in rpm spec.