### PR TITLE
Add flake.nix for NixCI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "skopeo - Work with remote images registries";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      packages.${system} = {
+        skopeo = pkgs.buildGoModule {
+          pname = "skopeo";
+          version = "dev";
+
+          src = self;
+
+          vendorHash = null;
+
+          doCheck = false;
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            go-md2man
+            installShellFiles
+          ];
+
+          buildInputs = with pkgs; [
+            gpgme
+            lvm2
+            btrfs-progs
+          ];
+
+          buildPhase = ''
+            runHook preBuild
+            patchShebangs .
+            make bin/skopeo docs
+            make completions
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            PREFIX=$out make install-binary install-docs install-completions
+            runHook postInstall
+          '';
+        };
+        default = self.packages.${system}.skopeo;
+      };
+
+      checks.${system} = {
+        skopeo = self.packages.${system}.skopeo;
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        inputsFrom = [ self.packages.${system}.skopeo ];
+        packages = with pkgs; [
+          go
+          golangci-lint
+        ];
+      };
+    };
+}


### PR DESCRIPTION
Add a Nix flake that builds skopeo, provides a dev shell, and runs the build as a flake check.


Hi! I saw that you scheduled a demo on https://nix-ci.com but it failed
because had no flake.nix so I decided to make you one so you can really try
it out.
You can see it passing here: https://staging.nix-ci.com/gh:NorfairKing:skopeo/your-first-flake/1e63cd11e3c1e9a15bdf72c8d55b851fab45bcd4

Please let me know if you have any feedback!

