### PR TITLE
Bump version to 1.22.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.21.0-dev"
+const Version = "1.22.0-dev"


### PR DESCRIPTION
1.21.0 was released (off an earlier commit): https://github.com/containers/skopeo/releases/tag/v1.21.0
