### PR TITLE
Add completion subcommand

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -108,6 +108,7 @@ func createApp() (*cobra.Command, *globalOptions) {
 		standaloneVerifyCmd(),
 		tagsCmd(&opts),
 		untrustedSignatureDumpCmd(),
+		completionCmd(),
 	)
 	return rootCommand, &opts
 }


### PR DESCRIPTION
Add explicit completion subcommand

While Cobra (which skopeo depends on) automatically provides completion functionality, the completion subcommand itself wasn't explicitly visible in the command list.

This change adds the completion subcommand explicitly, making it discoverable to users through standard command help output and improving overall usability.