### PR TITLE
Allow running CI from rawhide images

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -71,8 +71,8 @@ _run_setup() {
     # automation, but the sources are in different directories.  It's
     # possible for a mismatch to happen, but should (hopefully) be unlikely.
     # Double-check to make sure.
-    if ! fgrep -qx "ID=$OS_RELEASE_ID" $mnt/etc/os-release || \
-       ! fgrep -qx "VERSION_ID=$OS_RELEASE_VER" $mnt/etc/os-release; then
+    if ! grep -Fqx "ID=$OS_RELEASE_ID" $mnt/etc/os-release || \
+       ! grep -Fqx "VERSION_ID=$OS_RELEASE_VER" $mnt/etc/os-release; then
             die "Somehow $SKOPEO_CIDEV_CONTAINER_FQIN is not based on $OS_REL_VER."
     fi
     msg "Copying test binaries from $SKOPEO_CIDEV_CONTAINER_FQIN /usr/local/bin/"

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -71,8 +71,10 @@ _run_setup() {
     # automation, but the sources are in different directories.  It's
     # possible for a mismatch to happen, but should (hopefully) be unlikely.
     # Double-check to make sure.
+    # Temporarily, allow running on Rawhide VMs and consuming older binaries:
+    # that should be compatible enough. Eventually, we’ll stop using Rawhide again.
     if ! grep -Fqx "ID=$OS_RELEASE_ID" $mnt/etc/os-release || \
-       ! grep -Fqx "VERSION_ID=$OS_RELEASE_VER" $mnt/etc/os-release; then
+       { ! [[ "$VM_IMAGE_NAME" =~ "rawhide" ]] && ! grep -Fqx "VERSION_ID=$OS_RELEASE_VER" $mnt/etc/os-release; } then
             die "Somehow $SKOPEO_CIDEV_CONTAINER_FQIN is not based on $OS_REL_VER."
     fi
     msg "Copying test binaries from $SKOPEO_CIDEV_CONTAINER_FQIN /usr/local/bin/"


### PR DESCRIPTION
We will, temporarily, want to run from rawhide images that include the rust-podman-sequoia RPM, as well as Fedora 43 images.

We have only one `skopeo_cidev` though, and we don't want to build a rawhide variant; so, allow consuming it from rawhide.

See individual commit messages for details.

A prerequisite for Sequoia https://github.com/containers/image/pull/2876 , see https://github.com/containers/image/pull/2876/checks?check_run_id=48518809749 .

@lsm5 PTAL.