### PR TITLE
Try triggering an image rebuild

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,7 +157,7 @@ ostree-rs-ext_task:
         dockerfile: contrib/cirrus/ostree_ext.dockerfile
         docker_arguments:  # required build-args
             BASE_FQIN: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-            CIRRUS_IMAGE_VERSION: 3
+            CIRRUS_IMAGE_VERSION: 4
     env:
         EXT_REPO_NAME: ostree-rs-ext
         EXT_REPO_HOME: $CIRRUS_WORKING_DIR/../$EXT_REPO_NAME


### PR DESCRIPTION
https://cirrus-ci.com/task/4601027732701184 shows it using go 1.24.3, but https://quay.io/repository/coreos-assembler/fcos-buildroot/manifest/sha256:55d7510ee1b15ae4c8c503efaa463c58ce0c3d484ab7ec4fe8b211ca5a5aacf9?tab=packages shows 1.25.4 already; are we caching an older build?