### PR TITLE
Support `containers-storage:` with `sha256:` prefix

### DIFF
--- a/vendor/go.podman.io/image/v5/storage/storage_transport.go
+++ b/vendor/go.podman.io/image/v5/storage/storage_transport.go
@@ -168,6 +168,10 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 			// We have recognized an image ID; peel it off.
 			ref = ref[:split]
 		}
+	} else if rest, ok := strings.CutPrefix(ref, "sha256:"); ok {
+		// If it starts with sha256: then it's pretty clear that it's already an ID
+		id = rest
+		ref = ""
 	}
 
 	// If we only have one @-delimited portion, then _maybe_ it's a truncated image ID.  Only check on that if it's


### PR DESCRIPTION
The code was previously trying to interpret this as a named reference and landing up turning sha256:xyz into docker.io/library/sha256:xyz and failing to find it.

That's very clearly not what the user intended in this case, so let's just use the digest value directly.

Fixes #2750