### PR TITLE
.golangci.yml: simplify

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,10 +2,12 @@ version: "2"
 linters:
   settings:
     staticcheck:
-      checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1005"] # golangci-lint's default, we add -ST1005
+      checks:
+        # Compared to golangci-lint v2.0.2 defaults, we don’t exclude
+        # ST1003, ST1016, ST1020, ST1021, ST1022 as we don't hit those.
+        - all
+        - -ST1000 # Incorrect or missing package comment.
+        - -ST1005 # Incorrectly formatted error string.
   exclusions:
     presets:
-      - comments
-      - common-false-positives
-      - legacy
       - std-error-handling


### PR DESCRIPTION
1. Remove some unused exclusions, document the used ones.
2. ~~Add `errorlint`, fix found warnings ("Use `%w` to format errors").~~ (dropped)