### PR TITLE
[release-1.9] Add conditional release-checking system test

### DIFF
--- a/systemtest/001-basic.bats
+++ b/systemtest/001-basic.bats
@@ -16,4 +16,29 @@ function setup() {
     expect_output --substring "skopeo version [0-9.]+"
 }
 
+@test "skopeo release isn't a development version" {
+    [[ "${RELEASE_TESTING:-false}" == "true" ]] || \
+      skip "Release testing may be enabled by setting \$RELEASE_TESTING = 'true'."
+
+    run_skopeo --version
+
+    # expect_output() doesn't support negative matching
+    if [[ "$output" =~ "dev" ]]; then
+        # This is a multi-line message, which may in turn contain multi-line
+        # output, so let's format it ourselves, readably
+        local -a output_split
+        readarray -t output_split <<<"$output"
+        printf "#/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n"  >&2
+        printf "#|       FAIL: $BATS_TEST_NAME\n"                   >&2
+        printf "#| unexpected: 'dev'\n"                             >&2
+        printf "#|     actual: '%s'\n" "${output_split[0]}"         >&2
+        local line
+        for line in "${output_split[@]:1}"; do
+            printf "#|           > '%s'\n" "$line"                  >&2
+        done
+        printf "#\\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" >&2
+        false
+    fi
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Unfortunately on a number of occasions, Skopeo has been released officially with a `-dev` suffix in the version number.  Assist in catching this mistake at release time by the addition of a simple conditional test.  Note that it must be positively enabled by a magic env. var. before executing the system tests.

Original PR: https://github.com/containers/skopeo/pull/2631

(AI was used to help craft this PR)