### PR TITLE
Add --force-compress-format option on copy

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -239,6 +239,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
 	copyOpts.OciEncryptLayers = encLayers
 	copyOpts.OciEncryptConfig = encConfig
 	copyOpts.MaxParallelDownloads = opts.imageParallelCopies
+	copyOpts.ForceCompressionFormat = opts.destImage.forceCompressionFormat
 
 	return retry.IfNecessary(ctx, func() error {
 		manifestBytes, err := copy.Image(ctx, policyContext, destRef, srcRef, copyOpts)

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -266,6 +266,7 @@ type imageDestOptions struct {
 	compressionFormat           string                 // Format to use for the compression
 	compressionLevel            commonFlag.OptionalInt // Level to use for the compression
 	precomputeDigests           bool                   // Precompute digests to dedup layers when saving to the docker: transport
+	forceCompressionFormat      bool                   // Ensures that the compression algorithm set in compressionFormat is used exclusively
 	imageDestFlagPrefix         string
 }
 
@@ -281,6 +282,7 @@ func imageDestFlags(global *globalOptions, shared *sharedImageOptions, deprecate
 	fs.StringVar(&opts.compressionFormat, flagPrefix+"compress-format", "", "`FORMAT` to use for the compression")
 	fs.Var(commonFlag.NewOptionalIntValue(&opts.compressionLevel), flagPrefix+"compress-level", "`LEVEL` to use for the compression")
 	fs.BoolVar(&opts.precomputeDigests, flagPrefix+"precompute-digests", false, "Precompute digests to prevent uploading layers already on the registry using the 'docker' transport.")
+	fs.BoolVar(&opts.forceCompressionFormat, flagPrefix+"force-compress-format", false, "Force exclusive use of the compression algorithm set in --dest-compress-format")
 	return fs, &opts
 }
 

--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -191,6 +191,10 @@ and will be treated as `zstd` with a warning in that case.
 
 Specifies the compression level to use.  The value is specific to the compression algorithm used, e.g. for zstd the accepted values are in the range 1-20 (inclusive), while for gzip it is 1-9 (inclusive).
 
+**--dest-force-compress-format**
+
+Ensures that the compression algorithm set in --dest-compress-format is used exclusively.
+
 **--src-registry-token** _token_
 
 Bearer token for accessing the source registry.


### PR DESCRIPTION
Add a `--force-compress-format` option on `copy` command.

Closes https://github.com/containers/skopeo/issues/2343