### PR TITLE
Use platform-specific Docker socket location on macOS

### DIFF
--- a/cmd/skopeo/utils_darwin_test.go
+++ b/cmd/skopeo/utils_darwin_test.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetDefaultDockerSocketDarwin(t *testing.T) {
+	// Save original HOME
+	originalHome := os.Getenv("HOME")
+	defer func() {
+		os.Setenv("HOME", originalHome)
+	}()
+
+	// Test with HOME set
+	testHome := "/Users/test"
+	os.Setenv("HOME", testHome)
+	expected := "unix://" + filepath.Join(testHome, ".docker/run/docker.sock")
+	result := getDefaultDockerSocket()
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+
+	// Test with HOME unset
+	os.Unsetenv("HOME")
+	result = getDefaultDockerSocket()
+	if result != "" {
+		t.Errorf("Expected empty string when HOME is unset, got %s", result)
+	}
+}


### PR DESCRIPTION
Work around Docker Desktop's macOS socket location change

Docker Desktop 4.13.0+ moved the socket from /var/run/docker.sock to
~/.docker/run/docker.sock on macOS, but the Docker client library still
defaults to the old location for all Unix systems.

Add platform-specific logic to use the correct default on macOS when
--daemon-host is not specified.

This makes skopeo work more reliable out of the box for new users.

Signed-off-by: Jacques Nadeau <jacques@apache.org>