### PR TITLE
docs: include examples for --command-timeout duration format

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -90,7 +90,7 @@ func createApp() (*cobra.Command, *globalOptions) {
 	rootCommand.PersistentFlags().StringVar(&opts.overrideArch, "override-arch", "", "use `ARCH` instead of the architecture of the machine for choosing images")
 	rootCommand.PersistentFlags().StringVar(&opts.overrideOS, "override-os", "", "use `OS` instead of the running OS for choosing images")
 	rootCommand.PersistentFlags().StringVar(&opts.overrideVariant, "override-variant", "", "use `VARIANT` instead of the running architecture variant for choosing images")
-	rootCommand.PersistentFlags().DurationVar(&opts.commandTimeout, "command-timeout", 0, "timeout for the command execution")
+	rootCommand.PersistentFlags().DurationVar(&opts.commandTimeout, "command-timeout", 0, "timeout for the command execution (e.g. 30s, 10m)")
 	rootCommand.PersistentFlags().StringVar(&opts.registriesConfPath, "registries-conf", "", "path to the registries.conf file")
 	if err := rootCommand.PersistentFlags().MarkHidden("registries-conf"); err != nil {
 		logrus.Fatal("unable to mark registries-conf flag as hidden")

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -58,7 +58,7 @@ Individual subcommands have their own options.
 
 **--command-timeout** _duration_
 
-Timeout for the command execution.
+Timeout for the command execution (e.g. 30s, 10m).
 
 **--debug**
 


### PR DESCRIPTION
I recently came across this flag while looking into a different issue and just thought it could use some clarification on what format the duration should be given in. These small examples should make it immediately clear to users.