### PR TITLE
Switch to the CNCF Code of Conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
 ## The skopeo Project Community Code of Conduct
 
-The skopeo project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).
+The skopeo project, as part of Podman Container Tools, follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
As part of the CNCF Sandbox, we are replacing our existing COC with the standard CNCF version.

No code changes, simply updates the existing code of conduct link to point to the CNCF version.