### PR TITLE
Indent option explanations using definition lists (:)

### DIFF
--- a/docs/skopeo-copy.1.md
+++ b/docs/skopeo-copy.1.md
@@ -24,224 +24,224 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--additional-tag**=_strings_
 
-Additional tags (supports docker-archive).
+:   Additional tags (supports docker-archive).
 
 **--all**, **-a**
 
-If _source-image_ refers to a list of images, instead of copying just the image which matches the current OS and
-architecture (subject to the use of the global --override-os, --override-arch and --override-variant options), attempt to copy all of
-the images in the list, and the list itself.
+:   If _source-image_ refers to a list of images, instead of copying just the image which matches the current OS and
+    architecture (subject to the use of the global --override-os, --override-arch and --override-variant options), attempt to copy all of
+    the images in the list, and the list itself.
 
 **--authfile** _path_
 
-Path of the primary registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
-See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
-
-Use `skopeo login` to manage the credentials.
-
-The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
+:   Path of the primary registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
+    See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
+    
+    Use `skopeo login` to manage the credentials.
+    
+    The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
 
 **--src-authfile** _path_
 
-Path of the primary registry credentials file for the source registry. Uses path given by `--authfile`, if not provided.
+:   Path of the primary registry credentials file for the source registry. Uses path given by `--authfile`, if not provided.
 
 **--dest-authfile** _path_
 
-Path of the primary registry credentials file for the destination registry. Uses path given by `--authfile`, if not provided.
+:   Path of the primary registry credentials file for the destination registry. Uses path given by `--authfile`, if not provided.
 
 **--dest-shared-blob-dir** _directory_
 
-Directory to use to share blobs across OCI repositories.
+:   Directory to use to share blobs across OCI repositories.
 
 **--digestfile** _path_
 
-After copying the image, write the digest of the resulting image to the file.
+:   After copying the image, write the digest of the resulting image to the file.
 
 **--preserve-digests**
 
-Preserve the digests during copying. Fail if the digest cannot be preserved.
+:   Preserve the digests during copying. Fail if the digest cannot be preserved.
 
-This option does not change what will be copied; consider using `--all` at the same time.
+    This option does not change what will be copied; consider using `--all` at the same time.
 
 **--encrypt-layer** _ints_
 
-*Experimental* the 0-indexed layer indices, with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer)
+:   *Experimental* the 0-indexed layer indices, with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer)
 
 **--format**, **-f** _manifest-type_
 
-MANIFEST TYPE (oci, v2s1, or v2s2) to use in the destination (default is manifest type of source, with fallbacks)
+:   MANIFEST TYPE (oci, v2s1, or v2s2) to use in the destination (default is manifest type of source, with fallbacks)
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--multi-arch** _option_
 
-Control what is copied if _source-image_ refers to a multi-architecture image. Default is system.
+:   Control what is copied if _source-image_ refers to a multi-architecture image. Default is system.
 
-Options:
-- system: Copy only the image that matches the system architecture
-- all: Copy the full multi-architecture image
-- index-only: Copy only the index
-- _platform-list_: Copy only specific platforms (comma-separated list of OS/Architecture pairs, e.g., `linux/amd64,linux/arm64`)
+:   Options:
+    - system: Copy only the image that matches the system architecture
+    - all: Copy the full multi-architecture image
+    - index-only: Copy only the index
+    - _platform-list_: Copy only specific platforms (comma-separated list of OS/Architecture pairs, e.g., `linux/amd64,linux/arm64`)
 
-The index-only option and platform-list both create sparse manifest lists, which usually fail unless the referenced per-architecture images are already present in the destination, or the target registry supports sparse indexes.
+    The index-only option and platform-list both create sparse manifest lists, which usually fail unless the referenced per-architecture images are already present in the destination, or the target registry supports sparse indexes.
 
-When specifying a platform list, all compression variants and other variations for each platform are copied.
+    When specifying a platform list, all compression variants and other variations for each platform are copied.
 
 **--quiet**, **-q**
 
-Suppress output information when copying images.
+:   Suppress output information when copying images.
 
 **--remove-signatures**
 
-Do not copy signatures, if any, from _source-image_. Necessary when copying a signed image to a destination which does not support signatures.
+:   Do not copy signatures, if any, from _source-image_. Necessary when copying a signed image to a destination which does not support signatures.
 
 **--sign-by** _key-id_
 
-Add a “simple signing” signature using that key ID for an image name corresponding to _destination-image_
+:   Add a “simple signing” signature using that key ID for an image name corresponding to _destination-image_
 
 **--sign-by-sigstore** _param-file_
 
-Add a sigstore signature based on the options in the specified containers sigstore signing parameter file, _param-file_.
-See containers-sigstore-signing-params.yaml(5) for details about the file format.
+:   Add a sigstore signature based on the options in the specified containers sigstore signing parameter file, _param-file_.
+    See containers-sigstore-signing-params.yaml(5) for details about the file format.
 
 **--sign-by-sigstore-private-key** _path_
 
-Add a sigstore signature using a private key at _path_ for an image name corresponding to _destination-image_
+:   Add a sigstore signature using a private key at _path_ for an image name corresponding to _destination-image_
 
 **--sign-by-sq-fingerprint** _fingerprint_
 
-Add a “simple signing” signature using a Sequoia-PGP key with the specified _fingerprint_.
+:   Add a “simple signing” signature using a Sequoia-PGP key with the specified _fingerprint_.
 
 **--sign-passphrase-file** _path_
 
-The passphrase to use when signing with `--sign-by`, `--sign-by-sigstore-private-key` or `--sign-by-sq-fingerprint`.
-Only the first line will be read. A passphrase stored in a file is of questionable security if other users can read this file. Do not use this option if at all avoidable.
+:   The passphrase to use when signing with `--sign-by`, `--sign-by-sigstore-private-key` or `--sign-by-sq-fingerprint`.
+    Only the first line will be read. A passphrase stored in a file is of questionable security if other users can read this file. Do not use this option if at all avoidable.
 
 **--sign-identity** _reference_
 
-The identity to use when signing the image. The identity must be a fully specified docker reference. If the identity is not specified, the target docker reference will be used.
+:   The identity to use when signing the image. The identity must be a fully specified docker reference. If the identity is not specified, the target docker reference will be used.
 
 **--src-shared-blob-dir** _directory_
 
-Directory to use to share blobs across OCI repositories.
+:   Directory to use to share blobs across OCI repositories.
 
 **--encryption-key** _protocol:keyfile_
 
-Specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
+:   Specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
 
 **--decryption-key** _key[:passphrase]_
 
-Key to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.
+:   Key to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.
 
 **--src-creds** _username[:password]_
 
-Credentials for accessing the source registry.
+:   Credentials for accessing the source registry.
 
 **--dest-compress**
 
-Compress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source).
+:   Compress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source).
 
 **--dest-decompress**
 
-Decompress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source).
+:   Decompress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source).
 
 **--dest-oci-accept-uncompressed-layers**
 
-Allow uncompressed image layers when saving to an OCI image using the 'oci' transport. (default is to compress things that aren't compressed).
+:   Allow uncompressed image layers when saving to an OCI image using the 'oci' transport. (default is to compress things that aren't compressed).
 
 **--dest-creds** _username[:password]_
 
-Credentials for accessing the destination registry.
+:   Credentials for accessing the destination registry.
 
 **--src-cert-dir** _path_
 
-Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the source registry or daemon.
+:   Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the source registry or daemon.
 
 **--src-no-creds**
 
-Access the registry anonymously.
+:   Access the registry anonymously.
 
 **--src-tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to container source registry or daemon. Default to source registry setting.
+:   Require HTTPS and verify certificates when talking to container source registry or daemon. Default to source registry setting.
 
 **--dest-cert-dir** _path_
 
-Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the destination registry or daemon.
+:   Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the destination registry or daemon.
 
 **--dest-no-creds**
 
-Access the registry anonymously.
+:   Access the registry anonymously.
 
 **--dest-tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to container destination registry or daemon. Default to destination registry setting.
+:   Require HTTPS and verify certificates when talking to container destination registry or daemon. Default to destination registry setting.
 
 **--src-daemon-host** _host_
 
-Copy from docker daemon at _host_. If _host_ starts with `tcp://`, HTTPS is enabled by default. To use plain HTTP, use the form `http://` (default is `unix:///var/run/docker.sock`).
+:   Copy from docker daemon at _host_. If _host_ starts with `tcp://`, HTTPS is enabled by default. To use plain HTTP, use the form `http://` (default is `unix:///var/run/docker.sock`).
 
 **--dest-daemon-host** _host_
 
-Copy to docker daemon at _host_. If _host_ starts with `tcp://`, HTTPS is enabled by default. To use plain HTTP, use the form `http://` (default is `unix:///var/run/docker.sock`).
+:   Copy to docker daemon at _host_. If _host_ starts with `tcp://`, HTTPS is enabled by default. To use plain HTTP, use the form `http://` (default is `unix:///var/run/docker.sock`).
 
-Existing signatures, if any, are preserved as well.
+    Existing signatures, if any, are preserved as well.
 
 **--dest-compress-format** _format_
 
-Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.
-`zstd:chunked` is incompatible with encrypting images,
-and will be treated as `zstd` with a warning in that case.
+:   Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.
+    `zstd:chunked` is incompatible with encrypting images,
+    and will be treated as `zstd` with a warning in that case.
 
 **--dest-compress-level** _format_
 
-Specifies the compression level to use.  The value is specific to the compression algorithm used, e.g. for zstd the accepted values are in the range 1-20 (inclusive), while for gzip it is 1-9 (inclusive).
+:   Specifies the compression level to use.  The value is specific to the compression algorithm used, e.g. for zstd the accepted values are in the range 1-20 (inclusive), while for gzip it is 1-9 (inclusive).
 
 **--dest-force-compress-format**
 
-Ensures that the compression algorithm set in --dest-compress-format is used exclusively.
+:   Ensures that the compression algorithm set in --dest-compress-format is used exclusively.
 
 **--src-registry-token** _token_
 
-Bearer token for accessing the source registry.
+:   Bearer token for accessing the source registry.
 
 **--dest-registry-token** _token_
 
-Bearer token for accessing the destination registry.
+:   Bearer token for accessing the destination registry.
 
 **--dest-precompute-digests**
 
-Precompute digests to ensure layers are not uploaded that already exist on the destination registry. Layers with initially unknown digests (ex. compressing "on the fly") will be temporarily streamed to disk.
+:   Precompute digests to ensure layers are not uploaded that already exist on the destination registry. Layers with initially unknown digests (ex. compressing "on the fly") will be temporarily streamed to disk.
 
 **--retry-times**
 
-The number of times to retry. By default, no retries are attempted.
+:   The number of times to retry. By default, no retries are attempted.
 
 **--retry-delay**
 
-Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
+:   Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--src-username**
 
-The username to access the source registry.
+:   The username to access the source registry.
 
 **--src-password**
 
-The password to access the source registry.
+:   The password to access the source registry.
 
 **--dest-username**
 
-The username to access the destination registry.
+:   The username to access the destination registry.
 
 **--dest-password**
 
-The password to access the destination registry.
+:   The password to access the destination registry.
 
 **--image-parallel-copies** _n_
 
-Maximum number of image layers to be copied (pulled/pushed) simultaneously. Not setting this field will fall back to containers/image defaults.
+:   Maximum number of image layers to be copied (pulled/pushed) simultaneously. Not setting this field will fall back to containers/image defaults.
 
 ## EXAMPLES
 

--- a/docs/skopeo-delete.1.md
+++ b/docs/skopeo-delete.1.md
@@ -35,62 +35,62 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--authfile** _path_
 
-Path of the primary registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
-See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
+:   Path of the primary registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
+    See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
 
-Use `skopeo login` to manage the credentials.
+    Use `skopeo login` to manage the credentials.
 
-The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
+    The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
 
 **--creds** _username[:password]_
 
-Credentials for accessing the registry.
+:   Credentials for accessing the registry.
 
 **--cert-dir** _path_
 
-Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the registry.
+:   Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the registry.
 
 **--daemon-host** _host_
 
-Use docker daemon host at _host_ (`docker-daemon:` transport only)
+:   Use docker daemon host at _host_ (`docker-daemon:` transport only)
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--no-creds**
 
-Access the registry anonymously.
+:   Access the registry anonymously.
 
-Additionally, the registry must allow deletions by setting `REGISTRY_STORAGE_DELETE_ENABLED=true` for the registry daemon.
+    Additionally, the registry must allow deletions by setting `REGISTRY_STORAGE_DELETE_ENABLED=true` for the registry daemon.
 
 **--registry-token** _token_
 
-Bearer token for accessing the registry.
+:   Bearer token for accessing the registry.
 
 **--retry-times**
 
-The number of times to retry. By default, no retries are attempted.
+:   The number of times to retry. By default, no retries are attempted.
 
 **--retry-delay**
 
-Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
+:   Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--shared-blob-dir** _directory_
 
-Directory to use to share blobs across OCI repositories.
+:   Directory to use to share blobs across OCI repositories.
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
+:   Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 **--username**
 
-The username to access the registry.
+:   The username to access the registry.
 
 **--password**
 
-The password to access the registry.
+:   The password to access the registry.
 
 ## EXAMPLES
 

--- a/docs/skopeo-generate-sigstore-key.1.md
+++ b/docs/skopeo-generate-sigstore-key.1.md
@@ -21,19 +21,19 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--output-prefix** _prefix_
 
-Mandatory.
-Path prefix for the output keys (_prefix_**.private** and _prefix_**.pub**).
+:   Mandatory.
+    Path prefix for the output keys (_prefix_**.private** and _prefix_**.pub**).
 
 **--passphrase-file** _path_
 
-The passphare to use to encrypt the private key.
-Only the first line will be read.
-A passphrase stored in a file is of questionable security if other users can read this file.
-Do not use this option if at all avoidable.
+:   The passphare to use to encrypt the private key.
+    Only the first line will be read.
+    A passphrase stored in a file is of questionable security if other users can read this file.
+    Do not use this option if at all avoidable.
 
 ## EXAMPLES
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -97,9 +97,9 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--manifest-digest**=_algorithm_ **EXPERIMENTAL**
 
-Algorithm to use for computing manifest digest (sha256, sha512); defaults to algorithm used in config digest.
+:   Algorithm to use for computing manifest digest (sha256, sha512); defaults to algorithm used in config digest.
 
-**Note:** This flag is experimental and its behavior may change in future releases.
+    **Note:** This flag is experimental and its behavior may change in future releases.
 
 ## EXAMPLES
 

--- a/docs/skopeo-inspect.1.md
+++ b/docs/skopeo-inspect.1.md
@@ -21,79 +21,79 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--authfile** _path_
 
-Path of the primary registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
-See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
+:   Path of the primary registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
+    See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
 
-Use `skopeo login` to manage the credentials.
+    Use `skopeo login` to manage the credentials.
 
-The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
+    The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
 
 **--cert-dir** _path_
 
-Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry.
+:   Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry.
 
 **--config**
 
-Output configuration in OCI format, default is to format in JSON format.
+:   Output configuration in OCI format, default is to format in JSON format.
 
 **--creds** _username[:password]_
 
-Username and password for accessing the registry.
+:   Username and password for accessing the registry.
 
 **--daemon-host** _host_
 
-Use docker daemon host at _host_ (`docker-daemon:` transport only)
+:   Use docker daemon host at _host_ (`docker-daemon:` transport only)
 
 **--format**, **-f**=*format*
 
-Format the output using the given Go template.
-The keys of the returned JSON can be used as the values for the --format flag (see examples below).
-Supports the Go templating functions available at https://pkg.go.dev/github.com/containers/common/pkg/report#hdr-Template_Functions
+:   Format the output using the given Go template.
+    The keys of the returned JSON can be used as the values for the --format flag (see examples below).
+    Supports the Go templating functions available at https://pkg.go.dev/github.com/containers/common/pkg/report#hdr-Template_Functions
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--no-creds**
 
-Access the registry anonymously.
+:   Access the registry anonymously.
 
 **--raw**
 
-Output raw manifest or config data depending on --config option.
-The --format option is not supported with --raw option.
+:   Output raw manifest or config data depending on --config option.
+    The --format option is not supported with --raw option.
 
 **--registry-token** _Bearer token_
 
-Registry token for accessing the registry.
+:   Registry token for accessing the registry.
 
 **--retry-times**
 
-The number of times to retry. By default, no retries are attempted.
+:   The number of times to retry. By default, no retries are attempted.
 
 **--retry-delay**
 
-Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
+:   Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--shared-blob-dir** _directory_
 
-Directory to use to share blobs across OCI repositories.
+:   Directory to use to share blobs across OCI repositories.
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
+:   Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 **--username**
 
-The username to access the registry.
+:   The username to access the registry.
 
 **--password**
 
-The password to access the registry.
+:   The password to access the registry.
 
 **--no-tags**, **-n**
 
-Do not list the available tags from the repository in the output. When `true`, the `RepoTags` array will be empty.  Defaults to `false`, which includes all available tags.
+:   Do not list the available tags from the repository in the output. When `true`, the `RepoTags` array will be empty.  Defaults to `false`, which includes all available tags.
 
 **--manifest-digest**=_algorithm_ **EXPERIMENTAL**
 

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -25,7 +25,7 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--creds** _username[:password]_
 
-:   For accessing the registry
+:   Credentials for accessing the registry
 
 **--cert-dir** _path_
 

--- a/docs/skopeo-list-tags.1.md
+++ b/docs/skopeo-list-tags.1.md
@@ -16,50 +16,52 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--authfile** _path_
 
-Path of the updated registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
-See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
+:   Path of the updated registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
+    See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
 
-Use `skopeo login` to manage the credentials.
+    Use `skopeo login` to manage the credentials.
 
-The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
+    The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
 
-**--creds** _username[:password]_ for accessing the registry.
+**--creds** _username[:password]_
+
+:   For accessing the registry
 
 **--cert-dir** _path_
 
-Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry.
+:   Use certificates at _path_ (\*.crt, \*.cert, \*.key) to connect to the registry.
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--no-creds**
 
-Access the registry anonymously.
+:   Access the registry anonymously.
 
 **--registry-token** _Bearer token_
 
-Bearer token for accessing the registry.
+:   Bearer token for accessing the registry.
 
 **--retry-times**
 
-The number of times to retry. By default, no retries are attempted.
+:   The number of times to retry. By default, no retries are attempted.
 
 **--retry-delay**
 
-Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
+:   Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
+:   Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 **--username**
 
-The username to access the registry.
+:   The username to access the registry.
 
 **--password**
 
-The password to access the registry.
+:   The password to access the registry.
 
 ## REPOSITORY NAMES
 

--- a/docs/skopeo-login.1.md
+++ b/docs/skopeo-login.1.md
@@ -19,47 +19,47 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--password**, **-p**=*password*
 
-Password for registry
+:   Password for registry
 
 **--password-stdin**
 
-Take the password from stdin
+:   Take the password from stdin
 
 **--username**, **-u**=*username*
 
-Username for registry
+:   Username for registry
 
 **--authfile**=*path*
 
-Path of the managed registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
-See **containers-auth.json**(5) for more details about the default on other platforms.
+:   Path of the managed registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
+    See **containers-auth.json**(5) for more details about the default on other platforms.
 
-The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
+    The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
 
 **--compat-auth-file**=*path*
 
-Instead of updating the default credentials file, update the one at *path*, and use a Docker-compatible format.
+:   Instead of updating the default credentials file, update the one at *path*, and use a Docker-compatible format.
 
 **--get-login**
 
-Return the logged-in user for the registry. Return error if no login is found.
+:   Return the logged-in user for the registry. Return error if no login is found.
 
 **--cert-dir**=*path*
 
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+:   Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
+    Default certificates directory is _/etc/containers/certs.d_.
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
+:   Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 **--verbose**, **-v**
 
-Write more detailed information to stdout
+:   Write more detailed information to stdout
 
 ## EXAMPLES
 

--- a/docs/skopeo-logout.1.md
+++ b/docs/skopeo-logout.1.md
@@ -17,26 +17,26 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--authfile**=*path*
 
-Path of the managed registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
-See **containers-auth.json**(5) for more details about the default on other platforms.
+:   Path of the managed registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
+    See **containers-auth.json**(5) for more details about the default on other platforms.
 
-The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
+    The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
 
 **--compat-auth-file**=*path*
 
-Instead of updating the default credentials file, update the one at *path*, and use a Docker-compatible format.
+:   Instead of updating the default credentials file, update the one at *path*, and use a Docker-compatible format.
 
 **--all**, **-a**
 
-Remove the cached credentials for all registries in the auth file
+:   Remove the cached credentials for all registries in the auth file
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--tls-verify**=_bool_
 
-Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
+:   Require HTTPS and verify certificates when talking to the container registry or daemon. Default to registry.conf setting.
 
 ## EXAMPLES
 

--- a/docs/skopeo-manifest-digest.1.md
+++ b/docs/skopeo-manifest-digest.1.md
@@ -14,7 +14,7 @@ Compute a manifest digest of _manifest-file_ and write it to standard output.
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 ## EXAMPLES
 

--- a/docs/skopeo-standalone-sign.1.md
+++ b/docs/skopeo-standalone-sign.1.md
@@ -21,15 +21,15 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--output**, **-o** _output file_
 
-Write signature to _output file_.
+:   Write signature to _output file_.
 
 **--passphrase-file**=_path_
 
-The passphare to use when signing with the key ID from `--sign-by`. Only the first line will be read. A passphrase stored in a file is of questionable security if other users can read this file. Do not use this option if at all avoidable.
+:   The passphare to use when signing with the key ID from `--sign-by`. Only the first line will be read. A passphrase stored in a file is of questionable security if other users can read this file. Do not use this option if at all avoidable.
 
 ## EXAMPLES
 

--- a/docs/skopeo-standalone-verify.1.md
+++ b/docs/skopeo-standalone-verify.1.md
@@ -28,11 +28,11 @@ See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--help**, **-h**
 
-Print usage statement
+:   Print usage statement
 
 **--public-key-file** _public key file_
 
-File containing the public keys to use when verifying signatures. If this is not specified, keys from the GPG homedir are used.
+:   File containing the public keys to use when verifying signatures. If this is not specified, keys from the GPG homedir are used.
 
 ## EXAMPLES
 

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -33,131 +33,164 @@ name can be stored at _destination_.
 See also [skopeo(1)](skopeo.1.md) for options placed before the subcommand name.
 
 **--all**, **-a**
-If one of the images in __src__ refers to a list of images, instead of copying just the image which matches the current OS and
-architecture (subject to the use of the global --override-os, --override-arch and --override-variant options), attempt to copy all of
-the images in the list, and the list itself.
+
+:   If one of the images in __src__ refers to a list of images, instead of copying just the image which matches the current OS and
+    architecture (subject to the use of the global --override-os, --override-arch and --override-variant options), attempt to copy all of
+    the images in the list, and the list itself.
 
 **--authfile** _path_
 
-Path of the primary registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
-See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
+:   Path of the primary registry credentials file. On Linux, the default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
+    See **containers-auth.json**(5) for more details about the credential search mechanism and defaults on other platforms.
 
-Use `skopeo login` to manage the credentials.
+    Use `skopeo login` to manage the credentials.
 
-The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
+    The default value of this option is read from the `REGISTRY\_AUTH\_FILE` environment variable.
 
 **--src-authfile** _path_
 
-Path of the primary registry credentials file for the source registry. Uses path given by `--authfile`, if not provided.
+:   Path of the primary registry credentials file for the source registry. Uses path given by `--authfile`, if not provided.
 
 **--dest-authfile** _path_
 
-Path of the primary registry credentials file for the destination registry. Uses path given by `--authfile`, if not provided.
+:   Path of the primary registry credentials file for the destination registry. Uses path given by `--authfile`, if not provided.
 
 **--dry-run**
 
-Run the sync without actually copying data to the destination.
+:   Run the sync without actually copying data to the destination.
 
-**--src**, **-s** _transport_ Transport for the source repository.
+**--src**, **-s** _transport_
 
-**--dest**, **-d** _transport_ Destination transport.
+:   Transport for the source repository.
 
-**--format**, **-f** _manifest-type_ Manifest Type (oci, v2s1, or v2s2) to use when syncing image(s) to a destination (default is manifest type of source, with fallbacks).
+**--dest**, **-d** _transport_
+
+:   Destination transport.
+
+**--format**, **-f** _manifest-type_
+
+:   Manifest Type (oci, v2s1, or v2s2) to use when syncing image(s) to a destination (default is manifest type of source, with fallbacks).
 
 **--help**, **-h**
 
-Print usage statement.
+:   Print usage statement.
 
-**--scoped** Prefix images with the source image path, so that multiple images with the same name can be stored at _destination_.
+**--scoped**
 
-**--append-suffix** _tag-suffix_ String to append to destination tags.
+:   Prefix images with the source image path, so that multiple images with the same name can be stored at _destination_.
+
+**--append-suffix** _tag-suffix_
+
+:   String to append to destination tags.
 
 **--digestfile** _path_
 
-After copying the images from source, write the digest of the resulting images along with Image Reference.
+:   After copying the images from source, write the digest of the resulting images along with Image Reference.
 
-```
-sha256:bf91f90823248017a4f920fb541727fa8368dc6cf377a7debbd271cf6a31c8a7 docker://myhost.com/alpine:edge
-sha256:31603596830fc7e56753139f9c2c6bd3759e48a850659506ebfb885d1cf3aef5 docker://myhost.com/postgres:14.3
-
-```
+    ```
+    sha256:bf91f90823248017a4f920fb541727fa8368dc6cf377a7debbd271cf6a31c8a7 docker://myhost.com/alpine:edge
+    sha256:31603596830fc7e56753139f9c2c6bd3759e48a850659506ebfb885d1cf3aef5 docker://myhost.com/postgres:14.3
+    ```
 
 **--preserve-digests**
 
-Preserve the digests during copying. Fail if the digest cannot be preserved.
+:   Preserve the digests during copying. Fail if the digest cannot be preserved.
 
-This option does not change what will be copied; consider using `--all` at the same time.
+    This option does not change what will be copied; consider using `--all` at the same time.
 
-**--remove-signatures** Do not copy signatures, if any, from _source-image_. This is necessary when copying a signed image to a destination which does not support signatures.
+**--remove-signatures**
+
+:   Do not copy signatures, if any, from _source-image_. This is necessary when copying a signed image to a destination which does not support signatures.
 
 **--sign-by** _key-id_
 
-Add a “simple signing” signature using that key ID for an image name corresponding to _destination-image_
+:   Add a “simple signing” signature using that key ID for an image name corresponding to _destination-image_
 
 **--sign-by-sigstore** _param-file_
 
-Add a sigstore signature based on the options in the specified containers sigstore signing parameter file, _param-file_.
-See containers-sigstore-signing-params.yaml(5) for details about the file format.
+:   Add a sigstore signature based on the options in the specified containers sigstore signing parameter file, _param-file_.
+    See containers-sigstore-signing-params.yaml(5) for details about the file format.
 
 **--sign-by-sigstore-private-key** _path_
 
-Add a sigstore signature using a private key at _path_ for an image name corresponding to _destination-image_
+:   Add a sigstore signature using a private key at _path_ for an image name corresponding to _destination-image_
 
 **--sign-by-sq-fingerprint** _fingerprint_
 
-Add a “simple signing” signature using a Sequoia-PGP key with the specified _fingerprint_.
+:   Add a “simple signing” signature using a Sequoia-PGP key with the specified _fingerprint_.
 
 **--sign-passphrase-file** _path_
 
-The passphrase to use when signing with `--sign-by`, `--sign-by-sigstore-private-key` or `--sign-by-sq-fingerprint`.
-Only the first line will be read. A passphrase stored in a file is of questionable security if other users can read this file. Do not use this option if at all avoidable.
+:   The passphrase to use when signing with `--sign-by`, `--sign-by-sigstore-private-key` or `--sign-by-sq-fingerprint`.
+    Only the first line will be read. A passphrase stored in a file is of questionable security if other users can read this file. Do not use this option if at all avoidable.
 
-**--src-creds** _username[:password]_ for accessing the source registry.
+**--src-creds** _username[:password]_
 
-**--dest-creds** _username[:password]_ for accessing the destination registry.
+:   For accessing the source registry.
 
-**--src-cert-dir** _path_ Use certificates (*.crt, *.cert, *.key) at _path_ to connect to the source registry or daemon.
+**--dest-creds** _username[:password]_
 
-**--src-no-creds** Access the registry anonymously.
+:   For accessing the destination registry.
 
-**--src-tls-verify**=_bool_ Require HTTPS and verify certificates when talking to a container source registry or daemon. Default to source registry entry in registry.conf setting.
+**--src-cert-dir** _path_
 
-**--dest-cert-dir** _path_ Use certificates (*.crt, *.cert, *.key) at _path_ to connect to the destination registry or daemon.
+:   Use certificates (*.crt, *.cert, *.key) at _path_ to connect to the source registry or daemon.
 
-**--dest-no-creds** Access the registry anonymously.
+**--src-no-creds**
 
-**--dest-tls-verify**=_bool_ Require HTTPS and verify certificates when talking to a container destination registry or daemon. Default to destination registry entry in registry.conf setting.
+:   Access the registry anonymously.
 
-**--src-registry-token** _Bearer token_ for accessing the source registry.
+**--src-tls-verify**=_bool_
 
-**--dest-registry-token** _Bearer token_ for accessing the destination registry.
+:   Require HTTPS and verify certificates when talking to a container source registry or daemon. Default to source registry entry in registry.conf setting.
+
+**--dest-cert-dir** _path_
+
+:   Use certificates (*.crt, *.cert, *.key) at _path_ to connect to the destination registry or daemon.
+
+**--dest-no-creds**
+
+:   Access the registry anonymously.
+
+**--dest-tls-verify**=_bool_
+
+:   Require HTTPS and verify certificates when talking to a container destination registry or daemon. Default to destination registry entry in registry.conf setting.
+
+**--src-registry-token** _Bearer token_
+
+:   For accessing the source registry.
+
+**--dest-registry-token** _Bearer token_
+
+:   For accessing the destination registry.
 
 **--retry-times**
 
-The number of times to retry. By default, no retries are attempted.
+:   The number of times to retry. By default, no retries are attempted.
 
 **--retry-delay**
 
-Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
+:   Fixed delay between retries. If not set (or set to 0s), retry wait time will be exponentially increased based on the number of failed attempts.
 
 **--keep-going**
-If any errors occur during copying of images, those errors are logged and the process continues syncing rest of the images and finally fails at the end.
+
+:   If any errors occur during copying of images, those errors are logged and the process continues syncing rest of the images and finally fails at the end.
 
 **--src-username**
 
-The username to access the source registry.
+:   The username to access the source registry.
 
 **--src-password**
 
-The password to access the source registry.
+:   The password to access the source registry.
 
 **--dest-username**
 
-The username to access the destination registry.
+:   The username to access the destination registry.
 
 **--dest-password**
 
-The password to access the destination registry.
+:   The password to access the destination registry.
 
 ## EXAMPLES
 

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -56,7 +56,7 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
 :   An image _tag_ in a tar archive compliant with "Open Container Image Layout Specification" at _path_.
 
-    See [containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md) for details.
+See [containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md) for details.
 
 ## OPTIONS
 

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -26,30 +26,37 @@ its functionality.  It also does not require root, unless you are copying images
 ## IMAGE NAMES
 Most commands refer to container images, using a _transport_`:`_details_ format. The following formats are supported:
 
-  **containers-storage:**_docker-reference_
-  An image located in a local containers/storage image store.  Both the location and image store are specified in /etc/containers/storage.conf. (Backend for Podman, CRI-O, Buildah and friends)
+**containers-storage:**_docker-reference_
 
-  **dir:**_path_
-  An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
+:   An image located in a local containers/storage image store.  Both the location and image store are specified in /etc/containers/storage.conf. (Backend for Podman, CRI-O, Buildah and friends)
 
-  **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2".
-  Credentials are typically managed using `(skopeo login)`;
-  see **containers-auth.json**(5) for more details about the credential search mechanism.
+**dir:**_path_
 
-  **docker-archive:**_path_[**:**_docker-reference_]
-  An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
+:   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
-  **docker-daemon:**_docker-reference_
-  An image _docker-reference_ stored in the docker daemon internal storage.  _docker-reference_ must contain either a tag or a digest.  Alternatively, when reading images, the format can be docker-daemon:algo:digest (an image ID).
+**docker://**_docker-reference_
 
-  **oci:**_path_**:**_tag_
-  An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
+:   An image in a registry implementing the "Docker Registry HTTP API V2".
+    Credentials are typically managed using `(skopeo login)`;
+    see **containers-auth.json**(5) for more details about the credential search mechanism.
 
-  **oci-archive:**_path_**:**_tag_
-  An image _tag_ in a tar archive compliant with "Open Container Image Layout Specification" at _path_.
+**docker-archive:**_path_[**:**_docker-reference_]
 
-See [containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md) for details.
+:   An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
+
+**docker-daemon:**_docker-reference_
+
+:   An image _docker-reference_ stored in the docker daemon internal storage.  _docker-reference_ must contain either a tag or a digest.  Alternatively, when reading images, the format can be docker-daemon:algo:digest (an image ID).
+
+**oci:**_path_**:**_tag_
+
+:   An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
+
+**oci-archive:**_path_**:**_tag_
+
+:   An image _tag_ in a tar archive compliant with "Open Container Image Layout Specification" at _path_.
+
+    See [containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md) for details.
 
 ## OPTIONS
 
@@ -58,64 +65,64 @@ Individual subcommands have their own options.
 
 **--command-timeout** _duration_
 
-Timeout for the command execution.
+:   Timeout for the command execution.
 
 **--debug**
 
-enable debug output
+:   enable debug output
 
 **--help**, **-h**
 
-Show help
+:   Show help
 
 **--insecure-policy**
 
-Adopt an insecure, permissive policy that allows anything. This obviates the need for a policy file.
+:   Adopt an insecure, permissive policy that allows anything. This obviates the need for a policy file.
 
 **--override-arch** _arch_
 
-Use _arch_ instead of the architecture of the machine for choosing images.
+:   Use _arch_ instead of the architecture of the machine for choosing images.
 
 **--override-os** _os_
 
-Use _OS_ instead of the running OS for choosing images.
+:   Use _OS_ instead of the running OS for choosing images.
 
 **--override-variant** _variant_
 
-Use _variant_ instead of the running architecture variant for choosing images.
+:   Use _variant_ instead of the running architecture variant for choosing images.
 
 **--policy** _path-to-policy_
 
-Path to a policy.json file to use for verifying signatures and deciding whether an image is trusted, overriding the default trust policy file.
+:   Path to a policy.json file to use for verifying signatures and deciding whether an image is trusted, overriding the default trust policy file.
 
 **--registries.d** _dir_
 
-Use registry configuration files in _dir_ (e.g. for container signature storage), overriding the default path.
+:   Use registry configuration files in _dir_ (e.g. for container signature storage), overriding the default path.
 
 **--require-signed**
 
-Require that any pulled image must be signed regardless of what the default or provided trust policy file says.
+:   Require that any pulled image must be signed regardless of what the default or provided trust policy file says.
 
 **--tls-details** _path_
 
-Path to a containers-tls-details(5) file, affecting TLS behavior throughout the program.
+:   Path to a containers-tls-details(5) file, affecting TLS behavior throughout the program.
 
-If not set, defaults to a reasonable default that may change over time (depending on system’s global policy,
-version of the program, version of the Go language, and the like).
+    If not set, defaults to a reasonable default that may change over time (depending on system’s global policy,
+    version of the program, version of the Go language, and the like).
 
-Users should generally not use this option unless they have a process to ensure that the configuration will be kept up to date.
+    Users should generally not use this option unless they have a process to ensure that the configuration will be kept up to date.
 
 **--tmpdir** _dir_
 
-Directory used to store temporary files. Defaults to /var/tmp.
+:   Directory used to store temporary files. Defaults to /var/tmp.
 
 **--user-agent-prefix** _prefix_
 
-Prefix to add to the user agent string. The resulting user agent will be in the format "_prefix_ skopeo/_version_".
+:   Prefix to add to the user agent string. The resulting user agent will be in the format "_prefix_ skopeo/_version_".
 
 **--version**, **-v**
 
-Print the version number
+:   Print the version number
 
 ## COMMANDS
 


### PR DESCRIPTION
This will render fine when generating man page files and also when viewed in vscode using "Markdown Preview Enhanced" extension. The built-in preview does not support definition lists. Also, when users are browsing project files in Github and view any of the .md files they will show a colon in front of each explanation unfortunately.