### PR TITLE
proxy: call maybeReexec() up front

### DIFF
--- a/cmd/skopeo/proxy.go
+++ b/cmd/skopeo/proxy.go
@@ -876,6 +876,12 @@ func (h *proxyHandler) processRequest(readBytes []byte) (rb replyBuf, terminate 
 
 // Implementation of podman experimental-image-proxy
 func (opts *proxyOptions) run(args []string, stdout io.Writer) error {
+	// We may get a request to pull from a containers-storage: URL, so do
+	// this up front.
+	if err := maybeReexec(); err != nil {
+		return err
+	}
+
 	handler := &proxyHandler{
 		opts:        opts,
 		images:      make(map[uint64]*openImage),

--- a/cmd/skopeo/unshare.go
+++ b/cmd/skopeo/unshare.go
@@ -2,6 +2,10 @@
 
 package main
 
+func maybeReexec() error {
+	return nil
+}
+
 func reexecIfNecessaryForImages(_ ...string) error {
 	return nil
 }


### PR DESCRIPTION
Commands like `skopeo copy` do this first depending on the image names involved in the operation, but we don't have the luxury of having access to that information up-front.  Always call maybeReexec(), just in case it's required later on.

Fixes #2563