### PR TITLE
Fix misc. warnings

### DIFF
--- a/cmd/skopeo/proxy.go
+++ b/cmd/skopeo/proxy.go
@@ -674,8 +674,7 @@ func (h *proxyHandler) GetRawBlob(args []any) (replyBuf, error) {
 				// Should never happen
 				panic(err)
 			}
-			_, writeErr := errpipeW.Write(buf)
-			if writeErr != nil && !errors.Is(err, syscall.EPIPE) {
+			if _, err := errpipeW.Write(buf); err != nil && !errors.Is(err, syscall.EPIPE) {
 				logrus.Debugf("Writing to client: %v", err)
 			}
 		}

--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -75,15 +76,13 @@ func TestStandaloneSign(t *testing.T) {
 	assertTestFailed(t, out, err, "/dev/full")
 
 	// Success
-	sigOutput, err := os.CreateTemp("", "sig")
-	require.NoError(t, err)
-	defer os.Remove(sigOutput.Name())
-	out, err = runSkopeo("standalone-sign", "-o", sigOutput.Name(),
+	sigOutput := filepath.Join(t.TempDir(), "sig")
+	out, err = runSkopeo("standalone-sign", "-o", sigOutput,
 		manifestPath, dockerReference, fixturesTestKeyFingerprint)
 	require.NoError(t, err)
 	assert.Empty(t, out)
 
-	sig, err := os.ReadFile(sigOutput.Name())
+	sig, err := os.ReadFile(sigOutput)
 	require.NoError(t, err)
 	manifest, err := os.ReadFile(manifestPath)
 	require.NoError(t, err)

--- a/cmd/skopeo/utils_test.go
+++ b/cmd/skopeo/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -368,10 +369,8 @@ func fakeSharedCopyOptions(t *testing.T, cmdFlags []string) *sharedCopyOptions {
 func TestSharedCopyOptionsCopyOptions(t *testing.T) {
 	someStdout := bytes.Buffer{}
 
-	passphraseFile, err := os.CreateTemp("", "passphrase") // Eventually we could refer to a passphrase fixture instead
-	require.NoError(t, err)
-	defer os.Remove(passphraseFile.Name())
-	_, err = passphraseFile.WriteString("test-passphrase")
+	passphraseFile := filepath.Join(t.TempDir(), "passphrase") // Eventually we could refer to a passphrase fixture instead
+	err := os.WriteFile(passphraseFile, []byte("test-passphrase"), 0o600)
 	require.NoError(t, err)
 
 	type tc struct {
@@ -408,7 +407,7 @@ func TestSharedCopyOptionsCopyOptions(t *testing.T) {
 		{ // --sign-passphrase-file + --sign-by work
 			options: []string{
 				"--sign-by", "gpgFingerprint",
-				"--sign-passphrase-file", passphraseFile.Name(),
+				"--sign-passphrase-file", passphraseFile,
 			},
 			expected: copy.Options{
 				SignBy:                           "gpgFingerprint",
@@ -420,7 +419,7 @@ func TestSharedCopyOptionsCopyOptions(t *testing.T) {
 		{ // --sign-passphrase-file + --sign-by-sigstore-private-key work
 			options: []string{
 				"--sign-by-sigstore-private-key", "/some/key/path.private",
-				"--sign-passphrase-file", passphraseFile.Name(),
+				"--sign-passphrase-file", passphraseFile,
 			},
 			expected: copy.Options{
 				SignPassphrase:                   "test-passphrase",
@@ -447,7 +446,7 @@ func TestSharedCopyOptionsCopyOptions(t *testing.T) {
 		c = append(c, tc{
 			options: []string{
 				"--sign-by-sq-fingerprint", "sqFingerprint",
-				"--sign-passphrase-file", passphraseFile.Name(),
+				"--sign-passphrase-file", passphraseFile,
 			},
 			expected: copy.Options{
 				SignPassphrase:                   "test-passphrase",
@@ -473,9 +472,9 @@ func TestSharedCopyOptionsCopyOptions(t *testing.T) {
 		{"--format", "invalid"}, // Invalid --format
 		// More --sign-by-sigstore-private-key, --sign-by-sigstore failure cases should be tested here.
 		// --sign-passphrase-file + more than one key option
-		{"--sign-by", "gpgFingerprint", "--sign-by-sq-fingerprint", "sqFingerprint", "--sign-passphrase-file", passphraseFile.Name()},
-		{"--sign-by", "gpgFingerprint", "--sign-by-sigstore-private-key", "sigstorePrivateKey", "--sign-passphrase-file", passphraseFile.Name()},
-		{"--sign-by-sq-fingerprint", "sqFingerprint", "--sign-by-sigstore-private-key", "sigstorePrivateKey", "--sign-passphrase-file", passphraseFile.Name()},
+		{"--sign-by", "gpgFingerprint", "--sign-by-sq-fingerprint", "sqFingerprint", "--sign-passphrase-file", passphraseFile},
+		{"--sign-by", "gpgFingerprint", "--sign-by-sigstore-private-key", "sigstorePrivateKey", "--sign-passphrase-file", passphraseFile},
+		{"--sign-by-sq-fingerprint", "sqFingerprint", "--sign-by-sigstore-private-key", "sigstorePrivateKey", "--sign-passphrase-file", passphraseFile},
 		{"--sign-by", "gpgFingerprint", "--sign-passphrase-file", "/dev/null/this/does/not/exist"}, // --sign-passphrase-file not found
 		{"--sign-by-sigstore", "/dev/null/this/does/not/exist"},                                    // --sign-by-sigstore file not found
 	} {

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -1359,17 +1359,13 @@ func (s *copySuite) TestRequireSignedAcceptsSignedImage() {
 	policyJSON, err := json.Marshal(policy)
 	require.NoError(t, err)
 
-	policyFile, err := os.CreateTemp("", "policy-*.json")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.Remove(policyFile.Name()) })
-	_, err = policyFile.Write(policyJSON)
-	require.NoError(t, err)
-	err = policyFile.Close()
+	policyFile := filepath.Join(t.TempDir(), "policy.json")
+	err = os.WriteFile(policyFile, policyJSON, 0o600)
 	require.NoError(t, err)
 
 	// now copying with --require-signed should pass
 	destDir3 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "--policy", policyFile.Name(), "--require-signed", "copy",
+	assertSkopeoSucceeds(t, "", "--policy", policyFile, "--require-signed", "copy",
 		"dir:"+srcDir, "dir:"+destDir3)
 
 	// Delete the signature and sanity-check that copying fails. This doesn't
@@ -1380,6 +1376,6 @@ func (s *copySuite) TestRequireSignedAcceptsSignedImage() {
 
 	destDir4 := t.TempDir()
 	assertSkopeoFails(t, ".*Source image rejected: A signature was required, but no signature exists.*",
-		"--policy", policyFile.Name(), "--require-signed", "copy",
+		"--policy", policyFile, "--require-signed", "copy",
 		"dir:"+srcDir, "dir:"+destDir4)
 }

--- a/integration/signing_test.go
+++ b/integration/signing_test.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,13 +54,11 @@ func (s *signingSuite) TestSignVerifySmoke() {
 	manifestPath := "fixtures/image.manifest.json"
 	dockerReference := "testing/smoketest"
 
-	sigOutput, err := os.CreateTemp("", "sig")
-	require.NoError(t, err)
-	defer os.Remove(sigOutput.Name())
-	assertSkopeoSucceeds(t, "^$", "standalone-sign", "-o", sigOutput.Name(),
+	sigOutput := filepath.Join(t.TempDir(), "sig")
+	assertSkopeoSucceeds(t, "^$", "standalone-sign", "-o", sigOutput,
 		manifestPath, dockerReference, s.fingerprint)
 
 	expected := fmt.Sprintf("^Signature verified using fingerprint %s, digest %s\n$", s.fingerprint, TestImageManifestDigest)
 	assertSkopeoSucceeds(t, expected, "standalone-verify", manifestPath,
-		dockerReference, s.fingerprint, sigOutput.Name())
+		dockerReference, s.fingerprint, sigOutput)
 }

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -140,7 +140,7 @@ func (s *syncSuite) TestDocker2DirTagged() {
 	dir2 := path.Join(tmpDir, "dir2")
 
 	// sync docker => dir
-	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--src", "docker", "--dest", "dir", image, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--scoped", "--src", "docker", "--dest", "dir", image, dir1)
 	_, err = os.Stat(path.Join(dir1, imagePath, "manifest.json"))
 	require.NoError(t, err)
 
@@ -167,7 +167,7 @@ func (s *syncSuite) TestDocker2DirTaggedAll() {
 	dir2 := path.Join(tmpDir, "dir2")
 
 	// sync docker => dir
-	assertSkopeoSucceeds(t, "", "sync", "--all", "--scoped", "--src", "docker", "--dest", "dir", image, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--all", "--scoped", "--src", "docker", "--dest", "dir", image, dir1)
 	_, err = os.Stat(path.Join(dir1, imagePath, "manifest.json"))
 	require.NoError(t, err)
 
@@ -205,11 +205,11 @@ func (s *syncSuite) TestScoped() {
 	imagePath := imageRef.DockerReference().String()
 
 	dir1 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "sync", "--src", "docker", "--dest", "dir", image, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--src", "docker", "--dest", "dir", image, dir1)
 	_, err = os.Stat(path.Join(dir1, path.Base(imagePath), "manifest.json"))
 	require.NoError(t, err)
 
-	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--src", "docker", "--dest", "dir", image, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--scoped", "--src", "docker", "--dest", "dir", image, dir1)
 	_, err = os.Stat(path.Join(dir1, imagePath, "manifest.json"))
 	require.NoError(t, err)
 }
@@ -227,7 +227,7 @@ func (s *syncSuite) TestDirIsNotOverwritten() {
 
 	// sync upstream image to dir, not scoped
 	dir1 := t.TempDir()
-	assertSkopeoSucceeds(t, "", "sync", "--src", "docker", "--dest", "dir", image, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--src", "docker", "--dest", "dir", image, dir1)
 	_, err = os.Stat(path.Join(dir1, path.Base(imagePath), "manifest.json"))
 	require.NoError(t, err)
 
@@ -254,7 +254,7 @@ func (s *syncSuite) TestDocker2DirUntagged() {
 	imagePath := imageRef.DockerReference().String()
 
 	dir1 := path.Join(tmpDir, "dir1")
-	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--src", "docker", "--dest", "dir", image, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--scoped", "--src", "docker", "--dest", "dir", image, dir1)
 
 	sysCtx := types.SystemContext{}
 	tags, err := docker.GetRepositoryTags(context.Background(), &sysCtx, imageRef)
@@ -291,7 +291,7 @@ func (s *syncSuite) TestYamlUntagged() {
 	yamlFile := path.Join(tmpDir, "registries.yaml")
 	err = os.WriteFile(yamlFile, []byte(yamlConfig), 0o644)
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--src", "yaml", "--dest", "docker", "--dest-tls-verify=false", yamlFile, v2DockerRegistryURL)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--scoped", "--src", "yaml", "--dest", "docker", "--dest-tls-verify=false", yamlFile, v2DockerRegistryURL)
 	// sync back from local registry to a folder
 	os.Remove(yamlFile)
 	yamlConfig = fmt.Sprintf(`
@@ -334,7 +334,7 @@ registry.k8s.io:
 	yamlFile := path.Join(tmpDir, "registries.yaml")
 	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0o644)
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
 	assertNumberOfManifestsInSubdirs(t, dir1, nTags)
 }
 
@@ -352,7 +352,7 @@ registry.k8s.io:
 	yamlFile := path.Join(tmpDir, "registries.yaml")
 	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0o644)
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
 	assertNumberOfManifestsInSubdirs(t, dir1, 1)
 }
 
@@ -391,7 +391,7 @@ quay.io:
 	yamlFile := path.Join(tmpDir, "registries.yaml")
 	err := os.WriteFile(yamlFile, []byte(yamlConfig), 0o644)
 	require.NoError(t, err)
-	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--scoped", "--src", "yaml", "--dest", "dir", yamlFile, dir1)
 	assertNumberOfManifestsInSubdirs(t, dir1, nTags)
 }
 
@@ -460,11 +460,11 @@ func (s *syncSuite) TestSyncManifestOutput() {
 	// Split image:tag path from image URI for manifest comparison
 	imageDir := pullableTaggedImage[strings.LastIndex(pullableTaggedImage, "/")+1:]
 
-	assertSkopeoSucceeds(t, "", "sync", "--format=oci", "--all", "--src", "docker", "--dest", "dir", pullableTaggedImage, destDir1)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--format=oci", "--all", "--src", "docker", "--dest", "dir", pullableTaggedImage, destDir1)
 	verifyManifestMIMEType(t, filepath.Join(destDir1, imageDir), imgspecv1.MediaTypeImageManifest)
-	assertSkopeoSucceeds(t, "", "sync", "--format=v2s2", "--all", "--src", "docker", "--dest", "dir", pullableTaggedImage, destDir2)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--format=v2s2", "--all", "--src", "docker", "--dest", "dir", pullableTaggedImage, destDir2)
 	verifyManifestMIMEType(t, filepath.Join(destDir2, imageDir), manifest.DockerV2Schema2MediaType)
-	assertSkopeoSucceeds(t, "", "sync", "--format=v2s1", "--all", "--src", "docker", "--dest", "dir", pullableTaggedImage, destDir3)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--format=v2s1", "--all", "--src", "docker", "--dest", "dir", pullableTaggedImage, destDir3)
 	verifyManifestMIMEType(t, filepath.Join(destDir3, imageDir), manifest.DockerV2Schema1SignedMediaType)
 }
 
@@ -484,7 +484,7 @@ func (s *syncSuite) TestDocker2DockerTagged() {
 	dir2 := path.Join(tmpDir, "dir2")
 
 	// sync docker => docker
-	assertSkopeoSucceeds(t, "", "sync", "--scoped", "--dest-tls-verify=false", "--src", "docker", "--dest", "docker", image, v2DockerRegistryURL)
+	assertSkopeoSucceeds(t, "", "sync", "--retry-times", "3", "--scoped", "--dest-tls-verify=false", "--src", "docker", "--dest", "docker", image, v2DockerRegistryURL)
 
 	// copy docker => dir
 	assertSkopeoSucceeds(t, "", "copy", "--retry-times", "3", "docker://"+image, "dir:"+dir1)

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -206,14 +206,9 @@ func fileFromFixture(t *testing.T, inputPath string, edits map[string]string) st
 		contents = updated
 	}
 
-	file, err := os.CreateTemp("", "policy.json")
-	require.NoError(t, err)
-	path := file.Name()
-	t.Cleanup(func() { os.Remove(path) })
+	path := filepath.Join(t.TempDir(), "policy.json")
 
-	_, err = file.Write(contents)
-	require.NoError(t, err)
-	err = file.Close()
+	err = os.WriteFile(path, contents, 0o600)
 	require.NoError(t, err)
 	return path
 }


### PR DESCRIPTION
On a whim, I tried enabling all `golangci-lint` linters. One real bug fix, some cleanups.