### PR TITLE
[release-1.9] Bump to release version 1.9.4

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.9.4-dev"
+const Version = "1.9.4"


### PR DESCRIPTION
This branch is utilized for RHEL releases and therefore should never ever represent a `-dev` development release.  Bump the version number to account for the change.

Resolves: RHEL-97102