### PR TITLE
dynamically link sqlite3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ MANPAGES ?= $(MANPAGES_MD:%.md=%)
 
 BTRFS_BUILD_TAG = $(shell hack/btrfs_installed_tag.sh)
 LIBSUBID_BUILD_TAG = $(shell hack/libsubid_tag.sh)
-LOCAL_BUILD_TAGS = $(BTRFS_BUILD_TAG) $(LIBSUBID_BUILD_TAG)
+SQLITE_BUILD_TAG = $(shell hack/sqlite_tag.sh)
+LOCAL_BUILD_TAGS = $(BTRFS_BUILD_TAG) $(LIBSUBID_BUILD_TAG) $(SQLITE_BUILD_TAG)
 BUILDTAGS += $(LOCAL_BUILD_TAGS)
 
 ifeq ($(DISABLE_CGO), 1)

--- a/hack/sqlite_tag.sh
+++ b/hack/sqlite_tag.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - &> /dev/null << EOF
+#include <sqlite3.h>
+EOF
+if test $? -eq 0 ; then
+	echo libsqlite3
+fi

--- a/rpm/skopeo.spec
+++ b/rpm/skopeo.spec
@@ -66,6 +66,7 @@ BuildRequires: libassuan-devel
 BuildRequires: glib2-devel
 BuildRequires: make
 BuildRequires: shadow-utils-subid-devel
+BuildRequires: sqlite-devel
 Requires: containers-common >= 4:1-21
 
 %description
@@ -117,7 +118,7 @@ CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-an
 export CGO_CFLAGS="$CGO_CFLAGS -m64 -mtune=generic -fcf-protection=full"
 %endif
 
-BASEBUILDTAGS="$(hack/libsubid_tag.sh)"
+BASEBUILDTAGS="$(hack/libsubid_tag.sh) libsqlite3"
 %if %{defined build_with_btrfs}
 export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh)"
 %else


### PR DESCRIPTION
Dynamically link sqlite3 when installed, the main motivation is that we
reduce the podman binary size with that. I see about 3.3 MB savings.

But also dynamically linking it means if there a vulnerabilities only
the sqlite3 distro package needs updating and we don't have to make a
new podman release with the vendored update.
