### PR TITLE
unshare: Add CAP_SYS_ADMIN to needed capabilities

### DIFF
--- a/cmd/skopeo/unshare_linux.go
+++ b/cmd/skopeo/unshare_linux.go
@@ -16,6 +16,7 @@ var neededCapabilities = []capability.Cap{
 	capability.CAP_FSETID,
 	capability.CAP_MKNOD,
 	capability.CAP_SETFCAP,
+	capability.CAP_SYS_ADMIN,
 }
 
 func maybeReexec() error {


### PR DESCRIPTION
Some container storage operations (e.g., mounting the home directory for containers/storage) require CAP_SYS_ADMIN.