### PR TITLE
ci: remove git safe.directory workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - name: fix git safe.directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - run: make tools
       - run: make validate-local
       - name: vendor + tree status
@@ -72,8 +70,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - name: fix git safe.directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: remove pre-installed skopeo package
         run: dnf remove -y skopeo
       - name: build + install
@@ -153,8 +149,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - name: fix git safe.directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - run: make vendor
       - name: build + install
         run: |
@@ -179,8 +173,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - name: fix git safe.directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: install rustup stable
         run: |
           dnf remove -y rust


### PR DESCRIPTION
## Description

The container jobs in `.github/workflows/ci.yml` manually configure the Git repository as a safe directory after `actions/checkout`.

`actions/checkout` already handles the `safe.directory` configuration, making this workaround redundant. This change removes the duplicate configuration from the `validate`, `doccheck`, `test_skopeo`, and `ostree_rs_ext` jobs.

## Testing

* `git diff --check`  passed
* Verified all `safe.directory` references were removed from `.github/workflows/ci.yml`
* Reviewed the diff to confirm only the redundant workaround was removed

Fixes #2915
