### PR TITLE
[release-1.21] Packit: use `post-modifications` hook to update downstream TMT plan

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,8 +22,6 @@ packages:
 # https://packit.dev/docs/configuration/actions
 actions:
   get-current-version: bash -c 'grep "^const Version" version/version.go | cut -f2 -d\" | tr \- \~'
-  prepare-files: >-
-    bash -c "sed -i 's/^\(\s*\)ref: .*/\1ref: \"${PACKIT_PROJECT_TAG}\"/' ${PACKIT_DOWNSTREAM_REPO}/plans/main.fmf"
 
 srpm_build_deps:
   - make
@@ -121,6 +119,9 @@ jobs:
     update_release: false
     dist_git_branches: &fedora_targets
       - fedora-all
+    actions:
+        post-modifications: >-
+          bash -c "sed -i 's/^\(\s*\)ref: .*/\1ref: \"v${PACKIT_PROJECT_VERSION}\"/' ${PACKIT_DOWNSTREAM_REPO}/plans/main.fmf"
 
   # Sync to CentOS Stream
   # FIXME: Switch trigger whenever we're ready to update CentOS Stream via


### PR DESCRIPTION
`prepare-files` action was interfering with spec file update which caused https://github.com/containers/skopeo/issues/2760 .

`post-modifications` needs to be limited to the propose_downstream job or else it will interfere with upstream PR copr builds.

Also, s/PACKIT_PROJECT_TAG/PACKIT_PROJECT_VERSION/ .




(cherry picked from commit e26a4237fc7bee11ac347c2bb0ae0ac821c169a0)