### PR TITLE
[skip-ci] Packit: set fedora-all after F40 EOL

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -51,11 +51,8 @@ jobs:
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     targets: &fedora_copr_targets
-      # This should generally be fedora-all-*, but we exclude Fedora 40 because it does not have Go 1.23.
-      - fedora-latest-stable-x86_64
-      - fedora-latest-stable-aarch64
-      - fedora-development-x86_64
-      - fedora-development-aarch64
+      - fedora-all-x86_64
+      - fedora-all-aarch64
     enable_net: true
 
   - job: copr_build


### PR DESCRIPTION
F40 is now EOL and all current Fedora releases have Go 1.23. So, we're safe to re-enable fedora-all.