### PR TITLE
Bump to c/common 0.63.0, c/image 5.35.0, Skopeo to v1.19.0, v1.20.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.19.0-dev"
+const Version = "1.19.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.19.0"
+const Version = "1.20.0-dev"


### PR DESCRIPTION
This bumps c/common and c/image to v0.63.0 and v5.35.0, respectively.  It then bumps Skopeo to v1.19.0, and then to the next dev version, v1.20.0-dev.

c/storage has already been bumped to v1.58.0, with this PR, we will line up with Podman v5.5.0

There are way more updates from the c/common and c/image bumps than I anticipated.....