### PR TITLE
Don't BuildRequires: ostree-devel

### DIFF
--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -63,7 +63,6 @@ BuildRequires: go-rpm-macros
 %endif
 BuildRequires: gpgme-devel
 BuildRequires: libassuan-devel
-BuildRequires: ostree-devel
 BuildRequires: glib2-devel
 BuildRequires: make
 BuildRequires: shadow-utils-subid-devel


### PR DESCRIPTION
We are not opting into the ostree backend, and it doesn't build: https://github.com/containers/image/pull/2821 . So, stop referencing the dependency.

Should not change behavior.

@lsm5 @jnovy PTAL.