### PR TITLE
[release-1.9] Bump Skopeo to v1.9.5

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.9.4"
+const Version = "1.9.5"


### PR DESCRIPTION
This should have been done as part of #2805.

This will bump the version of Skopeo to v1.9.5 so
it can be used for the CVE fix, CVE-2025-65637

Fixes: https://issues.redhat.com/browse/OCPBUGS-67549