### PR TITLE
skopeo: add `--require-signed`

### DIFF
--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -92,6 +92,10 @@ Path to a policy.json file to use for verifying signatures and deciding whether 
 
 Use registry configuration files in _dir_ (e.g. for container signature storage), overriding the default path.
 
+**--require-signed**
+
+Require that any pulled image must be signed regardless of what the default or provided trust policy file says.
+
 **--tmpdir** _dir_
 
 Directory used to store temporary files. Defaults to /var/tmp.

--- a/integration/signing_test.go
+++ b/integration/signing_test.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,16 +25,6 @@ type signingSuite struct {
 }
 
 var _ = suite.SetupAllSuite(&signingSuite{})
-
-func findFingerprint(lineBytes []byte) (string, error) {
-	for line := range bytes.SplitSeq(lineBytes, []byte{'\n'}) {
-		fields := strings.Split(string(line), ":")
-		if len(fields) >= 10 && fields[0] == "fpr" {
-			return fields[9], nil
-		}
-	}
-	return "", errors.New("No fingerprint found")
-}
 
 func (s *signingSuite) SetupSuite() {
 	t := s.T()

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/netip"
@@ -28,6 +29,17 @@ var skopeoBinary = func() string {
 	}
 	return "skopeo"
 }()
+
+// findFingerprint extracts the GPG key fingerprint from gpg --with-colons output.
+func findFingerprint(lineBytes []byte) (string, error) {
+	for line := range bytes.SplitSeq(lineBytes, []byte{'\n'}) {
+		fields := strings.Split(string(line), ":")
+		if len(fields) >= 10 && fields[0] == "fpr" {
+			return fields[9], nil
+		}
+	}
+	return "", errors.New("No fingerprint found")
+}
 
 const (
 	testFQIN           = "docker://quay.io/libpod/busybox" // tag left off on purpose, some tests need to add a special one


### PR DESCRIPTION
In bootc, we want the ability to assert that signature verification is
enforced.

Add a new top-level `--require-signed` switch. When passed, we use the
new `RequireSignatureVerification()` method to ensure that signature
verification is enforced.

Part of https://github.com/containers/skopeo/issues/1829.