### PR TITLE
[release-1.11] Support CI testing on non-x86_64

### DIFF
--- a/systemtest/helpers.bash
+++ b/systemtest/helpers.bash
@@ -10,7 +10,7 @@ SKOPEO_BINARY=${SKOPEO_BINARY:-${TEST_SOURCE_DIR}/../bin/skopeo}
 SKOPEO_TIMEOUT=${SKOPEO_TIMEOUT:-300}
 
 # Default image to run as a local registry
-REGISTRY_FQIN=${SKOPEO_TEST_REGISTRY_FQIN:-quay.io/libpod/registry:2}
+REGISTRY_FQIN=${SKOPEO_TEST_REGISTRY_FQIN:-quay.io/libpod/registry:2.8.2}
 
 ###############################################################################
 # BEGIN setup/teardown


### PR DESCRIPTION
Previously, internal CI gating tests sometimes fail because the required registry container image only supports x86_64.  Update to the `2.8.2` image tag with support for all primary architectures.