### PR TITLE
GHA: remove .github/labeler.yaml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,0 @@
-# https://github.com/actions/labeler
-release:
-  - base-branch: [^release-\d+\.\d+]


### PR DESCRIPTION
This was added earlier as part of PR label-based triggering of Packit jobs. But we decided not to go ahead with that approach, thus keeping only a single set of tests. This file should've been removed during the revert, but better late than never.

Ref: https://github.com/containers/skopeo/pull/2558

FWIW, this yaml file doesn't work by itself without the corresponding GHA which was never included. So, this yaml config was pretty much a NOP anyway.