### PR TITLE
Use retries in more cases of copying from external registries

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -118,13 +118,13 @@ func (s *copySuite) policyFixture(extraSubstitutions map[string]string) string {
 func (s *copySuite) TestCopyWithManifestList() {
 	t := s.T()
 	dir := t.TempDir()
-	assertSkopeoSucceeds(t, "", "copy", knownListImage, "dir:"+dir)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImage, "dir:"+dir)
 }
 
 func (s *copySuite) TestCopyAllWithManifestList() {
 	t := s.T()
 	dir := t.TempDir()
-	assertSkopeoSucceeds(t, "", "copy", "--all", knownListImage, "dir:"+dir)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--all", knownListImage, "dir:"+dir)
 }
 
 func (s *copySuite) TestCopyAllWithManifestListRoundTrip() {
@@ -133,7 +133,7 @@ func (s *copySuite) TestCopyAllWithManifestListRoundTrip() {
 	oci2 := t.TempDir()
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", knownListImage, "oci:"+oci1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--multi-arch=all", knownListImage, "oci:"+oci1)
 	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", "oci:"+oci1, "dir:"+dir1)
 	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", "dir:"+dir1, "oci:"+oci2)
 	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", "oci:"+oci2, "dir:"+dir2)
@@ -148,9 +148,9 @@ func (s *copySuite) TestCopyAllWithManifestListConverge() {
 	oci2 := t.TempDir()
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", knownListImage, "oci:"+oci1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--multi-arch=all", knownListImage, "oci:"+oci1)
 	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", "oci:"+oci1, "dir:"+dir1)
-	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", "--format", "oci", knownListImage, "dir:"+dir2)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--multi-arch=all", "--format", "oci", knownListImage, "dir:"+dir2)
 	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", "dir:"+dir2, "oci:"+oci2)
 	assertDirImagesAreEqual(t, dir1, dir2)
 	out := combinedOutputOfCommand(t, "diff", "-urN", oci1, oci2)
@@ -160,7 +160,7 @@ func (s *copySuite) TestCopyAllWithManifestListConverge() {
 func (s *copySuite) TestCopyNoneWithManifestList() {
 	t := s.T()
 	dir1 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=index-only", knownListImage, "dir:"+dir1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--multi-arch=index-only", knownListImage, "dir:"+dir1)
 
 	manifestPath := filepath.Join(dir1, "manifest.json")
 	readManifest, err := os.ReadFile(manifestPath)
@@ -177,9 +177,9 @@ func (s *copySuite) TestCopyWithManifestListConverge() {
 	oci2 := t.TempDir()
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "copy", knownListImage, "oci:"+oci1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImage, "oci:"+oci1)
 	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", "oci:"+oci1, "dir:"+dir1)
-	assertSkopeoSucceeds(t, "", "copy", "--format", "oci", knownListImage, "dir:"+dir2)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--format", "oci", knownListImage, "dir:"+dir2)
 	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", "dir:"+dir2, "oci:"+oci2)
 	assertDirImagesAreEqual(t, dir1, dir2)
 	out := combinedOutputOfCommand(t, "diff", "-urN", oci1, oci2)
@@ -190,7 +190,8 @@ func (s *copySuite) TestCopyAllWithManifestListStorageFails() {
 	t := s.T()
 	storage := t.TempDir()
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
-	assertSkopeoFails(t, `.*destination transport .* does not support copying multiple images as a group.*`, "copy", "--multi-arch=all", knownListImage, "containers-storage:"+storage+"test")
+	assertSkopeoFails(t, `.*destination transport .* does not support copying multiple images as a group.*`,
+		"copy", "--retry-times", "3", "--multi-arch=all", knownListImage, "containers-storage:"+storage+"test")
 }
 
 func (s *copySuite) TestCopyWithManifestListStorage() {
@@ -199,8 +200,8 @@ func (s *copySuite) TestCopyWithManifestListStorage() {
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "copy", knownListImage, "containers-storage:"+storage+"test")
-	assertSkopeoSucceeds(t, "", "copy", knownListImage, "dir:"+dir1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImage, "containers-storage:"+storage+"test")
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImage, "dir:"+dir1)
 	assertSkopeoSucceeds(t, "", "copy", "containers-storage:"+storage+"test", "dir:"+dir2)
 	decompressDirs(t, dir1, dir2)
 	assertDirImagesAreEqual(t, dir1, dir2)
@@ -212,9 +213,9 @@ func (s *copySuite) TestCopyWithManifestListStorageMultiple() {
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "--override-arch", "amd64", "copy", knownListImage, "containers-storage:"+storage+"test")
-	assertSkopeoSucceeds(t, "", "--override-arch", "arm64", "copy", knownListImage, "containers-storage:"+storage+"test")
-	assertSkopeoSucceeds(t, "", "--override-arch", "arm64", "copy", knownListImage, "dir:"+dir1)
+	assertSkopeoSucceeds(t, "", "--override-arch", "amd64", "copy", "--retry-times", "3", knownListImage, "containers-storage:"+storage+"test")
+	assertSkopeoSucceeds(t, "", "--override-arch", "arm64", "copy", "--retry-times", "3", knownListImage, "containers-storage:"+storage+"test")
+	assertSkopeoSucceeds(t, "", "--override-arch", "arm64", "copy", "--retry-times", "3", knownListImage, "dir:"+dir1)
 	assertSkopeoSucceeds(t, "", "copy", "containers-storage:"+storage+"test", "dir:"+dir2)
 	decompressDirs(t, dir1, dir2)
 	assertDirImagesAreEqual(t, dir1, dir2)
@@ -226,12 +227,12 @@ func (s *copySuite) TestCopyWithManifestListDigest() {
 	dir2 := t.TempDir()
 	oci1 := t.TempDir()
 	oci2 := t.TempDir()
-	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--raw", knownListImage)
+	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--retry-times", "3", "--raw", knownListImage)
 	manifestDigest, err := manifest.Digest([]byte(m))
 	require.NoError(t, err)
 	digest := manifestDigest.String()
-	assertSkopeoSucceeds(t, "", "copy", knownListImageRepo+"@"+digest, "dir:"+dir1)
-	assertSkopeoSucceeds(t, "", "copy", "--multi-arch=all", knownListImageRepo+"@"+digest, "dir:"+dir2)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "dir:"+dir1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--multi-arch=all", knownListImageRepo+"@"+digest, "dir:"+dir2)
 	assertSkopeoSucceeds(t, "", "copy", "dir:"+dir1, "oci:"+oci1)
 	assertSkopeoSucceeds(t, "", "copy", "dir:"+dir2, "oci:"+oci2)
 	out := combinedOutputOfCommand(t, "diff", "-urN", oci1, oci2)
@@ -243,7 +244,7 @@ func (s *copySuite) TestCopyWithDigestfileOutput() {
 	tempdir := t.TempDir()
 	dir1 := t.TempDir()
 	digestOutPath := filepath.Join(tempdir, "digest.txt")
-	assertSkopeoSucceeds(t, "", "copy", "--digestfile="+digestOutPath, knownListImage, "dir:"+dir1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--digestfile="+digestOutPath, knownListImage, "dir:"+dir1)
 	readDigest, err := os.ReadFile(digestOutPath)
 	require.NoError(t, err)
 	_, err = digest.Parse(string(readDigest))
@@ -256,13 +257,13 @@ func (s *copySuite) TestCopyWithManifestListStorageDigest() {
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
-	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--raw", knownListImage)
+	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--retry-times", "3", "--raw", knownListImage)
 	manifestDigest, err := manifest.Digest([]byte(m))
 	require.NoError(t, err)
 	digest := manifestDigest.String()
-	assertSkopeoSucceeds(t, "", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
 	assertSkopeoSucceeds(t, "", "copy", "containers-storage:"+storage+"test@"+digest, "dir:"+dir1)
-	assertSkopeoSucceeds(t, "", "copy", knownListImageRepo+"@"+digest, "dir:"+dir2)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "dir:"+dir2)
 	decompressDirs(t, dir1, dir2)
 	assertDirImagesAreEqual(t, dir1, dir2)
 }
@@ -273,13 +274,13 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArches() {
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
-	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--raw", knownListImage)
+	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--retry-times", "3", "--raw", knownListImage)
 	manifestDigest, err := manifest.Digest([]byte(m))
 	require.NoError(t, err)
 	digest := manifestDigest.String()
-	assertSkopeoSucceeds(t, "", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
 	assertSkopeoSucceeds(t, "", "copy", "containers-storage:"+storage+"test@"+digest, "dir:"+dir1)
-	assertSkopeoSucceeds(t, "", "copy", knownListImageRepo+"@"+digest, "dir:"+dir2)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "dir:"+dir2)
 	decompressDirs(t, dir1, dir2)
 	assertDirImagesAreEqual(t, dir1, dir2)
 }
@@ -288,14 +289,14 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesBothUseLi
 	t := s.T()
 	storage := t.TempDir()
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
-	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--raw", knownListImage)
+	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--retry-times", "3", "--raw", knownListImage)
 	manifestDigest, err := manifest.Digest([]byte(m))
 	require.NoError(t, err)
 	digest := manifestDigest.String()
 	_, err = manifest.ListFromBlob([]byte(m), manifest.GuessMIMEType([]byte(m)))
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
-	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
 	assertSkopeoFails(t, `.*reading manifest for image instance.*does not exist.*`, "--override-arch=amd64", "inspect", "containers-storage:"+storage+"test@"+digest)
 	assertSkopeoFails(t, `.*reading manifest for image instance.*does not exist.*`, "--override-arch=amd64", "inspect", "--config", "containers-storage:"+storage+"test@"+digest)
 	i2 := combinedOutputOfCommand(t, skopeoBinary, "--override-arch=arm64", "inspect", "--config", "containers-storage:"+storage+"test@"+digest)
@@ -309,7 +310,7 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesFirstUses
 	t := s.T()
 	storage := t.TempDir()
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
-	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--raw", knownListImage)
+	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--retry-times", "3", "--raw", knownListImage)
 	manifestDigest, err := manifest.Digest([]byte(m))
 	require.NoError(t, err)
 	digest := manifestDigest.String()
@@ -319,8 +320,8 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesFirstUses
 	require.NoError(t, err)
 	arm64Instance, err := list.ChooseInstance(&types.SystemContext{ArchitectureChoice: "arm64"})
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
-	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", knownListImageRepo+"@"+arm64Instance.String(), "containers-storage:"+storage+"test@"+arm64Instance.String())
+	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", "--retry-times", "3", knownListImageRepo+"@"+arm64Instance.String(), "containers-storage:"+storage+"test@"+arm64Instance.String())
 	i1 := combinedOutputOfCommand(t, skopeoBinary, "--override-arch=amd64", "inspect", "--config", "containers-storage:"+storage+"test@"+digest)
 	var image1 imgspecv1.Image
 	err = json.Unmarshal([]byte(i1), &image1)
@@ -344,7 +345,7 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesSecondUse
 	t := s.T()
 	storage := t.TempDir()
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
-	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--raw", knownListImage)
+	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--retry-times", "3", "--raw", knownListImage)
 	manifestDigest, err := manifest.Digest([]byte(m))
 	require.NoError(t, err)
 	digest := manifestDigest.String()
@@ -354,8 +355,8 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesSecondUse
 	require.NoError(t, err)
 	arm64Instance, err := list.ChooseInstance(&types.SystemContext{ArchitectureChoice: "arm64"})
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", knownListImageRepo+"@"+amd64Instance.String(), "containers-storage:"+storage+"test@"+amd64Instance.String())
-	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", "--retry-times", "3", knownListImageRepo+"@"+amd64Instance.String(), "containers-storage:"+storage+"test@"+amd64Instance.String())
+	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
 	i1 := combinedOutputOfCommand(t, skopeoBinary, "--override-arch=amd64", "inspect", "--config", "containers-storage:"+storage+"test@"+amd64Instance.String())
 	var image1 imgspecv1.Image
 	err = json.Unmarshal([]byte(i1), &image1)
@@ -379,7 +380,7 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesThirdUses
 	t := s.T()
 	storage := t.TempDir()
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
-	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--raw", knownListImage)
+	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--retry-times", "3", "--raw", knownListImage)
 	manifestDigest, err := manifest.Digest([]byte(m))
 	require.NoError(t, err)
 	digest := manifestDigest.String()
@@ -389,9 +390,9 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesThirdUses
 	require.NoError(t, err)
 	arm64Instance, err := list.ChooseInstance(&types.SystemContext{ArchitectureChoice: "arm64"})
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", knownListImageRepo+"@"+amd64Instance.String(), "containers-storage:"+storage+"test@"+amd64Instance.String())
-	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
-	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", "--retry-times", "3", knownListImageRepo+"@"+amd64Instance.String(), "containers-storage:"+storage+"test@"+amd64Instance.String())
+	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
 	assertSkopeoFails(t, `.*reading manifest for image instance.*does not exist.*`, "--override-arch=amd64", "inspect", "--config", "containers-storage:"+storage+"test@"+digest)
 	i1 := combinedOutputOfCommand(t, skopeoBinary, "--override-arch=amd64", "inspect", "--config", "containers-storage:"+storage+"test@"+amd64Instance.String())
 	var image1 imgspecv1.Image
@@ -414,7 +415,7 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesTagAndDig
 	t := s.T()
 	storage := t.TempDir()
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
-	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--raw", knownListImage)
+	m := combinedOutputOfCommand(t, skopeoBinary, "inspect", "--retry-times", "3", "--raw", knownListImage)
 	manifestDigest, err := manifest.Digest([]byte(m))
 	require.NoError(t, err)
 	digest := manifestDigest.String()
@@ -424,8 +425,8 @@ func (s *copySuite) TestCopyWithManifestListStorageDigestMultipleArchesTagAndDig
 	require.NoError(t, err)
 	arm64Instance, err := list.ChooseInstance(&types.SystemContext{ArchitectureChoice: "arm64"})
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", knownListImage, "containers-storage:"+storage+"test:latest")
-	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
+	assertSkopeoSucceeds(t, "", "--override-arch=amd64", "copy", "--retry-times", "3", knownListImage, "containers-storage:"+storage+"test:latest")
+	assertSkopeoSucceeds(t, "", "--override-arch=arm64", "copy", "--retry-times", "3", knownListImageRepo+"@"+digest, "containers-storage:"+storage+"test@"+digest)
 	assertSkopeoFails(t, `.*reading manifest for image instance.*does not exist.*`, "--override-arch=amd64", "inspect", "--config", "containers-storage:"+storage+"test@"+digest)
 	i1 := combinedOutputOfCommand(t, skopeoBinary, "--override-arch=arm64", "inspect", "--config", "containers-storage:"+storage+"test:latest")
 	var image1 imgspecv1.Image
@@ -458,14 +459,14 @@ func (s *copySuite) TestCopyFailsWhenImageOSDoesNotMatchRuntimeOS() {
 	t := s.T()
 	storage := t.TempDir()
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
-	assertSkopeoFails(t, `.*no image found in manifest list for architecture .*, variant .*, OS .*`, "copy", knownWindowsOnlyImage, "containers-storage:"+storage+"test")
+	assertSkopeoFails(t, `.*no image found in manifest list for architecture .*, variant .*, OS .*`, "copy", "--retry-times", "3", knownWindowsOnlyImage, "containers-storage:"+storage+"test")
 }
 
 func (s *copySuite) TestCopySucceedsWhenImageDoesNotMatchRuntimeButWeOverride() {
 	t := s.T()
 	storage := t.TempDir()
 	storage = fmt.Sprintf("[vfs@%s/root+%s/runroot]", storage, storage)
-	assertSkopeoSucceeds(t, "", "--override-os=windows", "--override-arch=amd64", "copy", knownWindowsOnlyImage, "--retry-times", "3",
+	assertSkopeoSucceeds(t, "", "--override-os=windows", "--override-arch=amd64", "copy", "--retry-times", "3", knownWindowsOnlyImage,
 		"containers-storage:"+storage+"test")
 }
 
@@ -494,7 +495,7 @@ func (s *copySuite) TestCopySimple() {
 
 	// FIXME: It would be nice to use one of the local Docker registries instead of needing an Internet connection.
 	// "pull": docker: → dir:
-	assertSkopeoSucceeds(t, "", "copy", "docker://registry.k8s.io/pause", "dir:"+dir1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "docker://registry.k8s.io/pause", "dir:"+dir1)
 	// "push": dir: → docker(v2s2):
 	assertSkopeoSucceeds(t, "", "--tls-verify=false", "--debug", "copy", "dir:"+dir1, ourRegistry+"pause:unsigned")
 	// The result of pushing and pulling is an unmodified image.
@@ -508,7 +509,7 @@ func (s *copySuite) TestCopySimple() {
 	ociDest := "pause-latest-image"
 	ociImgName := "pause"
 	defer os.RemoveAll(ociDest)
-	assertSkopeoSucceeds(t, "", "copy", "docker://registry.k8s.io/pause:latest", "oci:"+ociDest+":"+ociImgName)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "docker://registry.k8s.io/pause:latest", "oci:"+ociDest+":"+ociImgName)
 	_, err := os.Stat(ociDest)
 	require.NoError(t, err)
 	// copy exits with status 2 if the image is not found within the container, in some transports.
@@ -517,7 +518,7 @@ func (s *copySuite) TestCopySimple() {
 	// docker v2s2 -> OCI image layout without image name
 	ociDest = "pause-latest-noimage"
 	defer os.RemoveAll(ociDest)
-	assertSkopeoSucceeds(t, "", "copy", "docker://registry.k8s.io/pause:latest", "oci:"+ociDest)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "docker://registry.k8s.io/pause:latest", "oci:"+ociDest)
 	_, err = os.Stat(ociDest)
 	require.NoError(t, err)
 }
@@ -762,10 +763,10 @@ func (s *copySuite) TestCopySignatures() {
 
 	// type: reject
 	assertSkopeoFails(t, fmt.Sprintf(".*Source image rejected: Running image %s:latest is rejected by policy.*", testFQIN),
-		"--policy", policy, "copy", testFQIN+":latest", dirDest)
+		"--policy", policy, "copy", "--retry-times", "3", testFQIN+":latest", dirDest)
 
 	// type: insecureAcceptAnything
-	assertSkopeoSucceeds(t, "", "--policy", policy, "copy", "docker://quay.io/openshift/origin-hello-openshift", dirDest)
+	assertSkopeoSucceeds(t, "", "--policy", policy, "copy", "--retry-times", "3", "docker://quay.io/openshift/origin-hello-openshift", dirDest)
 
 	// type: signedBy
 	// Sign the images
@@ -1205,8 +1206,8 @@ func (s *copySuite) TestCopyPreserveDigests() {
 	t := s.T()
 	topDir := t.TempDir()
 
-	assertSkopeoSucceeds(t, "", "copy", knownListImage, "--multi-arch=all", "--preserve-digests", "dir:"+topDir)
-	assertSkopeoFails(t, ".*Instructed to preserve digests.*", "copy", knownListImage, "--multi-arch=all", "--preserve-digests", "--format=oci", "dir:"+topDir)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", knownListImage, "--multi-arch=all", "--preserve-digests", "dir:"+topDir)
+	assertSkopeoFails(t, ".*Instructed to preserve digests.*", "copy", "--retry-times", "3", knownListImage, "--multi-arch=all", "--preserve-digests", "--format=oci", "dir:"+topDir)
 }
 
 func (s *copySuite) testCopySchemaConversionRegistries(t *testing.T, schema1Registry, schema2Registry string) {

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -146,7 +146,7 @@ func (s *syncSuite) TestDocker2DirTagged() {
 	require.NoError(t, err)
 
 	// copy docker => dir
-	assertSkopeoSucceeds(t, "", "copy", "docker://"+image, "dir:"+dir2)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "docker://"+image, "dir:"+dir2)
 	_, err = os.Stat(path.Join(dir2, "manifest.json"))
 	require.NoError(t, err)
 
@@ -173,7 +173,7 @@ func (s *syncSuite) TestDocker2DirTaggedAll() {
 	require.NoError(t, err)
 
 	// copy docker => dir
-	assertSkopeoSucceeds(t, "", "copy", "--all", "docker://"+image, "dir:"+dir2)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--all", "docker://"+image, "dir:"+dir2)
 	_, err = os.Stat(path.Join(dir2, "manifest.json"))
 	require.NoError(t, err)
 
@@ -189,11 +189,12 @@ func (s *syncSuite) TestPreserveDigests() {
 	image := pullableTaggedManifestList
 
 	// copy docker => dir
-	assertSkopeoSucceeds(t, "", "copy", "--all", "--preserve-digests", "docker://"+image, "dir:"+tmpDir)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--all", "--preserve-digests", "docker://"+image, "dir:"+tmpDir)
 	_, err := os.Stat(path.Join(tmpDir, "manifest.json"))
 	require.NoError(t, err)
 
-	assertSkopeoFails(t, ".*Instructed to preserve digests.*", "copy", "--all", "--preserve-digests", "--format=oci", "docker://"+image, "dir:"+tmpDir)
+	assertSkopeoFails(t, ".*Instructed to preserve digests.*",
+		"copy", "--retry-times", "3", "--all", "--preserve-digests", "--format=oci", "docker://"+image, "dir:"+tmpDir)
 }
 
 func (s *syncSuite) TestScoped() {
@@ -223,7 +224,7 @@ func (s *syncSuite) TestDirIsNotOverwritten() {
 	imagePath := imageRef.DockerReference().String()
 
 	// make a copy of the image in the local registry
-	assertSkopeoSucceeds(t, "", "copy", "--dest-tls-verify=false", "docker://"+image, "docker://"+path.Join(v2DockerRegistryURL, reference.Path(imageRef.DockerReference())))
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--dest-tls-verify=false", "docker://"+image, "docker://"+path.Join(v2DockerRegistryURL, reference.Path(imageRef.DockerReference())))
 
 	//sync upstream image to dir, not scoped
 	dir1 := t.TempDir()
@@ -405,7 +406,7 @@ func (s *syncSuite) TestYamlTLSVerify() {
 
 	// FIXME: It would be nice to use one of the local Docker registries instead of needing an Internet connection.
 	// copy docker => docker
-	assertSkopeoSucceeds(t, "", "copy", "--dest-tls-verify=false", "docker://"+image+":"+tag, localRegURL+image+":"+tag)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "--dest-tls-verify=false", "docker://"+image+":"+tag, localRegURL+image+":"+tag)
 
 	yamlTemplate := `
 %s:
@@ -488,7 +489,7 @@ func (s *syncSuite) TestDocker2DockerTagged() {
 	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--dest-tls-verify=false", "--src", "docker", "--dest", "docker", image, v2DockerRegistryURL)
 
 	// copy docker => dir
-	assertSkopeoSucceeds(t, "", "copy", "docker://"+image, "dir:"+dir1)
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "docker://"+image, "dir:"+dir1)
 	_, err = os.Stat(path.Join(dir1, "manifest.json"))
 	require.NoError(t, err)
 
@@ -522,7 +523,7 @@ func (s *syncSuite) TestDir2DockerTagged() {
 	require.NoError(t, err)
 
 	// copy docker => dir
-	assertSkopeoSucceeds(t, "", "copy", "docker://"+image, "dir:"+path.Join(dir1, image))
+	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "docker://"+image, "dir:"+path.Join(dir1, image))
 	_, err = os.Stat(path.Join(dir1, image, "manifest.json"))
 	require.NoError(t, err)
 


### PR DESCRIPTION
We added retries to other registry operations before, these were missed for some reason.

Motivated by: https://api.cirrus-ci.com/v1/task/6228198955941888/logs/integration.log .