### PR TITLE
Bump to v1.20.0 then v1.21.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.20.0-dev"
+const Version = "1.20.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.20.0"
+const Version = "1.21.0-dev"


### PR DESCRIPTION
Since Skopeo now has the same versions of the c/* libraries as Buildah v1.41 and Podman v5.6, bumping it to v1.20.0 to go along with those for RHEL 9.7/10.1.    Once this merges, I'll tag and create a release branch.

The second commit is to 1.21.0-dev, to get the main branch back onto a dev version.