### PR TITLE
ci: add riscv64 to local-cross build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ bin/skopeo:
 	$(GO) build ${GO_DYN_FLAGS} ${SKOPEO_LDFLAGS} -gcflags "$(GOGCFLAGS)" -tags "$(BUILDTAGS)" -o $@ ./cmd/skopeo
 bin/skopeo.%:
 	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) $(GO) build ${SKOPEO_LDFLAGS} -tags "containers_image_openpgp $(BUILDTAGS)" -o $@ ./cmd/skopeo
-local-cross: bin/skopeo.darwin.amd64 bin/skopeo.linux.arm bin/skopeo.linux.arm64 bin/skopeo.windows.386.exe bin/skopeo.windows.amd64.exe
+local-cross: bin/skopeo.darwin.amd64 bin/skopeo.linux.arm bin/skopeo.linux.arm64 bin/skopeo.linux.riscv64 bin/skopeo.windows.386.exe bin/skopeo.windows.amd64.exe
 
 $(MANPAGES): %: %.md
 ifneq ($(DISABLE_DOCS), 1)


### PR DESCRIPTION
Adds `bin/skopeo.linux.riscv64` to the `local-cross` Makefile target, so the Cirrus CI cross-compilation task validates riscv64 alongside the existing architectures (darwin/amd64, linux/arm, linux/arm64, windows/386, windows/amd64).

One-line change, same pattern as Podman (containers/podman#28333, approved by @Luap99).

Validated on native riscv64 hardware (BananaPi F3, SpacemiT K1, rv64gc):
```
$ ./bin/skopeo --version
skopeo version 1.22.0-dev
```

Closes #2827