### PR TITLE
Update tests to work with the Sequoia c/image backend

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -776,9 +776,9 @@ func (s *copySuite) TestCopySignatures() {
 	// Verify that mis-signed images are rejected
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "copy", "atomic:localhost:5006/myns/personal:personal", "atomic:localhost:5006/myns/official:attack")
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "copy", "atomic:localhost:5006/myns/official:official", "atomic:localhost:5006/myns/personal:attack")
-	assertSkopeoFails(t, ".*Source image rejected: Invalid GPG signature.*",
+	assertSkopeoFails(t, ".*Source image rejected: (Invalid GPG signature|.* was not found).*",
 		"--tls-verify=false", "--policy", policy, "copy", "atomic:localhost:5006/myns/personal:attack", dirDest)
-	assertSkopeoFails(t, ".*Source image rejected: Invalid GPG signature.*",
+	assertSkopeoFails(t, ".*Source image rejected: (Invalid GPG signature|.* was not found).*",
 		"--tls-verify=false", "--policy", policy, "copy", "atomic:localhost:5006/myns/official:attack", dirDest)
 
 	// Verify that signed identity is verified.
@@ -791,7 +791,7 @@ func (s *copySuite) TestCopySignatures() {
 
 	// Verify that cosigning requirements are enforced
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "copy", "atomic:localhost:5006/myns/official:official", "atomic:localhost:5006/myns/cosigned:cosigned")
-	assertSkopeoFails(t, ".*Source image rejected: Invalid GPG signature.*",
+	assertSkopeoFails(t, ".*Source image rejected: (Invalid GPG signature|.* was not found).*",
 		"--tls-verify=false", "--policy", policy, "copy", "atomic:localhost:5006/myns/cosigned:cosigned", dirDest)
 
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "copy", "--sign-by", "personal@example.com", "atomic:localhost:5006/myns/official:official", "atomic:localhost:5006/myns/cosigned:cosigned")
@@ -836,7 +836,7 @@ func (s *copySuite) TestCopyDirSignatures() {
 	// Verify that correct images are accepted
 	assertSkopeoSucceeds(t, "", "--policy", policy, "copy", topDirDest+"/restricted/official", topDirDest+"/dest")
 	// ... and that mis-signed images are rejected.
-	assertSkopeoFails(t, ".*Source image rejected: Invalid GPG signature.*",
+	assertSkopeoFails(t, ".*Source image rejected: (Invalid GPG signature|.* was not found).*",
 		"--policy", policy, "copy", topDirDest+"/restricted/personal", topDirDest+"/dest")
 
 	// Verify that the signed identity is verified.

--- a/systemtest/050-signing.bats
+++ b/systemtest/050-signing.bats
@@ -154,7 +154,7 @@ END_PUSH
         fi
     done <<END_TESTS
 /myns/alice:signed
-/myns/bob:signedbyalice    Invalid GPG signature
+/myns/bob:signedbyalice    (Invalid GPG signature|.* not found)
 /myns/alice:unsigned       Signature for identity \\\\\\\\"localhost:5000/myns/alice:signed\\\\\\\\" is not accepted
 /myns/carol:latest         Running image docker://localhost:5000/myns/carol:latest is rejected by policy.
 /open/forall:latest


### PR DESCRIPTION
Currently, if a key is not found, the GPG mechanism reports
> Invalid GPG signature: {$GoStructDump}

while the Sequoia one reports
> $keyFingerprint was not found

Accept both.

This is split from https://github.com/containers/skopeo/pull/2645 , to make it easier to sequence the PRs: First this PR, then https://github.com/containers/image/pull/2876 (which will pass tests), and then https://github.com/containers/skopeo/pull/2645 .