### PR TITLE
Add MAINTAINERS.md and Governance, update OWNERS

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,3 @@
+## The Skopeo Project Community Governance
+
+The Skopeo project, as part of Podman Container Tools, follows the [Podman Project Governance](https://github.com/containers/podman/blob/main/GOVERNANCE.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,29 @@
+# Skopeo Maintainers
+
+[GOVERNANCE.md](https://github.com/containers/podman/blob/main/GOVERNANCE.md)
+describes the project's governance and the Project Roles used below.
+
+## Maintainers
+
+| Maintainer        | GitHub ID                                                | Project Roles                    | Affiliation                                  |
+|-------------------|----------------------------------------------------------|----------------------------------|----------------------------------------------|
+| Brent Baude       | [baude](https://github.com/baude)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Nalin Dahyabhai   | [nalind](https://github.com/nalind)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Matthew Heon      | [mheon](https://github.com/mheon)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Neil Smith        | [Neil-Smith](https://github.com/Neil-Smith)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
+| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
+| Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
+| Dan Walsh         | [rhatdan](https://github.com/rhatdan)                    | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
+| Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Valentin Rothberg | [vrothberg](https://github.com/vrothberg)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+
+## Alumni
+
+None at present
+
+## Credits
+
+The structure of this document was based off of the equivalent one in the [CRI-O Project](https://github.com/cri-o/cri-o/blob/main/MAINTAINERS.md).

--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,22 @@
 approvers:
-  - mtrmac
+  - baude
+  - giuseppe
   - lsm5
-  - TomSweeneyRedHat
+  - Luap99
+  - mheon
+  - mtrmac
+  - nalind
   - rhatdan
-  - vrothberg
+  - TomSweeneyRedHat
 reviewers:
   - ashley-cui
+  - baude
   - giuseppe
-  - containers/image-maintainers
   - lsm5
+  - Luap99
+  - mheon
   - mtrmac
-  - QiWang19
+  - nalind
   - rhatdan
-  - runcom
   - TomSweeneyRedHat
   - vrothberg


### PR DESCRIPTION
Many of the people in OWNERS no longer contribute to the project, so clean the file and restrict to those who are still active. Alongside this, add our core maintainers who have merge authority on all repos.

Governance is a simple link to the Podman governance model, and MAINTAINERS.md mirrors the new OWNERS.