### PR TITLE
Update to Go 1.23

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -51,8 +51,11 @@ jobs:
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     targets: &fedora_copr_targets
-      - fedora-all-x86_64
-      - fedora-all-aarch64
+      # This should generally be fedora-all-*, but we exclude Fedora 40 because it does not have Go 1.23.
+      - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
+      - fedora-development-x86_64
+      - fedora-development-aarch64
     enable_net: true
 
   - job: copr_build

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/containers/skopeo
 
 // Minimum required golang version
-go 1.22.8
+go 1.23.0
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates
 

--- a/install.md
+++ b/install.md
@@ -139,7 +139,7 @@ located at [https://github.com/containers/image_build/tree/main/skopeo](https://
 
 Otherwise, read on for building and installing it from source:
 
-To build the `skopeo` binary you need at least Go 1.22.
+To build the `skopeo` binary you need at least Go 1.23.
 
 There are two ways to build skopeo: in a container, or locally without a
 container. Choose the one which better matches your needs and environment.


### PR DESCRIPTION
This is a very minimal change, just to handle the version bump.

I intend to let Renovate do the dependency updates. And a separate PR to actually benefit from new language features will follow.