### PR TITLE
Move skopeo to go.podman.io

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ env:
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
     GOCACHE: "${GOPATH}/cache"
-    GOSRC: &gosrc "/var/tmp/go/src/github.com/containers/skopeo"
+    GOSRC: &gosrc "/var/tmp/go/src/go.podman.io/skopeo"
     # Required for consistency with containers/image CI
     SKOPEO_PATH: *gosrc
     CIRRUS_WORKING_DIR: *gosrc

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ INTERACTIVE := $(shell [ -t 0 ] && echo 1 || echo 0)
 ifeq ($(INTERACTIVE), 1)
 	CONTAINER_CMD += -t
 endif
-CONTAINER_GOSRC = /src/github.com/containers/skopeo
+CONTAINER_GOSRC = /src/go.podman.io/skopeo
 CONTAINER_RUN ?= $(CONTAINER_CMD) --security-opt label=disable -v $(CURDIR):$(CONTAINER_GOSRC) -w $(CONTAINER_GOSRC) $(SKOPEO_CIDEV_CONTAINER_FQIN)
 
 EXTRA_LDFLAGS ?=

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ validate-docs: bin/skopeo
 	hack/xref-helpmsgs-manpages
 
 test-unit-local:
-	$(GO) test $(SKOPEO_LDFLAGS) -tags "$(BUILDTAGS)" $$($(GO) list -tags "$(BUILDTAGS)" -e ./... | grep -v '^github\.com/containers/skopeo/\(integration\|vendor/.*\)$$')
+	$(GO) test $(SKOPEO_LDFLAGS) -tags "$(BUILDTAGS)" $$($(GO) list -tags "$(BUILDTAGS)" -e ./... | grep -v '^go\.podman\.io/skopeo/\(integration\|vendor/.*\)$$')
 
 vendor:
 	$(GO) mod tidy

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ----
 ![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/containers/skopeo)
-[![Go Report Card](https://goreportcard.com/badge/github.com/containers/skopeo)](https://goreportcard.com/report/github.com/containers/skopeo)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10516/badge)](https://www.bestpractices.dev/projects/10516)
 
 `skopeo` is a command line utility that performs various operations on container images and image repositories.

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/containers/skopeo/cmd/skopeo/inspect"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -20,6 +19,7 @@ import (
 	"go.podman.io/image/v5/manifest"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
+	"go.podman.io/skopeo/cmd/skopeo/inspect"
 )
 
 type inspectOptions struct {

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/skopeo/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	commonFlag "go.podman.io/common/pkg/flag"
 	"go.podman.io/image/v5/pkg/cli/basetls/tlsdetails"
 	"go.podman.io/image/v5/signature"
 	"go.podman.io/image/v5/types"
+	"go.podman.io/skopeo/version"
 	"go.podman.io/storage/pkg/reexec"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/containers/skopeo
+module go.podman.io/skopeo
 
 // Minimum required golang version
 go 1.25.6

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -29,7 +29,7 @@ in_get_ci_vm() {
 if [[ "$1" == "--config" ]]; then
     in_get_ci_vm "$1"
     cat <<EOF
-DESTDIR="/var/tmp/go/src/github.com/containers/skopeo"
+DESTDIR="/var/tmp/go/src/go.podman.io/skopeo"
 UPSTREAM_REPO="https://github.com/containers/skopeo.git"
 GCLOUD_PROJECT="skopeo"
 GCLOUD_IMGPROJECT="libpod-218412"

--- a/install.md
+++ b/install.md
@@ -183,8 +183,8 @@ sudo pacman -S base-devel gpgme btrfs-progs
 Make sure to clone this repository in your `GOPATH` - otherwise compilation fails.
 
 ```bash
-git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo
-cd $GOPATH/src/github.com/containers/skopeo && make bin/skopeo
+git clone https://github.com/containers/skopeo $GOPATH/src/go.podman.io/skopeo
+cd $GOPATH/src/go.podman.io/skopeo && make bin/skopeo
 ```
 
 By default the `make` command (make all) will build bin/skopeo and the documentation locally.

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -5,10 +5,10 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/containers/skopeo/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.podman.io/skopeo/version"
 )
 
 const (


### PR DESCRIPTION
With potential repo moves and cirus EOL, we have decided to begin preparing by making changes to the skopeo module name.  See https://github.com/containers/go.podman.io/pull/6 for more information.