### PR TITLE
test-integration-local: use SKOPEO_BINARY if set

### DIFF
--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -50,7 +50,7 @@ func (s *skopeoSuite) TearDownSuite() {
 
 func (s *skopeoSuite) TestVersion() {
 	t := s.T()
-	assertSkopeoSucceeds(t, fmt.Sprintf(".*%s version %s.*", skopeoBinary, version.Version),
+	assertSkopeoSucceeds(t, fmt.Sprintf(".*skopeo version %s.*", version.Version),
 		"--version")
 }
 

--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -282,7 +282,7 @@ func newProxy() (*proxy, error) {
 	}
 
 	// Note ExtraFiles starts at 3
-	proc := exec.Command("skopeo", "experimental-image-proxy", "--sockfd", "3")
+	proc := exec.Command(skopeoBinary, "experimental-image-proxy", "--sockfd", "3")
 	proc.Stderr = os.Stderr
 	cmdLifecycleToParentIfPossible(proc)
 	proc.ExtraFiles = append(proc.ExtraFiles, theirfd)

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -20,7 +20,14 @@ import (
 	"go.podman.io/image/v5/manifest"
 )
 
-const skopeoBinary = "skopeo"
+// FIXME: Move to SetupSuite
+// https://github.com/containers/skopeo/pull/2703#discussion_r2331374730
+var skopeoBinary = func() string {
+	if binary := os.Getenv("SKOPEO_BINARY"); binary != "" {
+		return binary
+	}
+	return "skopeo"
+}()
 
 const testFQIN = "docker://quay.io/libpod/busybox" // tag left off on purpose, some tests need to add a special one
 const testFQIN64 = "docker://quay.io/libpod/busybox:amd64"


### PR DESCRIPTION
Else use ./bin/skopeo as the default binary.

This makes it a lot more flexible compared to just searching and using the first skopeo in PATH. Also avoids any binary installation to /usr/bin.