### PR TITLE
Add --retry to test operations that tend to fail

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -64,7 +64,7 @@ _run_setup() {
     # things directly on the host VM.  Fortunately they're all
     # located in the container under /usr/local/bin
     msg "Accessing contents of $SKOPEO_CIDEV_CONTAINER_FQIN"
-    podman pull --quiet $SKOPEO_CIDEV_CONTAINER_FQIN
+    podman pull --retry 3 --quiet $SKOPEO_CIDEV_CONTAINER_FQIN
     mnt=$(podman mount $(podman create $SKOPEO_CIDEV_CONTAINER_FQIN))
 
     # The container and VM images are built in tandem in the same repo.

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -107,7 +107,8 @@ func (s *skopeoSuite) TestCopyWithLocalAuth() {
 		"login", "--tls-verify=false", "--username="+s.regV2WithAuth.username, "--password="+s.regV2WithAuth.password, s.regV2WithAuth.url)
 	// copy to private registry using local authentication
 	imageName := fmt.Sprintf("docker://%s/busybox:mine", s.regV2WithAuth.url)
-	assertSkopeoSucceeds(t, "", "copy", "--dest-tls-verify=false", testFQIN+":latest", imageName)
+	assertSkopeoSucceeds(t, "", "copy", "--dest-tls-verify=false", "--retry-times", "3",
+		testFQIN+":latest", imageName)
 	// inspect from private registry
 	assertSkopeoSucceeds(t, "", "inspect", "--tls-verify=false", imageName)
 	// logout from the registry


### PR DESCRIPTION
... to decrease impact of flakes.

---

We now see a network error at least once in most PRs in this repo, it’s becoming too much of a hassle.

I intend to keep expanding the scope of this PR as long as CI keeps showing new classes of avoidable failures.