### PR TITLE
[skip-ci] RPM: fix gating.yaml

### DIFF
--- a/rpm/gating.yaml
+++ b/rpm/gating.yaml
@@ -1,7 +1,7 @@
 --- !Policy
 product_versions:
   - fedora-*
-decision_context:
+decision_contexts:
   - bodhi_update_push_stable
   - bodhi_update_push_testing
 subject_type: koji_build


### PR DESCRIPTION
Koji builds don't work without this fix.
Ref: https://dashboard.packit.dev/jobs/koji/11394