### PR TITLE
ci: drop redundant make vendor from test_skopeo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,6 @@ jobs:
           persist-credentials: false
       - name: fix git safe.directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - run: make vendor
       - name: build + install
         run: |
           make "BUILDTAGS=${{ matrix.buildtags }}" bin/skopeo


### PR DESCRIPTION
I was reading through the CI cleanup issues and this one looked small enough to just do.

test_skopeo has validate in its needs, and validate already runs make vendor and then hack/tree_status.sh, so the vendor tree has been checked before this job even starts. vendor/ is committed too, so the checkout here already has what the build needs - I could not see anything in the later steps that wanted it regenerated.

The part that seems worth having back is go mod verify inside the target, since that was being paid three times over, once for each buildtags leg.

I have not run skopeo CI myself so I am going on reading the workflow rather than timing it. CI on this PR should show whether the three test legs are happy without it.

Closes: #2923