### PR TITLE
[release-1.22] Packit: fix downstream post-modifications action

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -121,7 +121,7 @@ jobs:
       - fedora-all
     actions:
         post-modifications: >-
-          bash -c "sed -i 's/^\(\s*\)ref: .*/\1ref: \"v${PACKIT_PROJECT_VERSION}\"/' ${PACKIT_DOWNSTREAM_REPO}/plans/main.fmf"
+          bash -c 'sed -i "s/^\(\s*\)ref: .*/\1ref: v${PACKIT_PROJECT_VERSION}/" ${PACKIT_DOWNSTREAM_REPO}/plans/main.fmf'
 
   # Sync to CentOS Stream
   # FIXME: Switch trigger whenever we're ready to update CentOS Stream via


### PR DESCRIPTION
The downstream TMT plan can use a ref value without double quotes[0], so the `post-modifications` action in packit config can be simplified as in this patch. Also, switch the single and double quote usage to be consistent with the usage in `get-current-version` packit action.

This should help to avoid variable substitution issues noticed in the previous release [1].

Refs:
[0]: https://src.fedoraproject.org/rpms/skopeo/pull-request/98
[1]: https://src.fedoraproject.org/fork/packit/rpms/skopeo/blob/fd38aa8a5e4ed14b70a1e3ba2212434ce39fe5a2/f/plans/main.fmf


(cherry picked from commit 1ea0fb4baf40840eda5a512614135bf240c0c6a2)