### PR TITLE
Update to Go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,7 @@
 module github.com/containers/skopeo
 
 // Minimum required golang version
-go 1.24.6
-
-toolchain go1.24.10
+go 1.25.0
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates
 

--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -384,7 +384,7 @@ func runTestMetadataAPIs(p *proxy, img string) error {
 	if err != nil {
 		return err
 	}
-	var layerInfoBytesData []interface{}
+	var layerInfoBytesData []any
 	err = json.Unmarshal(layerInfoBytes, &layerInfoBytesData)
 	if err != nil {
 		return err

--- a/integration/tls_test.go
+++ b/integration/tls_test.go
@@ -243,7 +243,7 @@ func (s *tlsSuite) TestOpenShift() {
 	t.Setenv("KUBECONFIG", configPath)
 
 	for _, e := range s.expected {
-		err := os.WriteFile(configPath, []byte(fmt.Sprintf(
+		err := os.WriteFile(configPath, fmt.Appendf(nil,
 			`apiVersion: v1
 clusters:
 - cluster:
@@ -257,7 +257,7 @@ contexts:
   name: our-context
 current-context: our-context
 kind: Config
-`, e.server.certPath, e.server.server.URL)), 0o644)
+`, e.server.certPath, e.server.server.URL), 0o644)
 		require.NoError(t, err)
 		// The atomic: image access starts with resolving the tag in a k8s API (and that will always fail, one way or another),
 		// so we never actually contact registry.example.


### PR DESCRIPTION
Use new features, and what `go fix` found.

See individual commit messages for details.