### PR TITLE
Use `go.yaml.in/yaml/v3` instead of `gopkg.in/yaml.v3`

### DIFF
--- a/cmd/skopeo/sync.go
+++ b/cmd/skopeo/sync.go
@@ -25,7 +25,7 @@ import (
 	"go.podman.io/image/v5/manifest"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // syncOptions contains information retrieved from the skopeo sync command line.

--- a/cmd/skopeo/sync_test.go
+++ b/cmd/skopeo/sync_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/image/v5/types"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var _ yaml.Unmarshaler = (*tlsVerifyConfig)(nil)

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	go.podman.io/common v0.68.0
 	go.podman.io/image/v5 v5.40.0
 	go.podman.io/storage v1.63.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/term v0.44.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -96,7 +96,6 @@ require (
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
@@ -107,4 +106,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60 // indirect
 	google.golang.org/grpc v1.82.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
`gopkg.in/yaml.v3` is unmaintained; `go.yaml.in/yaml/v3` is the current maintained version.

For now, we include both copies either way, but `container-libs` have also migrated, so the next time we update, `gopkg.in/yaml.v3` will only be used by test-only `stretchr/testify`.