### PR TITLE
Bump Skopeo to v1.18.0, then to v1.19.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.18.0-dev"
+const Version = "1.18.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.18.0"
+const Version = "1.19.0-dev"


### PR DESCRIPTION
As the title says, bumping to v1.18.0 to go out with Podman v5.4.