### PR TITLE
Packit: Do not notify on podman-next copr build failure

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -71,9 +71,6 @@ jobs:
   - job: copr_build
     trigger: commit
     packages: [skopeo-fedora]
-    notifications:
-      failure_comment:
-        message: "podman-next COPR build failed. @containers/packit-build please check."
     branch: main
     owner: rhcontainerbot
     project: podman-next


### PR DESCRIPTION
These happen after commit to upstream and don't affect upstream.

These notifications only end up adding unnecessary noise.

Overall build failures can happen for a variety of reasons like copr infra, outdated toolchain on some environments etc.