### PR TITLE
Link to Podman's LLM policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,18 @@ that we follow.
 
 ## Topics
 
+* [LLM ("AI") Policy](#llm-ai-policy)
 * [Reporting Issues](#reporting-issues)
 * [Submitting Pull Requests](#submitting-pull-requests)
 * [Communications](#communications)
 <!--
 * [Becoming a Maintainer](#becoming-a-maintainer)
 -->
+
+## LLM ("AI") Policy
+
+If your contribution is aided by LLMs or other AI tools, please read the [LLM Policy in the Podman project](https://github.com/containers/podman/blob/main/LLM_POLICY.md).
+This project also follows this LLM policy, which includes comments, issues, PRs, and any other interactions with the team.
 
 ## Reporting Issues
 


### PR DESCRIPTION
Originally from https://github.com/containers/podman/pull/28141 and discussed there.

@containers/skopeo-maintainers PTAL. Cc: @containers/podman-maintainers 