### PR TITLE
Enforce manifest and blob digests in (skopeo inspect) and (skopeo layers)

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -106,8 +106,9 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		}
 	}()
 
+	unparsedInstance := image.UnparsedInstance(src, nil)
 	if err := retry.IfNecessary(ctx, func() error {
-		rawManifest, _, err = src.GetManifest(ctx, nil)
+		rawManifest, _, err = unparsedInstance.Manifest(ctx)
 		return err
 	}, opts.retryOpts); err != nil {
 		return fmt.Errorf("Error retrieving manifest for image: %w", err)
@@ -122,7 +123,7 @@ func (opts *inspectOptions) run(args []string, stdout io.Writer) (retErr error) 
 		return nil
 	}
 
-	img, err := image.FromUnparsedImage(ctx, sys, image.UnparsedInstance(src, nil))
+	img, err := image.FromUnparsedImage(ctx, sys, unparsedInstance)
 	if err != nil {
 		return fmt.Errorf("Error parsing manifest for image: %w", err)
 	}

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -156,8 +156,16 @@ func (opts *layersOptions) run(args []string, stdout io.Writer) (retErr error) {
 				retErr = noteCloseFailure(retErr, fmt.Sprintf("closing blob %q", bd.digest.String()), err)
 			}
 		}()
-		if _, err := dest.PutBlob(ctx, r, types.BlobInfo{Digest: bd.digest, Size: blobSize}, cache, bd.isConfig); err != nil {
+		verifier := bd.digest.Verifier()
+		tr := io.TeeReader(r, verifier)
+		if _, err := dest.PutBlob(ctx, tr, types.BlobInfo{Digest: bd.digest, Size: blobSize}, cache, bd.isConfig); err != nil {
 			return err
+		}
+		if _, err := io.Copy(io.Discard, tr); err != nil { // Ensure we process all of tr, so that we can validate the digest.
+			return err
+		}
+		if !verifier.Verified() {
+			return fmt.Errorf("corrupt blob %q", bd.digest.String())
 		}
 	}
 


### PR DESCRIPTION
Nobody should be using `skopeo layers`.

For `skopeo inspect`, I could see an argument that it should return the data even if it does not match the digest, so that users can diagnose that. On balance, I think matching the expectation that digests are enforced is more valuable.