### PR TITLE
Packit: disable official CentOS Stream update job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -132,8 +132,10 @@ jobs:
       - fedora-all
 
   # Sync to CentOS Stream
+  # FIXME: Switch trigger whenever we're ready to update CentOS Stream via
+  # Packit
   - job: propose_downstream
-    trigger: release
+    trigger: ignore
     packages: [skopeo-centos]
     update_release: false
     dist_git_branches:


### PR DESCRIPTION
We're currently not updating official CentOS Stream packages via Packit. So, this commit disables the downstream PR update job.

No noticeable effect upstream. Safe to merge.