### PR TITLE
Update CI images with a dedicated registry that supports both schema1 and schema2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ env:
     # package is not available in earlier releases; once we update to a future
     # Fedora release (or if the package is backported), switch back from Rawhide
     # to the latest Fedora release.
-    IMAGE_SUFFIX: "c20250910t092246z-f42f41d13"
+    IMAGE_SUFFIX: "c20260310t170224z-f43f42d14"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     RAWHIDE_CACHE_IMAGE_NAME: "rawhide-${IMAGE_SUFFIX}"
 

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -35,8 +35,8 @@ func (s *skopeoSuite) SetupSuite() {
 	t := s.T()
 	_, err := exec.LookPath(skopeoBinary)
 	require.NoError(t, err)
-	s.regV2 = setupRegistryV2At(t, privateRegistryURL0, false, false)
-	s.regV2WithAuth = setupRegistryV2At(t, privateRegistryURL1, true, false)
+	s.regV2 = setupRegistryV2At(t, privateRegistryURL0, false, registryVersionModern)
+	s.regV2WithAuth = setupRegistryV2At(t, privateRegistryURL1, true, registryVersionModern)
 }
 
 func (s *skopeoSuite) TearDownSuite() {

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -76,8 +76,8 @@ func (s *copySuite) SetupSuite() {
 	}
 
 	// FIXME: Set up TLS for the docker registry port instead of using "--tls-verify=false" all over the place.
-	s.registry = setupRegistryV2At(t, v2DockerRegistryURL, false, false)
-	s.s1Registry = setupRegistryV2At(t, v2s1DockerRegistryURL, false, true)
+	s.registry = setupRegistryV2At(t, v2DockerRegistryURL, false, registryVersionModern)
+	s.s1Registry = setupRegistryV2At(t, v2s1DockerRegistryURL, false, registryVersionSchema1Only)
 
 	s.gpgHome = t.TempDir()
 	t.Setenv("GNUPGHOME", s.gpgHome)

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -30,11 +30,12 @@ import (
 )
 
 const (
-	v2DockerRegistryURL   = "localhost:5555" // Update also policy.json
-	v2s1DockerRegistryURL = "localhost:5556"
-	knownWindowsOnlyImage = "docker://mcr.microsoft.com/windows/nanoserver:1909"
-	knownListImageRepo    = "docker://registry.fedoraproject.org/fedora-minimal"
-	knownListImage        = knownListImageRepo + ":38"
+	v2DockerRegistryURL            = "localhost:5555" // Update also policy.json
+	v2s1OnlyDockerRegistryURL      = "localhost:5556"
+	v2s1SupportedDockerRegistryURL = "localhost:5557"
+	knownWindowsOnlyImage          = "docker://mcr.microsoft.com/windows/nanoserver:1909"
+	knownListImageRepo             = "docker://registry.fedoraproject.org/fedora-minimal"
+	knownListImage                 = knownListImageRepo + ":38"
 )
 
 func TestCopy(t *testing.T) {
@@ -43,11 +44,12 @@ func TestCopy(t *testing.T) {
 
 type copySuite struct {
 	suite.Suite
-	cluster     *openshiftCluster
-	registry    *testRegistryV2
-	s1Registry  *testRegistryV2
-	gpgHome     string
-	fingerprint string
+	cluster             *openshiftCluster
+	registry            *testRegistryV2
+	s1OnlyRegistry      *testRegistryV2
+	s1SupportedRegistry *testRegistryV2
+	gpgHome             string
+	fingerprint         string
 }
 
 var (
@@ -77,7 +79,8 @@ func (s *copySuite) SetupSuite() {
 
 	// FIXME: Set up TLS for the docker registry port instead of using "--tls-verify=false" all over the place.
 	s.registry = setupRegistryV2At(t, v2DockerRegistryURL, false, registryVersionModern)
-	s.s1Registry = setupRegistryV2At(t, v2s1DockerRegistryURL, false, registryVersionSchema1Only)
+	s.s1OnlyRegistry = setupRegistryV2At(t, v2s1OnlyDockerRegistryURL, false, registryVersionSchema1Only)
+	s.s1SupportedRegistry = setupRegistryV2At(t, v2s1SupportedDockerRegistryURL, false, registryVersionSchema1Supported)
 
 	s.gpgHome = t.TempDir()
 	t.Setenv("GNUPGHOME", s.gpgHome)
@@ -105,8 +108,11 @@ func (s *copySuite) TearDownSuite() {
 	if s.registry != nil {
 		s.registry.tearDown()
 	}
-	if s.s1Registry != nil {
-		s.s1Registry.tearDown()
+	if s.s1OnlyRegistry != nil {
+		s.s1OnlyRegistry.tearDown()
+	}
+	if s.s1SupportedRegistry != nil {
+		s.s1SupportedRegistry.tearDown()
 	}
 	if s.cluster != nil {
 		s.cluster.tearDown(t)
@@ -903,7 +909,7 @@ func (s *copySuite) TestCopyCompression() {
 	topDir := t.TempDir()
 
 	for i, c := range []struct{ fixture, remote string }{
-		{"uncompressed-image-s1", "docker://" + v2DockerRegistryURL + "/compression/compression:s1"},
+		{"uncompressed-image-s1", "docker://" + v2s1SupportedDockerRegistryURL + "/compression/compression:s1"},
 		{"uncompressed-image-s2", "docker://" + v2DockerRegistryURL + "/compression/compression:s2"},
 		{"uncompressed-image-s1", "atomic:localhost:5000/myns/compression:s1"},
 		{"uncompressed-image-s2", "atomic:localhost:5000/myns/compression:s2"},
@@ -1183,7 +1189,7 @@ func (s *copySuite) TestCopySchemaConversion() {
 	// Test conversion / schema autodetection both for the OpenShift embedded registry…
 	s.testCopySchemaConversionRegistries(t, "docker://localhost:5005/myns/schema1", "docker://localhost:5006/myns/schema2")
 	// … and for various docker/distribution registry versions.
-	s.testCopySchemaConversionRegistries(t, "docker://"+v2s1DockerRegistryURL+"/schema1", "docker://"+v2DockerRegistryURL+"/schema2")
+	s.testCopySchemaConversionRegistries(t, "docker://"+v2s1OnlyDockerRegistryURL+"/schema1", "docker://"+v2s1SupportedDockerRegistryURL+"/schema2")
 }
 
 func (s *copySuite) TestCopyManifestConversion() {

--- a/integration/registry_test.go
+++ b/integration/registry_test.go
@@ -17,6 +17,14 @@ const (
 	binaryV2Schema1 = "registry-v2-schema1"
 )
 
+type registryVersion int
+
+const (
+	registryVersionInvalid registryVersion = iota
+	registryVersionModern
+	registryVersionSchema1Only
+)
+
 type testRegistryV2 struct {
 	cmd      *exec.Cmd
 	url      string
@@ -25,8 +33,8 @@ type testRegistryV2 struct {
 	email    string
 }
 
-func setupRegistryV2At(t *testing.T, url string, auth, schema1 bool) *testRegistryV2 {
-	reg, err := newTestRegistryV2At(t, url, auth, schema1)
+func setupRegistryV2At(t *testing.T, url string, auth bool, version registryVersion) *testRegistryV2 {
+	reg, err := newTestRegistryV2At(t, url, auth, version)
 	require.NoError(t, err)
 
 	// Wait for registry to be ready to serve requests.
@@ -43,7 +51,7 @@ func setupRegistryV2At(t *testing.T, url string, auth, schema1 bool) *testRegist
 	return reg
 }
 
-func newTestRegistryV2At(t *testing.T, url string, auth, schema1 bool) (*testRegistryV2, error) {
+func newTestRegistryV2At(t *testing.T, url string, auth bool, version registryVersion) (*testRegistryV2, error) {
 	tmp := t.TempDir()
 	template := `version: 0.1
 loglevel: debug
@@ -89,10 +97,13 @@ compatibility:
 	}
 
 	var cmd *exec.Cmd
-	if schema1 {
-		cmd = exec.Command(binaryV2Schema1, confPath)
-	} else {
+	switch version {
+	case registryVersionModern:
 		cmd = exec.Command(binaryV2, "serve", confPath)
+	case registryVersionSchema1Only:
+		cmd = exec.Command(binaryV2Schema1, confPath)
+	default:
+		return nil, fmt.Errorf("invalid registry version: %v", version)
 	}
 
 	consumeAndLogOutputs(t, fmt.Sprintf("registry-%s", url), cmd)

--- a/integration/registry_test.go
+++ b/integration/registry_test.go
@@ -13,16 +13,18 @@ import (
 )
 
 const (
-	binaryV2        = "registry"
-	binaryV2Schema1 = "registry-v2-schema1"
+	binaryV2                 = "registry"
+	binaryV2Schema1Only      = "registry-v2-schema1-only"
+	binaryV2Schema1Supported = "registry-v2-schema1-supported"
 )
 
 type registryVersion int
 
 const (
-	registryVersionInvalid registryVersion = iota
-	registryVersionModern
-	registryVersionSchema1Only
+	registryVersionInvalid          registryVersion = iota
+	registryVersionModern                           // Whatever comes from a packaged docker-distribution; as of 2026-03 supports schema2, not schema1.
+	registryVersionSchema1Only                      // Supports only schema1
+	registryVersionSchema1Supported                 // Supports both schema1 and schema2
 )
 
 type testRegistryV2 struct {
@@ -101,7 +103,9 @@ compatibility:
 	case registryVersionModern:
 		cmd = exec.Command(binaryV2, "serve", confPath)
 	case registryVersionSchema1Only:
-		cmd = exec.Command(binaryV2Schema1, confPath)
+		cmd = exec.Command(binaryV2Schema1Only, confPath)
+	case registryVersionSchema1Supported:
+		cmd = exec.Command(binaryV2Schema1Supported, "serve", confPath)
 	default:
 		return nil, fmt.Errorf("invalid registry version: %v", version)
 	}

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -54,12 +54,9 @@ var (
 func (s *syncSuite) SetupSuite() {
 	t := s.T()
 
-	const registryAuth = false
-	const registrySchema1 = false
-
 	if os.Getenv("SKOPEO_LOCAL_TESTS") == "1" {
 		t.Log("Running tests without a container")
-		fmt.Printf("NOTE: tests requires a V2 registry at url=%s, with auth=%t, schema1=%t \n", v2DockerRegistryURL, registryAuth, registrySchema1)
+		fmt.Printf("NOTE: tests requires a V2 registry at url=%s\n", v2DockerRegistryURL)
 		return
 	}
 
@@ -82,7 +79,7 @@ func (s *syncSuite) SetupSuite() {
 	}
 
 	// FIXME: Set up TLS for the docker registry port instead of using "--tls-verify=false" all over the place.
-	s.registry = setupRegistryV2At(t, v2DockerRegistryURL, registryAuth, registrySchema1)
+	s.registry = setupRegistryV2At(t, v2DockerRegistryURL, false, registryVersionModern)
 
 	gpgHome := t.TempDir()
 	t.Setenv("GNUPGHOME", gpgHome)


### PR DESCRIPTION
This validates, and updates for, https://github.com/containers/automation_images/pull/437 .

After this merges, I expect the bot to close https://github.com/containers/skopeo/pull/2772 .