### PR TITLE
Support oci source/destination for sync operation

### DIFF
--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,7 +16,9 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/opencontainers/go-digest"
+	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.podman.io/common/pkg/retry"
@@ -403,6 +407,102 @@ func imagesToCopyFromRegistry(registryName string, cfg registrySyncConfig, sourc
 	return repoDescList, nil
 }
 
+// imagesToCopyFromOCI builds a list of image references from the images found
+// in the OCI directory.
+// It returns an image reference slice with as many elements as the images found
+// and any error encountered.
+func imagesToCopyFromOCI(ociPath string) ([]types.ImageReference, error) {
+	var sourceReferences []types.ImageReference
+	file, err := os.Open(path.Join(ociPath, specsv1.ImageIndexFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	indexManifest, err := v1.ParseIndexManifest(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse manifest: %w", err)
+	}
+
+	for _, el := range indexManifest.Manifests {
+		if refName, ok := el.Annotations[specsv1.AnnotationRefName]; ok {
+			ociRef := fmt.Sprintf("%s:%s", ociPath, refName)
+			ref, err := oci.Transport.ParseReference(ociRef)
+			if err != nil {
+				return nil, fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %q: %w", oci.Transport.Name(), ociRef, err)
+			}
+			sourceReferences = append(sourceReferences, ref)
+		}
+	}
+
+	return sourceReferences, nil
+}
+
+// extractIndexJSON extracts index.json from a tar archive
+func extractIndexJSON(tarPath string) ([]byte, error) {
+	file, err := os.Open(tarPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	tr := tar.NewReader(file)
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error reading tar: %w", err)
+		}
+
+		if header.Name == "index.json" ||
+			header.Name == "./index.json" ||
+			filepath.Base(header.Name) == "index.json" {
+
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("error reading index.json: %w", err)
+			}
+
+			return data, nil
+		}
+	}
+
+	return nil, fmt.Errorf("index.json not found in archive")
+}
+
+// imagesToCopyFromOCIArchive builds a list of image references from the images found
+// in the OCI archive file.
+// It returns an image reference slice with as many elements as the images found
+// and any error encountered.
+func imagesToCopyFromOCIArchive(ociPath string) ([]types.ImageReference, error) {
+	var sourceReferences []types.ImageReference
+
+	indexBytes, err := extractIndexJSON(ociPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract index.json: %w", err)
+	}
+
+	indexManifest, err := v1.ParseIndexManifest(bytes.NewReader(indexBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse manifest: %w", err)
+	}
+
+	for _, el := range indexManifest.Manifests {
+		if refName, ok := el.Annotations[specsv1.AnnotationRefName]; ok {
+			ref, err := archive.Transport.ParseReference(fmt.Sprintf("%s:%s", ociPath, refName))
+			if err != nil {
+				return nil, fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %q: %w", oci.Transport.Name(), refName, err)
+			}
+			sourceReferences = append(sourceReferences, ref)
+		}
+	}
+
+	return sourceReferences, nil
+}
+
 // filterFunc is a function used to limit the initial set of image references
 // using tags, patterns, semver, etc.
 type filterFunc func(*logrus.Entry, types.ImageReference) bool
@@ -588,6 +688,26 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 			}
 			descriptors = append(descriptors, descs...)
 		}
+	case oci.Transport.Name():
+		desc := repoDescriptor{
+			Context: sourceCtx,
+		}
+		var err error
+		desc.ImageRefs, err = imagesToCopyFromOCI(source)
+		if err != nil {
+			return descriptors, fmt.Errorf("Failed to retrieve list of images from oci %q: %w", source, err)
+		}
+		descriptors = append(descriptors, desc)
+	case archive.Transport.Name():
+		desc := repoDescriptor{
+			Context: sourceCtx,
+		}
+		var err error
+		desc.ImageRefs, err = imagesToCopyFromOCIArchive(source)
+		if err != nil {
+			return descriptors, fmt.Errorf("Failed to retrieve list of images from oci archive %q: %w", source, err)
+		}
+		descriptors = append(descriptors, desc)
 	}
 
 	return descriptors, nil
@@ -613,7 +733,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if len(opts.source) == 0 {
 		return errors.New("A source transport must be specified")
 	}
-	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name(), "yaml"}, opts.source) {
+	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name(), "yaml", oci.Transport.Name(), archive.Transport.Name()}, opts.source) {
 		return fmt.Errorf("%q is not a valid source transport", opts.source)
 	}
 
@@ -702,6 +822,12 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 					// if source is a full path to an image, have destPath scoped to repo:tag
 					destSuffix = path.Base(srcRepo.DirBasePath)
 				}
+			case oci.Transport:
+				// removed transport prefix
+				destSuffix = strings.SplitN(ref.StringWithinTransport(), ":", 2)[1]
+			case archive.Transport:
+				// removed transport prefix
+				destSuffix = strings.SplitN(ref.StringWithinTransport(), ":", 2)[1]
 			}
 
 			if !opts.scoped {

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -23,6 +23,8 @@ import (
 	"go.podman.io/image/v5/docker"
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/oci/archive"
+	oci "go.podman.io/image/v5/oci/layout"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
 	"gopkg.in/yaml.v3"
@@ -186,6 +188,12 @@ func destinationReference(destination string, transport string) (types.ImageRefe
 			return nil, fmt.Errorf("Error creating directory for image %s: %w", destination, err)
 		}
 		imageTransport = directory.Transport
+	case oci.Transport.Name():
+		destination = strings.Replace(destination, "/", ":", 1)
+		imageTransport = oci.Transport
+	case archive.Transport.Name():
+		destination = strings.Replace(destination, "/", ":", 1)
+		imageTransport = archive.Transport
 	default:
 		return nil, fmt.Errorf("%q is not a valid destination transport", transport)
 	}
@@ -612,7 +620,7 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if len(opts.destination) == 0 {
 		return errors.New("A destination transport must be specified")
 	}
-	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name()}, opts.destination) {
+	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name(), oci.Transport.Name(), archive.Transport.Name()}, opts.destination) {
 		return fmt.Errorf("%q is not a valid destination transport", opts.destination)
 	}
 

--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"archive/tar"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -27,7 +25,6 @@ import (
 	"go.podman.io/image/v5/docker"
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/manifest"
-	"go.podman.io/image/v5/oci/archive"
 	oci "go.podman.io/image/v5/oci/layout"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
@@ -195,9 +192,6 @@ func destinationReference(destination string, transport string) (types.ImageRefe
 	case oci.Transport.Name():
 		destination = strings.Replace(destination, "/", ":", 1)
 		imageTransport = oci.Transport
-	case archive.Transport.Name():
-		destination = strings.Replace(destination, "/", ":", 1)
-		imageTransport = archive.Transport
 	default:
 		return nil, fmt.Errorf("%q is not a valid destination transport", transport)
 	}
@@ -438,71 +432,6 @@ func imagesToCopyFromOCI(ociPath string) ([]types.ImageReference, error) {
 	return sourceReferences, nil
 }
 
-// extractIndexJSON extracts index.json from a tar archive
-func extractIndexJSON(tarPath string) ([]byte, error) {
-	file, err := os.Open(tarPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %w", err)
-	}
-	defer file.Close()
-
-	tr := tar.NewReader(file)
-
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("error reading tar: %w", err)
-		}
-
-		if header.Name == "index.json" ||
-			header.Name == "./index.json" ||
-			filepath.Base(header.Name) == "index.json" {
-
-			data, err := io.ReadAll(tr)
-			if err != nil {
-				return nil, fmt.Errorf("error reading index.json: %w", err)
-			}
-
-			return data, nil
-		}
-	}
-
-	return nil, fmt.Errorf("index.json not found in archive")
-}
-
-// imagesToCopyFromOCIArchive builds a list of image references from the images found
-// in the OCI archive file.
-// It returns an image reference slice with as many elements as the images found
-// and any error encountered.
-func imagesToCopyFromOCIArchive(ociPath string) ([]types.ImageReference, error) {
-	var sourceReferences []types.ImageReference
-
-	indexBytes, err := extractIndexJSON(ociPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract index.json: %w", err)
-	}
-
-	indexManifest, err := v1.ParseIndexManifest(bytes.NewReader(indexBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest: %w", err)
-	}
-
-	for _, el := range indexManifest.Manifests {
-		if refName, ok := el.Annotations[specsv1.AnnotationRefName]; ok {
-			ref, err := archive.Transport.ParseReference(fmt.Sprintf("%s:%s", ociPath, refName))
-			if err != nil {
-				return nil, fmt.Errorf("Cannot obtain a valid image reference for transport %q and reference %q: %w", oci.Transport.Name(), refName, err)
-			}
-			sourceReferences = append(sourceReferences, ref)
-		}
-	}
-
-	return sourceReferences, nil
-}
-
 // filterFunc is a function used to limit the initial set of image references
 // using tags, patterns, semver, etc.
 type filterFunc func(*logrus.Entry, types.ImageReference) bool
@@ -698,16 +627,6 @@ func imagesToCopy(source string, transport string, sourceCtx *types.SystemContex
 			return descriptors, fmt.Errorf("Failed to retrieve list of images from oci %q: %w", source, err)
 		}
 		descriptors = append(descriptors, desc)
-	case archive.Transport.Name():
-		desc := repoDescriptor{
-			Context: sourceCtx,
-		}
-		var err error
-		desc.ImageRefs, err = imagesToCopyFromOCIArchive(source)
-		if err != nil {
-			return descriptors, fmt.Errorf("Failed to retrieve list of images from oci archive %q: %w", source, err)
-		}
-		descriptors = append(descriptors, desc)
 	}
 
 	return descriptors, nil
@@ -733,14 +652,14 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 	if len(opts.source) == 0 {
 		return errors.New("A source transport must be specified")
 	}
-	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name(), "yaml", oci.Transport.Name(), archive.Transport.Name()}, opts.source) {
+	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name(), "yaml", oci.Transport.Name()}, opts.source) {
 		return fmt.Errorf("%q is not a valid source transport", opts.source)
 	}
 
 	if len(opts.destination) == 0 {
 		return errors.New("A destination transport must be specified")
 	}
-	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name(), oci.Transport.Name(), archive.Transport.Name()}, opts.destination) {
+	if !slices.Contains([]string{docker.Transport.Name(), directory.Transport.Name(), oci.Transport.Name()}, opts.destination) {
 		return fmt.Errorf("%q is not a valid destination transport", opts.destination)
 	}
 
@@ -823,9 +742,6 @@ func (opts *syncOptions) run(args []string, stdout io.Writer) (retErr error) {
 					destSuffix = path.Base(srcRepo.DirBasePath)
 				}
 			case oci.Transport:
-				// removed transport prefix
-				destSuffix = strings.SplitN(ref.StringWithinTransport(), ":", 2)[1]
-			case archive.Transport:
 				// removed transport prefix
 				destSuffix = strings.SplitN(ref.StringWithinTransport(), ":", 2)[1]
 			}

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -18,6 +18,8 @@ Available _source_ transports:
  If no image tag is specified, skopeo sync copies all the tags found in that repository.
  - _dir_ (i.e. `--src dir`): _source_ is a local directory path (e.g.: `/media/usb/`). Refer to skopeo(1) **dir:**_path_ for the local image format.
  - _yaml_ (i.e. `--src yaml`): _source_ is local YAML file path.
+- _oci_ (i.e. `--src oci`): _source_ is a oci directory path (e.g.: `/media/usb/`).
+- _oci-archive_ (i.e. `--src oci-archive`): _source_ is a oci archive file path (e.g.: `/media/usb/archive`).
  The YAML file should specify the list of images copied from different container registries (local directories are not supported). Refer to EXAMPLES for the file format.
 
 Available _destination_ transports:

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -23,6 +23,8 @@ Available _source_ transports:
 Available _destination_ transports:
  - _docker_ (i.e. `--dest docker`): _destination_ is a container registry (e.g.: `my-registry.local.lan`).
  - _dir_ (i.e. `--dest dir`): _destination_ is a local directory path (e.g.: `/media/usb/`).
+ - _oci_ (i.e. `--dest oci`): _destination_ is a oci directory path (e.g.: `/media/usb/`).
+ - _oci-archive_ (i.e. `--dest oci-archive`): _destination_ is a oci archive file path (e.g.: `/media/usb/archive`).
  One directory per source 'image:tag' is created for each copied image.
 
 When the `--scoped` option is specified, images are prefixed with the source image path so that multiple images with the same

--- a/docs/skopeo-sync.1.md
+++ b/docs/skopeo-sync.1.md
@@ -19,14 +19,12 @@ Available _source_ transports:
  - _dir_ (i.e. `--src dir`): _source_ is a local directory path (e.g.: `/media/usb/`). Refer to skopeo(1) **dir:**_path_ for the local image format.
  - _yaml_ (i.e. `--src yaml`): _source_ is local YAML file path.
 - _oci_ (i.e. `--src oci`): _source_ is a oci directory path (e.g.: `/media/usb/`).
-- _oci-archive_ (i.e. `--src oci-archive`): _source_ is a oci archive file path (e.g.: `/media/usb/archive`).
  The YAML file should specify the list of images copied from different container registries (local directories are not supported). Refer to EXAMPLES for the file format.
 
 Available _destination_ transports:
  - _docker_ (i.e. `--dest docker`): _destination_ is a container registry (e.g.: `my-registry.local.lan`).
  - _dir_ (i.e. `--dest dir`): _destination_ is a local directory path (e.g.: `/media/usb/`).
  - _oci_ (i.e. `--dest oci`): _destination_ is a oci directory path (e.g.: `/media/usb/`).
- - _oci-archive_ (i.e. `--dest oci-archive`): _destination_ is a oci archive file path (e.g.: `/media/usb/archive`).
  One directory per source 'image:tag' is created for each copied image.
 
 When the `--scoped` option is specified, images are prefixed with the source image path so that multiple images with the same

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/containers/ocicrypt v1.2.1
 	github.com/docker/distribution v2.8.3+incompatible
+	github.com/google/go-containerregistry v0.20.6
 	github.com/moby/sys/capability v0.4.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.2-0.20251016170850-26647a49f642
@@ -53,7 +54,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/go-containerregistry v0.20.6 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect


### PR DESCRIPTION
Add `oci` source/destination for `sync` operation.

Smoke tests:

```
$ cat sync.yaml 
docker.io:
  images:
    library/alpine:
    - 3.16
    library/nginx:
    - 1.29.4
$ bin/skopeo sync --src yaml --dest oci --scoped sync.yaml sync-oci
INFO[0000] Processing repo                               registry=docker.io repo=library/alpine
INFO[0000] Processing repo                               registry=docker.io repo=library/nginx
INFO[0000] Copying image ref 1/1                         from="docker://alpine:3.16" to="oci:sync-oci:docker.io/library/alpine:3.16"
Getting image source signatures
Copying blob a88dc8b54e91 done   | 
Copying config f535e67342 done   | 
Writing manifest to image destination
INFO[0002] Copying image ref 1/1                         from="docker://nginx:1.29.4" to="oci:sync-oci:docker.io/library/nginx:1.29.4"
Getting image source signatures
Copying blob bc4d011570c3 done   | 
Copying blob 173e7a5d3717 done   | 
Copying blob 0c8d55a45c0d done   | 
Copying blob acc398fdf80e done   | 
Copying blob 359cde133485 done   | 
Copying blob 2711d25abbb0 done   | 
Copying blob 1eb69ddd819c done   | 
Copying config 248d2326f3 done   | 
Writing manifest to image destination
INFO[0009] Synced 2 images from 2 sources               
$ bin/skopeo sync --dest-tls-verify=false --src oci --dest docker --scoped sync-oci 10.92.41.80:443/scopeo/
INFO[0000] Copying image ref 1/2                         from="oci:sync-oci:docker.io/library/alpine:3.16" to="docker://10.92.41.80:443/scopeo/docker.io/library/alpine:3.16"
Getting image source signatures
Copying blob a88dc8b54e91 done   | 
Copying config f535e67342 done   | 
Writing manifest to image destination
INFO[0001] Copying image ref 2/2                         from="oci:sync-oci:docker.io/library/nginx:1.29.4" to="docker://10.92.41.80:443/scopeo/docker.io/library/nginx:1.29.4"
Getting image source signatures
Copying blob 0c8d55a45c0d skipped: already exists  
Copying blob 173e7a5d3717 done   | 
Copying blob 2711d25abbb0 done   | 
Copying blob 359cde133485 done   | 
Copying blob acc398fdf80e done   | 
Copying blob bc4d011570c3 done   | 
Copying blob 1eb69ddd819c done   | 
Copying config 248d2326f3 done   | 
Writing manifest to image destination
INFO[0005] Synced 2 images from 1 sources
```